### PR TITLE
Convert keyword maps to static initializers

### DIFF
--- a/glslang/HLSL/hlslScanContext.cpp
+++ b/glslang/HLSL/hlslScanContext.cpp
@@ -78,414 +78,396 @@ struct str_hash
 };
 
 // A single global usable by all threads, by all versions, by all languages.
-// After a single process-level initialization, this is read only and thread safe
-std::unordered_map<const char*, glslang::EHlslTokenClass, str_hash, str_eq>* KeywordMap = nullptr;
-std::unordered_set<const char*, str_hash, str_eq>* ReservedSet = nullptr;
-std::unordered_map<const char*, glslang::TBuiltInVariable, str_hash, str_eq>* SemanticMap = nullptr;
+const std::unordered_map<const char*, glslang::EHlslTokenClass, str_hash, str_eq> KeywordMap {
+    {"static",glslang::EHTokStatic},
+    {"const",glslang::EHTokConst},
+    {"unorm",glslang::EHTokUnorm},
+    {"snorm",glslang::EHTokSNorm},
+    {"extern",glslang::EHTokExtern},
+    {"uniform",glslang::EHTokUniform},
+    {"volatile",glslang::EHTokVolatile},
+    {"precise",glslang::EHTokPrecise},
+    {"shared",glslang::EHTokShared},
+    {"groupshared",glslang::EHTokGroupShared},
+    {"linear",glslang::EHTokLinear},
+    {"centroid",glslang::EHTokCentroid},
+    {"nointerpolation",glslang::EHTokNointerpolation},
+    {"noperspective",glslang::EHTokNoperspective},
+    {"sample",glslang::EHTokSample},
+    {"row_major",glslang::EHTokRowMajor},
+    {"column_major",glslang::EHTokColumnMajor},
+    {"packoffset",glslang::EHTokPackOffset},
+    {"in",glslang::EHTokIn},
+    {"out",glslang::EHTokOut},
+    {"inout",glslang::EHTokInOut},
+    {"layout",glslang::EHTokLayout},
+    {"globallycoherent",glslang::EHTokGloballyCoherent},
+    {"inline",glslang::EHTokInline},
 
+    {"point",glslang::EHTokPoint},
+    {"line",glslang::EHTokLine},
+    {"triangle",glslang::EHTokTriangle},
+    {"lineadj",glslang::EHTokLineAdj},
+    {"triangleadj",glslang::EHTokTriangleAdj},
+
+    {"PointStream",glslang::EHTokPointStream},
+    {"LineStream",glslang::EHTokLineStream},
+    {"TriangleStream",glslang::EHTokTriangleStream},
+
+    {"InputPatch",glslang::EHTokInputPatch},
+    {"OutputPatch",glslang::EHTokOutputPatch},
+
+    {"Buffer",glslang::EHTokBuffer},
+    {"vector",glslang::EHTokVector},
+    {"matrix",glslang::EHTokMatrix},
+
+    {"void",glslang::EHTokVoid},
+    {"string",glslang::EHTokString},
+    {"bool",glslang::EHTokBool},
+    {"int",glslang::EHTokInt},
+    {"uint",glslang::EHTokUint},
+    {"uint64_t",glslang::EHTokUint64},
+    {"dword",glslang::EHTokDword},
+    {"half",glslang::EHTokHalf},
+    {"float",glslang::EHTokFloat},
+    {"double",glslang::EHTokDouble},
+    {"min16float",glslang::EHTokMin16float},
+    {"min10float",glslang::EHTokMin10float},
+    {"min16int",glslang::EHTokMin16int},
+    {"min12int",glslang::EHTokMin12int},
+    {"min16uint",glslang::EHTokMin16uint},
+
+    {"bool1",glslang::EHTokBool1},
+    {"bool2",glslang::EHTokBool2},
+    {"bool3",glslang::EHTokBool3},
+    {"bool4",glslang::EHTokBool4},
+    {"float1",glslang::EHTokFloat1},
+    {"float2",glslang::EHTokFloat2},
+    {"float3",glslang::EHTokFloat3},
+    {"float4",glslang::EHTokFloat4},
+    {"int1",glslang::EHTokInt1},
+    {"int2",glslang::EHTokInt2},
+    {"int3",glslang::EHTokInt3},
+    {"int4",glslang::EHTokInt4},
+    {"double1",glslang::EHTokDouble1},
+    {"double2",glslang::EHTokDouble2},
+    {"double3",glslang::EHTokDouble3},
+    {"double4",glslang::EHTokDouble4},
+    {"uint1",glslang::EHTokUint1},
+    {"uint2",glslang::EHTokUint2},
+    {"uint3",glslang::EHTokUint3},
+    {"uint4",glslang::EHTokUint4},
+
+    {"half1",glslang::EHTokHalf1},
+    {"half2",glslang::EHTokHalf2},
+    {"half3",glslang::EHTokHalf3},
+    {"half4",glslang::EHTokHalf4},
+    {"min16float1",glslang::EHTokMin16float1},
+    {"min16float2",glslang::EHTokMin16float2},
+    {"min16float3",glslang::EHTokMin16float3},
+    {"min16float4",glslang::EHTokMin16float4},
+    {"min10float1",glslang::EHTokMin10float1},
+    {"min10float2",glslang::EHTokMin10float2},
+    {"min10float3",glslang::EHTokMin10float3},
+    {"min10float4",glslang::EHTokMin10float4},
+    {"min16int1",glslang::EHTokMin16int1},
+    {"min16int2",glslang::EHTokMin16int2},
+    {"min16int3",glslang::EHTokMin16int3},
+    {"min16int4",glslang::EHTokMin16int4},
+    {"min12int1",glslang::EHTokMin12int1},
+    {"min12int2",glslang::EHTokMin12int2},
+    {"min12int3",glslang::EHTokMin12int3},
+    {"min12int4",glslang::EHTokMin12int4},
+    {"min16uint1",glslang::EHTokMin16uint1},
+    {"min16uint2",glslang::EHTokMin16uint2},
+    {"min16uint3",glslang::EHTokMin16uint3},
+    {"min16uint4",glslang::EHTokMin16uint4},
+
+    {"bool1x1",glslang::EHTokBool1x1},
+    {"bool1x2",glslang::EHTokBool1x2},
+    {"bool1x3",glslang::EHTokBool1x3},
+    {"bool1x4",glslang::EHTokBool1x4},
+    {"bool2x1",glslang::EHTokBool2x1},
+    {"bool2x2",glslang::EHTokBool2x2},
+    {"bool2x3",glslang::EHTokBool2x3},
+    {"bool2x4",glslang::EHTokBool2x4},
+    {"bool3x1",glslang::EHTokBool3x1},
+    {"bool3x2",glslang::EHTokBool3x2},
+    {"bool3x3",glslang::EHTokBool3x3},
+    {"bool3x4",glslang::EHTokBool3x4},
+    {"bool4x1",glslang::EHTokBool4x1},
+    {"bool4x2",glslang::EHTokBool4x2},
+    {"bool4x3",glslang::EHTokBool4x3},
+    {"bool4x4",glslang::EHTokBool4x4},
+    {"int1x1",glslang::EHTokInt1x1},
+    {"int1x2",glslang::EHTokInt1x2},
+    {"int1x3",glslang::EHTokInt1x3},
+    {"int1x4",glslang::EHTokInt1x4},
+    {"int2x1",glslang::EHTokInt2x1},
+    {"int2x2",glslang::EHTokInt2x2},
+    {"int2x3",glslang::EHTokInt2x3},
+    {"int2x4",glslang::EHTokInt2x4},
+    {"int3x1",glslang::EHTokInt3x1},
+    {"int3x2",glslang::EHTokInt3x2},
+    {"int3x3",glslang::EHTokInt3x3},
+    {"int3x4",glslang::EHTokInt3x4},
+    {"int4x1",glslang::EHTokInt4x1},
+    {"int4x2",glslang::EHTokInt4x2},
+    {"int4x3",glslang::EHTokInt4x3},
+    {"int4x4",glslang::EHTokInt4x4},
+    {"uint1x1",glslang::EHTokUint1x1},
+    {"uint1x2",glslang::EHTokUint1x2},
+    {"uint1x3",glslang::EHTokUint1x3},
+    {"uint1x4",glslang::EHTokUint1x4},
+    {"uint2x1",glslang::EHTokUint2x1},
+    {"uint2x2",glslang::EHTokUint2x2},
+    {"uint2x3",glslang::EHTokUint2x3},
+    {"uint2x4",glslang::EHTokUint2x4},
+    {"uint3x1",glslang::EHTokUint3x1},
+    {"uint3x2",glslang::EHTokUint3x2},
+    {"uint3x3",glslang::EHTokUint3x3},
+    {"uint3x4",glslang::EHTokUint3x4},
+    {"uint4x1",glslang::EHTokUint4x1},
+    {"uint4x2",glslang::EHTokUint4x2},
+    {"uint4x3",glslang::EHTokUint4x3},
+    {"uint4x4",glslang::EHTokUint4x4},
+    {"bool1x1",glslang::EHTokBool1x1},
+    {"bool1x2",glslang::EHTokBool1x2},
+    {"bool1x3",glslang::EHTokBool1x3},
+    {"bool1x4",glslang::EHTokBool1x4},
+    {"bool2x1",glslang::EHTokBool2x1},
+    {"bool2x2",glslang::EHTokBool2x2},
+    {"bool2x3",glslang::EHTokBool2x3},
+    {"bool2x4",glslang::EHTokBool2x4},
+    {"bool3x1",glslang::EHTokBool3x1},
+    {"bool3x2",glslang::EHTokBool3x2},
+    {"bool3x3",glslang::EHTokBool3x3},
+    {"bool3x4",glslang::EHTokBool3x4},
+    {"bool4x1",glslang::EHTokBool4x1},
+    {"bool4x2",glslang::EHTokBool4x2},
+    {"bool4x3",glslang::EHTokBool4x3},
+    {"bool4x4",glslang::EHTokBool4x4},
+    {"float1x1",glslang::EHTokFloat1x1},
+    {"float1x2",glslang::EHTokFloat1x2},
+    {"float1x3",glslang::EHTokFloat1x3},
+    {"float1x4",glslang::EHTokFloat1x4},
+    {"float2x1",glslang::EHTokFloat2x1},
+    {"float2x2",glslang::EHTokFloat2x2},
+    {"float2x3",glslang::EHTokFloat2x3},
+    {"float2x4",glslang::EHTokFloat2x4},
+    {"float3x1",glslang::EHTokFloat3x1},
+    {"float3x2",glslang::EHTokFloat3x2},
+    {"float3x3",glslang::EHTokFloat3x3},
+    {"float3x4",glslang::EHTokFloat3x4},
+    {"float4x1",glslang::EHTokFloat4x1},
+    {"float4x2",glslang::EHTokFloat4x2},
+    {"float4x3",glslang::EHTokFloat4x3},
+    {"float4x4",glslang::EHTokFloat4x4},
+    {"half1x1",glslang::EHTokHalf1x1},
+    {"half1x2",glslang::EHTokHalf1x2},
+    {"half1x3",glslang::EHTokHalf1x3},
+    {"half1x4",glslang::EHTokHalf1x4},
+    {"half2x1",glslang::EHTokHalf2x1},
+    {"half2x2",glslang::EHTokHalf2x2},
+    {"half2x3",glslang::EHTokHalf2x3},
+    {"half2x4",glslang::EHTokHalf2x4},
+    {"half3x1",glslang::EHTokHalf3x1},
+    {"half3x2",glslang::EHTokHalf3x2},
+    {"half3x3",glslang::EHTokHalf3x3},
+    {"half3x4",glslang::EHTokHalf3x4},
+    {"half4x1",glslang::EHTokHalf4x1},
+    {"half4x2",glslang::EHTokHalf4x2},
+    {"half4x3",glslang::EHTokHalf4x3},
+    {"half4x4",glslang::EHTokHalf4x4},
+    {"double1x1",glslang::EHTokDouble1x1},
+    {"double1x2",glslang::EHTokDouble1x2},
+    {"double1x3",glslang::EHTokDouble1x3},
+    {"double1x4",glslang::EHTokDouble1x4},
+    {"double2x1",glslang::EHTokDouble2x1},
+    {"double2x2",glslang::EHTokDouble2x2},
+    {"double2x3",glslang::EHTokDouble2x3},
+    {"double2x4",glslang::EHTokDouble2x4},
+    {"double3x1",glslang::EHTokDouble3x1},
+    {"double3x2",glslang::EHTokDouble3x2},
+    {"double3x3",glslang::EHTokDouble3x3},
+    {"double3x4",glslang::EHTokDouble3x4},
+    {"double4x1",glslang::EHTokDouble4x1},
+    {"double4x2",glslang::EHTokDouble4x2},
+    {"double4x3",glslang::EHTokDouble4x3},
+    {"double4x4",glslang::EHTokDouble4x4},
+    {"min16float1x1",glslang::EHTokMin16float1x1},
+    {"min16float1x2",glslang::EHTokMin16float1x2},
+    {"min16float1x3",glslang::EHTokMin16float1x3},
+    {"min16float1x4",glslang::EHTokMin16float1x4},
+    {"min16float2x1",glslang::EHTokMin16float2x1},
+    {"min16float2x2",glslang::EHTokMin16float2x2},
+    {"min16float2x3",glslang::EHTokMin16float2x3},
+    {"min16float2x4",glslang::EHTokMin16float2x4},
+    {"min16float3x1",glslang::EHTokMin16float3x1},
+    {"min16float3x2",glslang::EHTokMin16float3x2},
+    {"min16float3x3",glslang::EHTokMin16float3x3},
+    {"min16float3x4",glslang::EHTokMin16float3x4},
+    {"min16float4x1",glslang::EHTokMin16float4x1},
+    {"min16float4x2",glslang::EHTokMin16float4x2},
+    {"min16float4x3",glslang::EHTokMin16float4x3},
+    {"min16float4x4",glslang::EHTokMin16float4x4},
+    {"min10float1x1",glslang::EHTokMin10float1x1},
+    {"min10float1x2",glslang::EHTokMin10float1x2},
+    {"min10float1x3",glslang::EHTokMin10float1x3},
+    {"min10float1x4",glslang::EHTokMin10float1x4},
+    {"min10float2x1",glslang::EHTokMin10float2x1},
+    {"min10float2x2",glslang::EHTokMin10float2x2},
+    {"min10float2x3",glslang::EHTokMin10float2x3},
+    {"min10float2x4",glslang::EHTokMin10float2x4},
+    {"min10float3x1",glslang::EHTokMin10float3x1},
+    {"min10float3x2",glslang::EHTokMin10float3x2},
+    {"min10float3x3",glslang::EHTokMin10float3x3},
+    {"min10float3x4",glslang::EHTokMin10float3x4},
+    {"min10float4x1",glslang::EHTokMin10float4x1},
+    {"min10float4x2",glslang::EHTokMin10float4x2},
+    {"min10float4x3",glslang::EHTokMin10float4x3},
+    {"min10float4x4",glslang::EHTokMin10float4x4},
+    {"min16int1x1",glslang::EHTokMin16int1x1},
+    {"min16int1x2",glslang::EHTokMin16int1x2},
+    {"min16int1x3",glslang::EHTokMin16int1x3},
+    {"min16int1x4",glslang::EHTokMin16int1x4},
+    {"min16int2x1",glslang::EHTokMin16int2x1},
+    {"min16int2x2",glslang::EHTokMin16int2x2},
+    {"min16int2x3",glslang::EHTokMin16int2x3},
+    {"min16int2x4",glslang::EHTokMin16int2x4},
+    {"min16int3x1",glslang::EHTokMin16int3x1},
+    {"min16int3x2",glslang::EHTokMin16int3x2},
+    {"min16int3x3",glslang::EHTokMin16int3x3},
+    {"min16int3x4",glslang::EHTokMin16int3x4},
+    {"min16int4x1",glslang::EHTokMin16int4x1},
+    {"min16int4x2",glslang::EHTokMin16int4x2},
+    {"min16int4x3",glslang::EHTokMin16int4x3},
+    {"min16int4x4",glslang::EHTokMin16int4x4},
+    {"min12int1x1",glslang::EHTokMin12int1x1},
+    {"min12int1x2",glslang::EHTokMin12int1x2},
+    {"min12int1x3",glslang::EHTokMin12int1x3},
+    {"min12int1x4",glslang::EHTokMin12int1x4},
+    {"min12int2x1",glslang::EHTokMin12int2x1},
+    {"min12int2x2",glslang::EHTokMin12int2x2},
+    {"min12int2x3",glslang::EHTokMin12int2x3},
+    {"min12int2x4",glslang::EHTokMin12int2x4},
+    {"min12int3x1",glslang::EHTokMin12int3x1},
+    {"min12int3x2",glslang::EHTokMin12int3x2},
+    {"min12int3x3",glslang::EHTokMin12int3x3},
+    {"min12int3x4",glslang::EHTokMin12int3x4},
+    {"min12int4x1",glslang::EHTokMin12int4x1},
+    {"min12int4x2",glslang::EHTokMin12int4x2},
+    {"min12int4x3",glslang::EHTokMin12int4x3},
+    {"min12int4x4",glslang::EHTokMin12int4x4},
+    {"min16uint1x1",glslang::EHTokMin16uint1x1},
+    {"min16uint1x2",glslang::EHTokMin16uint1x2},
+    {"min16uint1x3",glslang::EHTokMin16uint1x3},
+    {"min16uint1x4",glslang::EHTokMin16uint1x4},
+    {"min16uint2x1",glslang::EHTokMin16uint2x1},
+    {"min16uint2x2",glslang::EHTokMin16uint2x2},
+    {"min16uint2x3",glslang::EHTokMin16uint2x3},
+    {"min16uint2x4",glslang::EHTokMin16uint2x4},
+    {"min16uint3x1",glslang::EHTokMin16uint3x1},
+    {"min16uint3x2",glslang::EHTokMin16uint3x2},
+    {"min16uint3x3",glslang::EHTokMin16uint3x3},
+    {"min16uint3x4",glslang::EHTokMin16uint3x4},
+    {"min16uint4x1",glslang::EHTokMin16uint4x1},
+    {"min16uint4x2",glslang::EHTokMin16uint4x2},
+    {"min16uint4x3",glslang::EHTokMin16uint4x3},
+    {"min16uint4x4",glslang::EHTokMin16uint4x4},
+
+    {"sampler",glslang::EHTokSampler},
+    {"sampler1D",glslang::EHTokSampler1d},
+    {"sampler2D",glslang::EHTokSampler2d},
+    {"sampler3D",glslang::EHTokSampler3d},
+    {"samplerCUBE",glslang::EHTokSamplerCube},
+    {"sampler_state",glslang::EHTokSamplerState},
+    {"SamplerState",glslang::EHTokSamplerState},
+    {"SamplerComparisonState",glslang::EHTokSamplerComparisonState},
+    {"texture",glslang::EHTokTexture},
+    {"Texture1D",glslang::EHTokTexture1d},
+    {"Texture1DArray",glslang::EHTokTexture1darray},
+    {"Texture2D",glslang::EHTokTexture2d},
+    {"Texture2DArray",glslang::EHTokTexture2darray},
+    {"Texture3D",glslang::EHTokTexture3d},
+    {"TextureCube",glslang::EHTokTextureCube},
+    {"TextureCubeArray",glslang::EHTokTextureCubearray},
+    {"Texture2DMS",glslang::EHTokTexture2DMS},
+    {"Texture2DMSArray",glslang::EHTokTexture2DMSarray},
+    {"RWTexture1D",glslang::EHTokRWTexture1d},
+    {"RWTexture1DArray",glslang::EHTokRWTexture1darray},
+    {"RWTexture2D",glslang::EHTokRWTexture2d},
+    {"RWTexture2DArray",glslang::EHTokRWTexture2darray},
+    {"RWTexture3D",glslang::EHTokRWTexture3d},
+    {"RWBuffer",glslang::EHTokRWBuffer},
+    {"SubpassInput",glslang::EHTokSubpassInput},
+    {"SubpassInputMS",glslang::EHTokSubpassInputMS},
+
+    {"AppendStructuredBuffer",glslang::EHTokAppendStructuredBuffer},
+    {"ByteAddressBuffer",glslang::EHTokByteAddressBuffer},
+    {"ConsumeStructuredBuffer",glslang::EHTokConsumeStructuredBuffer},
+    {"RWByteAddressBuffer",glslang::EHTokRWByteAddressBuffer},
+    {"RWStructuredBuffer",glslang::EHTokRWStructuredBuffer},
+    {"StructuredBuffer",glslang::EHTokStructuredBuffer},
+    {"TextureBuffer",glslang::EHTokTextureBuffer},
+
+    {"class",glslang::EHTokClass},
+    {"struct",glslang::EHTokStruct},
+    {"cbuffer",glslang::EHTokCBuffer},
+    {"ConstantBuffer",glslang::EHTokConstantBuffer},
+    {"tbuffer",glslang::EHTokTBuffer},
+    {"typedef",glslang::EHTokTypedef},
+    {"this",glslang::EHTokThis},
+    {"namespace",glslang::EHTokNamespace},
+
+    {"true",glslang::EHTokBoolConstant},
+    {"false",glslang::EHTokBoolConstant},
+
+    {"for",glslang::EHTokFor},
+    {"do",glslang::EHTokDo},
+    {"while",glslang::EHTokWhile},
+    {"break",glslang::EHTokBreak},
+    {"continue",glslang::EHTokContinue},
+    {"if",glslang::EHTokIf},
+    {"else",glslang::EHTokElse},
+    {"discard",glslang::EHTokDiscard},
+    {"return",glslang::EHTokReturn},
+    {"switch",glslang::EHTokSwitch},
+    {"case",glslang::EHTokCase},
+    {"default",glslang::EHTokDefault},
 };
 
-namespace glslang {
-
-void HlslScanContext::fillInKeywordMap()
-{
-    if (KeywordMap != nullptr) {
-        // this is really an error, as this should called only once per process
-        // but, the only risk is if two threads called simultaneously
-        return;
-    }
-    KeywordMap = new std::unordered_map<const char*, EHlslTokenClass, str_hash, str_eq>;
-
-    (*KeywordMap)["static"] =                  EHTokStatic;
-    (*KeywordMap)["const"] =                   EHTokConst;
-    (*KeywordMap)["unorm"] =                   EHTokUnorm;
-    (*KeywordMap)["snorm"] =                   EHTokSNorm;
-    (*KeywordMap)["extern"] =                  EHTokExtern;
-    (*KeywordMap)["uniform"] =                 EHTokUniform;
-    (*KeywordMap)["volatile"] =                EHTokVolatile;
-    (*KeywordMap)["precise"] =                 EHTokPrecise;
-    (*KeywordMap)["shared"] =                  EHTokShared;
-    (*KeywordMap)["groupshared"] =             EHTokGroupShared;
-    (*KeywordMap)["linear"] =                  EHTokLinear;
-    (*KeywordMap)["centroid"] =                EHTokCentroid;
-    (*KeywordMap)["nointerpolation"] =         EHTokNointerpolation;
-    (*KeywordMap)["noperspective"] =           EHTokNoperspective;
-    (*KeywordMap)["sample"] =                  EHTokSample;
-    (*KeywordMap)["row_major"] =               EHTokRowMajor;
-    (*KeywordMap)["column_major"] =            EHTokColumnMajor;
-    (*KeywordMap)["packoffset"] =              EHTokPackOffset;
-    (*KeywordMap)["in"] =                      EHTokIn;
-    (*KeywordMap)["out"] =                     EHTokOut;
-    (*KeywordMap)["inout"] =                   EHTokInOut;
-    (*KeywordMap)["layout"] =                  EHTokLayout;
-    (*KeywordMap)["globallycoherent"] =        EHTokGloballyCoherent;
-    (*KeywordMap)["inline"] =                  EHTokInline;
-
-    (*KeywordMap)["point"] =                   EHTokPoint;
-    (*KeywordMap)["line"] =                    EHTokLine;
-    (*KeywordMap)["triangle"] =                EHTokTriangle;
-    (*KeywordMap)["lineadj"] =                 EHTokLineAdj;
-    (*KeywordMap)["triangleadj"] =             EHTokTriangleAdj;
-
-    (*KeywordMap)["PointStream"] =             EHTokPointStream;
-    (*KeywordMap)["LineStream"] =              EHTokLineStream;
-    (*KeywordMap)["TriangleStream"] =          EHTokTriangleStream;
-
-    (*KeywordMap)["InputPatch"] =              EHTokInputPatch;
-    (*KeywordMap)["OutputPatch"] =             EHTokOutputPatch;
-
-    (*KeywordMap)["Buffer"] =                  EHTokBuffer;
-    (*KeywordMap)["vector"] =                  EHTokVector;
-    (*KeywordMap)["matrix"] =                  EHTokMatrix;
-
-    (*KeywordMap)["void"] =                    EHTokVoid;
-    (*KeywordMap)["string"] =                  EHTokString;
-    (*KeywordMap)["bool"] =                    EHTokBool;
-    (*KeywordMap)["int"] =                     EHTokInt;
-    (*KeywordMap)["uint"] =                    EHTokUint;
-    (*KeywordMap)["uint64_t"] =                EHTokUint64;
-    (*KeywordMap)["dword"] =                   EHTokDword;
-    (*KeywordMap)["half"] =                    EHTokHalf;
-    (*KeywordMap)["float"] =                   EHTokFloat;
-    (*KeywordMap)["double"] =                  EHTokDouble;
-    (*KeywordMap)["min16float"] =              EHTokMin16float;
-    (*KeywordMap)["min10float"] =              EHTokMin10float;
-    (*KeywordMap)["min16int"] =                EHTokMin16int;
-    (*KeywordMap)["min12int"] =                EHTokMin12int;
-    (*KeywordMap)["min16uint"] =               EHTokMin16uint;
-
-    (*KeywordMap)["bool1"] =                   EHTokBool1;
-    (*KeywordMap)["bool2"] =                   EHTokBool2;
-    (*KeywordMap)["bool3"] =                   EHTokBool3;
-    (*KeywordMap)["bool4"] =                   EHTokBool4;
-    (*KeywordMap)["float1"] =                  EHTokFloat1;
-    (*KeywordMap)["float2"] =                  EHTokFloat2;
-    (*KeywordMap)["float3"] =                  EHTokFloat3;
-    (*KeywordMap)["float4"] =                  EHTokFloat4;
-    (*KeywordMap)["int1"] =                    EHTokInt1;
-    (*KeywordMap)["int2"] =                    EHTokInt2;
-    (*KeywordMap)["int3"] =                    EHTokInt3;
-    (*KeywordMap)["int4"] =                    EHTokInt4;
-    (*KeywordMap)["double1"] =                 EHTokDouble1;
-    (*KeywordMap)["double2"] =                 EHTokDouble2;
-    (*KeywordMap)["double3"] =                 EHTokDouble3;
-    (*KeywordMap)["double4"] =                 EHTokDouble4;
-    (*KeywordMap)["uint1"] =                   EHTokUint1;
-    (*KeywordMap)["uint2"] =                   EHTokUint2;
-    (*KeywordMap)["uint3"] =                   EHTokUint3;
-    (*KeywordMap)["uint4"] =                   EHTokUint4;
-
-    (*KeywordMap)["half1"] =                   EHTokHalf1;
-    (*KeywordMap)["half2"] =                   EHTokHalf2;
-    (*KeywordMap)["half3"] =                   EHTokHalf3;
-    (*KeywordMap)["half4"] =                   EHTokHalf4;
-    (*KeywordMap)["min16float1"] =             EHTokMin16float1;
-    (*KeywordMap)["min16float2"] =             EHTokMin16float2;
-    (*KeywordMap)["min16float3"] =             EHTokMin16float3;
-    (*KeywordMap)["min16float4"] =             EHTokMin16float4;
-    (*KeywordMap)["min10float1"] =             EHTokMin10float1;
-    (*KeywordMap)["min10float2"] =             EHTokMin10float2;
-    (*KeywordMap)["min10float3"] =             EHTokMin10float3;
-    (*KeywordMap)["min10float4"] =             EHTokMin10float4;
-    (*KeywordMap)["min16int1"] =               EHTokMin16int1;
-    (*KeywordMap)["min16int2"] =               EHTokMin16int2;
-    (*KeywordMap)["min16int3"] =               EHTokMin16int3;
-    (*KeywordMap)["min16int4"] =               EHTokMin16int4;
-    (*KeywordMap)["min12int1"] =               EHTokMin12int1;
-    (*KeywordMap)["min12int2"] =               EHTokMin12int2;
-    (*KeywordMap)["min12int3"] =               EHTokMin12int3;
-    (*KeywordMap)["min12int4"] =               EHTokMin12int4;
-    (*KeywordMap)["min16uint1"] =              EHTokMin16uint1;
-    (*KeywordMap)["min16uint2"] =              EHTokMin16uint2;
-    (*KeywordMap)["min16uint3"] =              EHTokMin16uint3;
-    (*KeywordMap)["min16uint4"] =              EHTokMin16uint4;
-
-    (*KeywordMap)["bool1x1"] =                 EHTokBool1x1;
-    (*KeywordMap)["bool1x2"] =                 EHTokBool1x2;
-    (*KeywordMap)["bool1x3"] =                 EHTokBool1x3;
-    (*KeywordMap)["bool1x4"] =                 EHTokBool1x4;
-    (*KeywordMap)["bool2x1"] =                 EHTokBool2x1;
-    (*KeywordMap)["bool2x2"] =                 EHTokBool2x2;
-    (*KeywordMap)["bool2x3"] =                 EHTokBool2x3;
-    (*KeywordMap)["bool2x4"] =                 EHTokBool2x4;
-    (*KeywordMap)["bool3x1"] =                 EHTokBool3x1;
-    (*KeywordMap)["bool3x2"] =                 EHTokBool3x2;
-    (*KeywordMap)["bool3x3"] =                 EHTokBool3x3;
-    (*KeywordMap)["bool3x4"] =                 EHTokBool3x4;
-    (*KeywordMap)["bool4x1"] =                 EHTokBool4x1;
-    (*KeywordMap)["bool4x2"] =                 EHTokBool4x2;
-    (*KeywordMap)["bool4x3"] =                 EHTokBool4x3;
-    (*KeywordMap)["bool4x4"] =                 EHTokBool4x4;
-    (*KeywordMap)["int1x1"] =                  EHTokInt1x1;
-    (*KeywordMap)["int1x2"] =                  EHTokInt1x2;
-    (*KeywordMap)["int1x3"] =                  EHTokInt1x3;
-    (*KeywordMap)["int1x4"] =                  EHTokInt1x4;
-    (*KeywordMap)["int2x1"] =                  EHTokInt2x1;
-    (*KeywordMap)["int2x2"] =                  EHTokInt2x2;
-    (*KeywordMap)["int2x3"] =                  EHTokInt2x3;
-    (*KeywordMap)["int2x4"] =                  EHTokInt2x4;
-    (*KeywordMap)["int3x1"] =                  EHTokInt3x1;
-    (*KeywordMap)["int3x2"] =                  EHTokInt3x2;
-    (*KeywordMap)["int3x3"] =                  EHTokInt3x3;
-    (*KeywordMap)["int3x4"] =                  EHTokInt3x4;
-    (*KeywordMap)["int4x1"] =                  EHTokInt4x1;
-    (*KeywordMap)["int4x2"] =                  EHTokInt4x2;
-    (*KeywordMap)["int4x3"] =                  EHTokInt4x3;
-    (*KeywordMap)["int4x4"] =                  EHTokInt4x4;
-    (*KeywordMap)["uint1x1"] =                 EHTokUint1x1;
-    (*KeywordMap)["uint1x2"] =                 EHTokUint1x2;
-    (*KeywordMap)["uint1x3"] =                 EHTokUint1x3;
-    (*KeywordMap)["uint1x4"] =                 EHTokUint1x4;
-    (*KeywordMap)["uint2x1"] =                 EHTokUint2x1;
-    (*KeywordMap)["uint2x2"] =                 EHTokUint2x2;
-    (*KeywordMap)["uint2x3"] =                 EHTokUint2x3;
-    (*KeywordMap)["uint2x4"] =                 EHTokUint2x4;
-    (*KeywordMap)["uint3x1"] =                 EHTokUint3x1;
-    (*KeywordMap)["uint3x2"] =                 EHTokUint3x2;
-    (*KeywordMap)["uint3x3"] =                 EHTokUint3x3;
-    (*KeywordMap)["uint3x4"] =                 EHTokUint3x4;
-    (*KeywordMap)["uint4x1"] =                 EHTokUint4x1;
-    (*KeywordMap)["uint4x2"] =                 EHTokUint4x2;
-    (*KeywordMap)["uint4x3"] =                 EHTokUint4x3;
-    (*KeywordMap)["uint4x4"] =                 EHTokUint4x4;
-    (*KeywordMap)["bool1x1"] =                 EHTokBool1x1;
-    (*KeywordMap)["bool1x2"] =                 EHTokBool1x2;
-    (*KeywordMap)["bool1x3"] =                 EHTokBool1x3;
-    (*KeywordMap)["bool1x4"] =                 EHTokBool1x4;
-    (*KeywordMap)["bool2x1"] =                 EHTokBool2x1;
-    (*KeywordMap)["bool2x2"] =                 EHTokBool2x2;
-    (*KeywordMap)["bool2x3"] =                 EHTokBool2x3;
-    (*KeywordMap)["bool2x4"] =                 EHTokBool2x4;
-    (*KeywordMap)["bool3x1"] =                 EHTokBool3x1;
-    (*KeywordMap)["bool3x2"] =                 EHTokBool3x2;
-    (*KeywordMap)["bool3x3"] =                 EHTokBool3x3;
-    (*KeywordMap)["bool3x4"] =                 EHTokBool3x4;
-    (*KeywordMap)["bool4x1"] =                 EHTokBool4x1;
-    (*KeywordMap)["bool4x2"] =                 EHTokBool4x2;
-    (*KeywordMap)["bool4x3"] =                 EHTokBool4x3;
-    (*KeywordMap)["bool4x4"] =                 EHTokBool4x4;
-    (*KeywordMap)["float1x1"] =                EHTokFloat1x1;
-    (*KeywordMap)["float1x2"] =                EHTokFloat1x2;
-    (*KeywordMap)["float1x3"] =                EHTokFloat1x3;
-    (*KeywordMap)["float1x4"] =                EHTokFloat1x4;
-    (*KeywordMap)["float2x1"] =                EHTokFloat2x1;
-    (*KeywordMap)["float2x2"] =                EHTokFloat2x2;
-    (*KeywordMap)["float2x3"] =                EHTokFloat2x3;
-    (*KeywordMap)["float2x4"] =                EHTokFloat2x4;
-    (*KeywordMap)["float3x1"] =                EHTokFloat3x1;
-    (*KeywordMap)["float3x2"] =                EHTokFloat3x2;
-    (*KeywordMap)["float3x3"] =                EHTokFloat3x3;
-    (*KeywordMap)["float3x4"] =                EHTokFloat3x4;
-    (*KeywordMap)["float4x1"] =                EHTokFloat4x1;
-    (*KeywordMap)["float4x2"] =                EHTokFloat4x2;
-    (*KeywordMap)["float4x3"] =                EHTokFloat4x3;
-    (*KeywordMap)["float4x4"] =                EHTokFloat4x4;
-    (*KeywordMap)["half1x1"] =                 EHTokHalf1x1;
-    (*KeywordMap)["half1x2"] =                 EHTokHalf1x2;
-    (*KeywordMap)["half1x3"] =                 EHTokHalf1x3;
-    (*KeywordMap)["half1x4"] =                 EHTokHalf1x4;
-    (*KeywordMap)["half2x1"] =                 EHTokHalf2x1;
-    (*KeywordMap)["half2x2"] =                 EHTokHalf2x2;
-    (*KeywordMap)["half2x3"] =                 EHTokHalf2x3;
-    (*KeywordMap)["half2x4"] =                 EHTokHalf2x4;
-    (*KeywordMap)["half3x1"] =                 EHTokHalf3x1;
-    (*KeywordMap)["half3x2"] =                 EHTokHalf3x2;
-    (*KeywordMap)["half3x3"] =                 EHTokHalf3x3;
-    (*KeywordMap)["half3x4"] =                 EHTokHalf3x4;
-    (*KeywordMap)["half4x1"] =                 EHTokHalf4x1;
-    (*KeywordMap)["half4x2"] =                 EHTokHalf4x2;
-    (*KeywordMap)["half4x3"] =                 EHTokHalf4x3;
-    (*KeywordMap)["half4x4"] =                 EHTokHalf4x4;
-    (*KeywordMap)["double1x1"] =               EHTokDouble1x1;
-    (*KeywordMap)["double1x2"] =               EHTokDouble1x2;
-    (*KeywordMap)["double1x3"] =               EHTokDouble1x3;
-    (*KeywordMap)["double1x4"] =               EHTokDouble1x4;
-    (*KeywordMap)["double2x1"] =               EHTokDouble2x1;
-    (*KeywordMap)["double2x2"] =               EHTokDouble2x2;
-    (*KeywordMap)["double2x3"] =               EHTokDouble2x3;
-    (*KeywordMap)["double2x4"] =               EHTokDouble2x4;
-    (*KeywordMap)["double3x1"] =               EHTokDouble3x1;
-    (*KeywordMap)["double3x2"] =               EHTokDouble3x2;
-    (*KeywordMap)["double3x3"] =               EHTokDouble3x3;
-    (*KeywordMap)["double3x4"] =               EHTokDouble3x4;
-    (*KeywordMap)["double4x1"] =               EHTokDouble4x1;
-    (*KeywordMap)["double4x2"] =               EHTokDouble4x2;
-    (*KeywordMap)["double4x3"] =               EHTokDouble4x3;
-    (*KeywordMap)["double4x4"] =               EHTokDouble4x4;
-    (*KeywordMap)["min16float1x1"] =           EHTokMin16float1x1;
-    (*KeywordMap)["min16float1x2"] =           EHTokMin16float1x2;
-    (*KeywordMap)["min16float1x3"] =           EHTokMin16float1x3;
-    (*KeywordMap)["min16float1x4"] =           EHTokMin16float1x4;
-    (*KeywordMap)["min16float2x1"] =           EHTokMin16float2x1;
-    (*KeywordMap)["min16float2x2"] =           EHTokMin16float2x2;
-    (*KeywordMap)["min16float2x3"] =           EHTokMin16float2x3;
-    (*KeywordMap)["min16float2x4"] =           EHTokMin16float2x4;
-    (*KeywordMap)["min16float3x1"] =           EHTokMin16float3x1;
-    (*KeywordMap)["min16float3x2"] =           EHTokMin16float3x2;
-    (*KeywordMap)["min16float3x3"] =           EHTokMin16float3x3;
-    (*KeywordMap)["min16float3x4"] =           EHTokMin16float3x4;
-    (*KeywordMap)["min16float4x1"] =           EHTokMin16float4x1;
-    (*KeywordMap)["min16float4x2"] =           EHTokMin16float4x2;
-    (*KeywordMap)["min16float4x3"] =           EHTokMin16float4x3;
-    (*KeywordMap)["min16float4x4"] =           EHTokMin16float4x4;
-    (*KeywordMap)["min10float1x1"] =           EHTokMin10float1x1;
-    (*KeywordMap)["min10float1x2"] =           EHTokMin10float1x2;
-    (*KeywordMap)["min10float1x3"] =           EHTokMin10float1x3;
-    (*KeywordMap)["min10float1x4"] =           EHTokMin10float1x4;
-    (*KeywordMap)["min10float2x1"] =           EHTokMin10float2x1;
-    (*KeywordMap)["min10float2x2"] =           EHTokMin10float2x2;
-    (*KeywordMap)["min10float2x3"] =           EHTokMin10float2x3;
-    (*KeywordMap)["min10float2x4"] =           EHTokMin10float2x4;
-    (*KeywordMap)["min10float3x1"] =           EHTokMin10float3x1;
-    (*KeywordMap)["min10float3x2"] =           EHTokMin10float3x2;
-    (*KeywordMap)["min10float3x3"] =           EHTokMin10float3x3;
-    (*KeywordMap)["min10float3x4"] =           EHTokMin10float3x4;
-    (*KeywordMap)["min10float4x1"] =           EHTokMin10float4x1;
-    (*KeywordMap)["min10float4x2"] =           EHTokMin10float4x2;
-    (*KeywordMap)["min10float4x3"] =           EHTokMin10float4x3;
-    (*KeywordMap)["min10float4x4"] =           EHTokMin10float4x4;
-    (*KeywordMap)["min16int1x1"] =             EHTokMin16int1x1;
-    (*KeywordMap)["min16int1x2"] =             EHTokMin16int1x2;
-    (*KeywordMap)["min16int1x3"] =             EHTokMin16int1x3;
-    (*KeywordMap)["min16int1x4"] =             EHTokMin16int1x4;
-    (*KeywordMap)["min16int2x1"] =             EHTokMin16int2x1;
-    (*KeywordMap)["min16int2x2"] =             EHTokMin16int2x2;
-    (*KeywordMap)["min16int2x3"] =             EHTokMin16int2x3;
-    (*KeywordMap)["min16int2x4"] =             EHTokMin16int2x4;
-    (*KeywordMap)["min16int3x1"] =             EHTokMin16int3x1;
-    (*KeywordMap)["min16int3x2"] =             EHTokMin16int3x2;
-    (*KeywordMap)["min16int3x3"] =             EHTokMin16int3x3;
-    (*KeywordMap)["min16int3x4"] =             EHTokMin16int3x4;
-    (*KeywordMap)["min16int4x1"] =             EHTokMin16int4x1;
-    (*KeywordMap)["min16int4x2"] =             EHTokMin16int4x2;
-    (*KeywordMap)["min16int4x3"] =             EHTokMin16int4x3;
-    (*KeywordMap)["min16int4x4"] =             EHTokMin16int4x4;
-    (*KeywordMap)["min12int1x1"] =             EHTokMin12int1x1;
-    (*KeywordMap)["min12int1x2"] =             EHTokMin12int1x2;
-    (*KeywordMap)["min12int1x3"] =             EHTokMin12int1x3;
-    (*KeywordMap)["min12int1x4"] =             EHTokMin12int1x4;
-    (*KeywordMap)["min12int2x1"] =             EHTokMin12int2x1;
-    (*KeywordMap)["min12int2x2"] =             EHTokMin12int2x2;
-    (*KeywordMap)["min12int2x3"] =             EHTokMin12int2x3;
-    (*KeywordMap)["min12int2x4"] =             EHTokMin12int2x4;
-    (*KeywordMap)["min12int3x1"] =             EHTokMin12int3x1;
-    (*KeywordMap)["min12int3x2"] =             EHTokMin12int3x2;
-    (*KeywordMap)["min12int3x3"] =             EHTokMin12int3x3;
-    (*KeywordMap)["min12int3x4"] =             EHTokMin12int3x4;
-    (*KeywordMap)["min12int4x1"] =             EHTokMin12int4x1;
-    (*KeywordMap)["min12int4x2"] =             EHTokMin12int4x2;
-    (*KeywordMap)["min12int4x3"] =             EHTokMin12int4x3;
-    (*KeywordMap)["min12int4x4"] =             EHTokMin12int4x4;
-    (*KeywordMap)["min16uint1x1"] =            EHTokMin16uint1x1;
-    (*KeywordMap)["min16uint1x2"] =            EHTokMin16uint1x2;
-    (*KeywordMap)["min16uint1x3"] =            EHTokMin16uint1x3;
-    (*KeywordMap)["min16uint1x4"] =            EHTokMin16uint1x4;
-    (*KeywordMap)["min16uint2x1"] =            EHTokMin16uint2x1;
-    (*KeywordMap)["min16uint2x2"] =            EHTokMin16uint2x2;
-    (*KeywordMap)["min16uint2x3"] =            EHTokMin16uint2x3;
-    (*KeywordMap)["min16uint2x4"] =            EHTokMin16uint2x4;
-    (*KeywordMap)["min16uint3x1"] =            EHTokMin16uint3x1;
-    (*KeywordMap)["min16uint3x2"] =            EHTokMin16uint3x2;
-    (*KeywordMap)["min16uint3x3"] =            EHTokMin16uint3x3;
-    (*KeywordMap)["min16uint3x4"] =            EHTokMin16uint3x4;
-    (*KeywordMap)["min16uint4x1"] =            EHTokMin16uint4x1;
-    (*KeywordMap)["min16uint4x2"] =            EHTokMin16uint4x2;
-    (*KeywordMap)["min16uint4x3"] =            EHTokMin16uint4x3;
-    (*KeywordMap)["min16uint4x4"] =            EHTokMin16uint4x4;
-
-    (*KeywordMap)["sampler"] =                 EHTokSampler;
-    (*KeywordMap)["sampler1D"] =               EHTokSampler1d;
-    (*KeywordMap)["sampler2D"] =               EHTokSampler2d;
-    (*KeywordMap)["sampler3D"] =               EHTokSampler3d;
-    (*KeywordMap)["samplerCUBE"] =             EHTokSamplerCube;
-    (*KeywordMap)["sampler_state"] =           EHTokSamplerState;
-    (*KeywordMap)["SamplerState"] =            EHTokSamplerState;
-    (*KeywordMap)["SamplerComparisonState"] =  EHTokSamplerComparisonState;
-    (*KeywordMap)["texture"] =                 EHTokTexture;
-    (*KeywordMap)["Texture1D"] =               EHTokTexture1d;
-    (*KeywordMap)["Texture1DArray"] =          EHTokTexture1darray;
-    (*KeywordMap)["Texture2D"] =               EHTokTexture2d;
-    (*KeywordMap)["Texture2DArray"] =          EHTokTexture2darray;
-    (*KeywordMap)["Texture3D"] =               EHTokTexture3d;
-    (*KeywordMap)["TextureCube"] =             EHTokTextureCube;
-    (*KeywordMap)["TextureCubeArray"] =        EHTokTextureCubearray;
-    (*KeywordMap)["Texture2DMS"] =             EHTokTexture2DMS;
-    (*KeywordMap)["Texture2DMSArray"] =        EHTokTexture2DMSarray;
-    (*KeywordMap)["RWTexture1D"] =             EHTokRWTexture1d;
-    (*KeywordMap)["RWTexture1DArray"] =        EHTokRWTexture1darray;
-    (*KeywordMap)["RWTexture2D"] =             EHTokRWTexture2d;
-    (*KeywordMap)["RWTexture2DArray"] =        EHTokRWTexture2darray;
-    (*KeywordMap)["RWTexture3D"] =             EHTokRWTexture3d;
-    (*KeywordMap)["RWBuffer"] =                EHTokRWBuffer;
-    (*KeywordMap)["SubpassInput"] =            EHTokSubpassInput;
-    (*KeywordMap)["SubpassInputMS"] =          EHTokSubpassInputMS;
-
-    (*KeywordMap)["AppendStructuredBuffer"] =  EHTokAppendStructuredBuffer;
-    (*KeywordMap)["ByteAddressBuffer"] =       EHTokByteAddressBuffer;
-    (*KeywordMap)["ConsumeStructuredBuffer"] = EHTokConsumeStructuredBuffer;
-    (*KeywordMap)["RWByteAddressBuffer"] =     EHTokRWByteAddressBuffer;
-    (*KeywordMap)["RWStructuredBuffer"] =      EHTokRWStructuredBuffer;
-    (*KeywordMap)["StructuredBuffer"] =        EHTokStructuredBuffer;
-    (*KeywordMap)["TextureBuffer"] =           EHTokTextureBuffer;
-
-    (*KeywordMap)["class"] =                   EHTokClass;
-    (*KeywordMap)["struct"] =                  EHTokStruct;
-    (*KeywordMap)["cbuffer"] =                 EHTokCBuffer;
-    (*KeywordMap)["ConstantBuffer"] =          EHTokConstantBuffer;
-    (*KeywordMap)["tbuffer"] =                 EHTokTBuffer;
-    (*KeywordMap)["typedef"] =                 EHTokTypedef;
-    (*KeywordMap)["this"] =                    EHTokThis;
-    (*KeywordMap)["namespace"] =               EHTokNamespace;
-
-    (*KeywordMap)["true"] =                    EHTokBoolConstant;
-    (*KeywordMap)["false"] =                   EHTokBoolConstant;
-
-    (*KeywordMap)["for"] =                     EHTokFor;
-    (*KeywordMap)["do"] =                      EHTokDo;
-    (*KeywordMap)["while"] =                   EHTokWhile;
-    (*KeywordMap)["break"] =                   EHTokBreak;
-    (*KeywordMap)["continue"] =                EHTokContinue;
-    (*KeywordMap)["if"] =                      EHTokIf;
-    (*KeywordMap)["else"] =                    EHTokElse;
-    (*KeywordMap)["discard"] =                 EHTokDiscard;
-    (*KeywordMap)["return"] =                  EHTokReturn;
-    (*KeywordMap)["switch"] =                  EHTokSwitch;
-    (*KeywordMap)["case"] =                    EHTokCase;
-    (*KeywordMap)["default"] =                 EHTokDefault;
-
-    // TODO: get correct set here
-    ReservedSet = new std::unordered_set<const char*, str_hash, str_eq>;
-
-    ReservedSet->insert("auto");
-    ReservedSet->insert("catch");
-    ReservedSet->insert("char");
-    ReservedSet->insert("const_cast");
-    ReservedSet->insert("enum");
-    ReservedSet->insert("explicit");
-    ReservedSet->insert("friend");
-    ReservedSet->insert("goto");
-    ReservedSet->insert("long");
-    ReservedSet->insert("mutable");
-    ReservedSet->insert("new");
-    ReservedSet->insert("operator");
-    ReservedSet->insert("private");
-    ReservedSet->insert("protected");
-    ReservedSet->insert("public");
-    ReservedSet->insert("reinterpret_cast");
-    ReservedSet->insert("short");
-    ReservedSet->insert("signed");
-    ReservedSet->insert("sizeof");
-    ReservedSet->insert("static_cast");
-    ReservedSet->insert("template");
-    ReservedSet->insert("throw");
-    ReservedSet->insert("try");
-    ReservedSet->insert("typename");
-    ReservedSet->insert("union");
-    ReservedSet->insert("unsigned");
-    ReservedSet->insert("using");
-    ReservedSet->insert("virtual");
-
-    SemanticMap = new std::unordered_map<const char*, glslang::TBuiltInVariable, str_hash, str_eq>;
+const std::unordered_set<const char*, str_hash, str_eq> ReservedSet {
+    "auto",
+    "catch",
+    "char",
+    "const_cast",
+    "enum",
+    "explicit",
+    "friend",
+    "goto",
+    "long",
+    "mutable",
+    "new",
+    "operator",
+    "private",
+    "protected",
+    "public",
+    "reinterpret_cast",
+    "short",
+    "signed",
+    "sizeof",
+    "static_cast",
+    "template",
+    "throw",
+    "try",
+    "typename",
+    "union",
+    "unsigned",
+    "using",
+    "virtual",
+};
+std::unordered_map<const char*, glslang::TBuiltInVariable, str_hash, str_eq> SemanticMap { 
 
     // in DX9, all outputs had to have a semantic associated with them, that was either consumed
     // by the system or was a specific register assignment
@@ -494,49 +476,41 @@ void HlslScanContext::fillInKeywordMap()
     // Also, in DX10 if a SV value is present as the input of a stage, but isn't appropriate for that
     // stage, it would just be ignored as it is likely there as part of an output struct from one stage
     // to the next
-    bool bParseDX9 = false;
-    if (bParseDX9) {
-        (*SemanticMap)["PSIZE"] = EbvPointSize;
-        (*SemanticMap)["FOG"] =   EbvFogFragCoord;
-        (*SemanticMap)["DEPTH"] = EbvFragDepth;
-        (*SemanticMap)["VFACE"] = EbvFace;
-        (*SemanticMap)["VPOS"] =  EbvFragCoord;
-    }
+#if 0
+    (*SemanticMap)["PSIZE"] = EbvPointSize;
+    (*SemanticMap)["FOG"] =   EbvFogFragCoord;
+    (*SemanticMap)["DEPTH"] = EbvFragDepth;
+    (*SemanticMap)["VFACE"] = EbvFace;
+    (*SemanticMap)["VPOS"] =  EbvFragCoord;
+#endif
 
-    (*SemanticMap)["SV_POSITION"] =               EbvPosition;
-    (*SemanticMap)["SV_VERTEXID"] =               EbvVertexIndex;
-    (*SemanticMap)["SV_VIEWPORTARRAYINDEX"] =     EbvViewportIndex;
-    (*SemanticMap)["SV_TESSFACTOR"] =             EbvTessLevelOuter;
-    (*SemanticMap)["SV_SAMPLEINDEX"] =            EbvSampleId;
-    (*SemanticMap)["SV_RENDERTARGETARRAYINDEX"] = EbvLayer;
-    (*SemanticMap)["SV_PRIMITIVEID"] =            EbvPrimitiveId;
-    (*SemanticMap)["SV_OUTPUTCONTROLPOINTID"] =   EbvInvocationId;
-    (*SemanticMap)["SV_ISFRONTFACE"] =            EbvFace;
-    (*SemanticMap)["SV_VIEWID"] =                 EbvViewIndex;
-    (*SemanticMap)["SV_INSTANCEID"] =             EbvInstanceIndex;
-    (*SemanticMap)["SV_INSIDETESSFACTOR"] =       EbvTessLevelInner;
-    (*SemanticMap)["SV_GSINSTANCEID"] =           EbvInvocationId;
-    (*SemanticMap)["SV_DISPATCHTHREADID"] =       EbvGlobalInvocationId;
-    (*SemanticMap)["SV_GROUPTHREADID"] =          EbvLocalInvocationId;
-    (*SemanticMap)["SV_GROUPINDEX"] =             EbvLocalInvocationIndex;
-    (*SemanticMap)["SV_GROUPID"] =                EbvWorkGroupId;
-    (*SemanticMap)["SV_DOMAINLOCATION"] =         EbvTessCoord;
-    (*SemanticMap)["SV_DEPTH"] =                  EbvFragDepth;
-    (*SemanticMap)["SV_COVERAGE"] =               EbvSampleMask;
-    (*SemanticMap)["SV_DEPTHGREATEREQUAL"] =      EbvFragDepthGreater;
-    (*SemanticMap)["SV_DEPTHLESSEQUAL"] =         EbvFragDepthLesser;
-    (*SemanticMap)["SV_STENCILREF"] =             EbvFragStencilRef;
+    {"SV_POSITION",glslang::EbvPosition},
+    {"SV_VERTEXID",glslang::EbvVertexIndex},
+    {"SV_VIEWPORTARRAYINDEX",glslang::EbvViewportIndex},
+    {"SV_TESSFACTOR",glslang::EbvTessLevelOuter},
+    {"SV_SAMPLEINDEX",glslang::EbvSampleId},
+    {"SV_RENDERTARGETARRAYINDEX",glslang::EbvLayer},
+    {"SV_PRIMITIVEID",glslang::EbvPrimitiveId},
+    {"SV_OUTPUTCONTROLPOINTID",glslang::EbvInvocationId},
+    {"SV_ISFRONTFACE",glslang::EbvFace},
+    {"SV_VIEWID",glslang::EbvViewIndex},
+    {"SV_INSTANCEID",glslang::EbvInstanceIndex},
+    {"SV_INSIDETESSFACTOR",glslang::EbvTessLevelInner},
+    {"SV_GSINSTANCEID",glslang::EbvInvocationId},
+    {"SV_DISPATCHTHREADID",glslang::EbvGlobalInvocationId},
+    {"SV_GROUPTHREADID",glslang::EbvLocalInvocationId},
+    {"SV_GROUPINDEX",glslang::EbvLocalInvocationIndex},
+    {"SV_GROUPID",glslang::EbvWorkGroupId},
+    {"SV_DOMAINLOCATION",glslang::EbvTessCoord},
+    {"SV_DEPTH",glslang::EbvFragDepth},
+    {"SV_COVERAGE",glslang::EbvSampleMask},
+    {"SV_DEPTHGREATEREQUAL",glslang::EbvFragDepthGreater},
+    {"SV_DEPTHLESSEQUAL",glslang::EbvFragDepthLesser},
+    {"SV_STENCILREF", glslang::EbvFragStencilRef},
+};
 }
 
-void HlslScanContext::deleteKeywordMap()
-{
-    delete KeywordMap;
-    KeywordMap = nullptr;
-    delete ReservedSet;
-    ReservedSet = nullptr;
-    delete SemanticMap;
-    SemanticMap = nullptr;
-}
+namespace glslang {
 
 // Wrapper for tokenizeClass() to get everything inside the token.
 void HlslScanContext::tokenize(HlslToken& token)
@@ -547,8 +521,8 @@ void HlslScanContext::tokenize(HlslToken& token)
 
 glslang::TBuiltInVariable HlslScanContext::mapSemantic(const char* upperCase)
 {
-    auto it = SemanticMap->find(upperCase);
-    if (it != SemanticMap->end())
+    auto it = SemanticMap.find(upperCase);
+    if (it != SemanticMap.end())
         return it->second;
     else
         return glslang::EbvNone;
@@ -664,11 +638,11 @@ EHlslTokenClass HlslScanContext::tokenizeClass(HlslToken& token)
 
 EHlslTokenClass HlslScanContext::tokenizeIdentifier()
 {
-    if (ReservedSet->find(tokenText) != ReservedSet->end())
+    if (ReservedSet.find(tokenText) != ReservedSet.end())
         return reservedWord();
 
-    auto it = KeywordMap->find(tokenText);
-    if (it == KeywordMap->end()) {
+    auto it = KeywordMap.find(tokenText);
+    if (it == KeywordMap.end()) {
         // Should have an identifier of some sort
         return identifierOrType();
     }

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -322,502 +322,480 @@ struct str_hash
 };
 
 // A single global usable by all threads, by all versions, by all languages.
-// After a single process-level initialization, this is read only and thread safe
-std::unordered_map<const char*, int, str_hash, str_eq>* KeywordMap = nullptr;
-std::unordered_set<const char*, str_hash, str_eq>* ReservedSet = nullptr;
+const std::unordered_map<const char*, int, str_hash, str_eq> KeywordMap {
+    {"const",CONST},
+    {"uniform",UNIFORM},
+    {"tileImageEXT",TILEIMAGEEXT},
+    {"buffer",BUFFER},
+    {"in",IN},
+    {"out",OUT},
+    {"smooth",SMOOTH},
+    {"flat",FLAT},
+    {"centroid",CENTROID},
+    {"invariant",INVARIANT},
+    {"packed",PACKED},
+    {"resource",RESOURCE},
+    {"inout",INOUT},
+    {"struct",STRUCT},
+    {"break",BREAK},
+    {"continue",CONTINUE},
+    {"do",DO},
+    {"for",FOR},
+    {"while",WHILE},
+    {"switch",SWITCH},
+    {"case",CASE},
+    {"default",DEFAULT},
+    {"if",IF},
+    {"else",ELSE},
+    {"discard",DISCARD},
+    {"terminateInvocation",TERMINATE_INVOCATION},
+    {"terminateRayEXT",TERMINATE_RAY},
+    {"ignoreIntersectionEXT",IGNORE_INTERSECTION},
+    {"return",RETURN},
+    {"void",VOID},
+    {"bool",BOOL},
+    {"float",FLOAT},
+    {"int",INT},
+    {"bvec2",BVEC2},
+    {"bvec3",BVEC3},
+    {"bvec4",BVEC4},
+    {"vec2",VEC2},
+    {"vec3",VEC3},
+    {"vec4",VEC4},
+    {"ivec2",IVEC2},
+    {"ivec3",IVEC3},
+    {"ivec4",IVEC4},
+    {"mat2",MAT2},
+    {"mat3",MAT3},
+    {"mat4",MAT4},
+    {"true",BOOLCONSTANT},
+    {"false",BOOLCONSTANT},
+    {"layout",LAYOUT},
+    {"shared",SHARED},
+    {"highp",HIGH_PRECISION},
+    {"mediump",MEDIUM_PRECISION},
+    {"lowp",LOW_PRECISION},
+    {"superp",SUPERP},
+    {"precision",PRECISION},
+    {"mat2x2",MAT2X2},
+    {"mat2x3",MAT2X3},
+    {"mat2x4",MAT2X4},
+    {"mat3x2",MAT3X2},
+    {"mat3x3",MAT3X3},
+    {"mat3x4",MAT3X4},
+    {"mat4x2",MAT4X2},
+    {"mat4x3",MAT4X3},
+    {"mat4x4",MAT4X4},
+    {"uint",UINT},
+    {"uvec2",UVEC2},
+    {"uvec3",UVEC3},
+    {"uvec4",UVEC4},
+
+    {"nonuniformEXT",NONUNIFORM},
+    {"demote",DEMOTE},
+    {"attribute",ATTRIBUTE},
+    {"varying",VARYING},
+    {"noperspective",NOPERSPECTIVE},
+    {"coherent",COHERENT},
+    {"devicecoherent",DEVICECOHERENT},
+    {"queuefamilycoherent",QUEUEFAMILYCOHERENT},
+    {"workgroupcoherent",WORKGROUPCOHERENT},
+    {"subgroupcoherent",SUBGROUPCOHERENT},
+    {"shadercallcoherent",SHADERCALLCOHERENT},
+    {"nonprivate",NONPRIVATE},
+    {"restrict",RESTRICT},
+    {"readonly",READONLY},
+    {"writeonly",WRITEONLY},
+    {"atomic_uint",ATOMIC_UINT},
+    {"volatile",VOLATILE},
+    {"patch",PATCH},
+    {"sample",SAMPLE},
+    {"subroutine",SUBROUTINE},
+    {"dmat2",DMAT2},
+    {"dmat3",DMAT3},
+    {"dmat4",DMAT4},
+    {"dmat2x2",DMAT2X2},
+    {"dmat2x3",DMAT2X3},
+    {"dmat2x4",DMAT2X4},
+    {"dmat3x2",DMAT3X2},
+    {"dmat3x3",DMAT3X3},
+    {"dmat3x4",DMAT3X4},
+    {"dmat4x2",DMAT4X2},
+    {"dmat4x3",DMAT4X3},
+    {"dmat4x4",DMAT4X4},
+    {"image1D",IMAGE1D},
+    {"iimage1D",IIMAGE1D},
+    {"uimage1D",UIMAGE1D},
+    {"image2D",IMAGE2D},
+    {"iimage2D",IIMAGE2D},
+    {"uimage2D",UIMAGE2D},
+    {"image3D",IMAGE3D},
+    {"iimage3D",IIMAGE3D},
+    {"uimage3D",UIMAGE3D},
+    {"image2DRect",IMAGE2DRECT},
+    {"iimage2DRect",IIMAGE2DRECT},
+    {"uimage2DRect",UIMAGE2DRECT},
+    {"imageCube",IMAGECUBE},
+    {"iimageCube",IIMAGECUBE},
+    {"uimageCube",UIMAGECUBE},
+    {"imageBuffer",IMAGEBUFFER},
+    {"iimageBuffer",IIMAGEBUFFER},
+    {"uimageBuffer",UIMAGEBUFFER},
+    {"image1DArray",IMAGE1DARRAY},
+    {"iimage1DArray",IIMAGE1DARRAY},
+    {"uimage1DArray",UIMAGE1DARRAY},
+    {"image2DArray",IMAGE2DARRAY},
+    {"iimage2DArray",IIMAGE2DARRAY},
+    {"uimage2DArray",UIMAGE2DARRAY},
+    {"imageCubeArray",IMAGECUBEARRAY},
+    {"iimageCubeArray",IIMAGECUBEARRAY},
+    {"uimageCubeArray",UIMAGECUBEARRAY},
+    {"image2DMS",IMAGE2DMS},
+    {"iimage2DMS",IIMAGE2DMS},
+    {"uimage2DMS",UIMAGE2DMS},
+    {"image2DMSArray",IMAGE2DMSARRAY},
+    {"iimage2DMSArray",IIMAGE2DMSARRAY},
+    {"uimage2DMSArray",UIMAGE2DMSARRAY},
+    {"i64image1D",I64IMAGE1D},
+    {"u64image1D",U64IMAGE1D},
+    {"i64image2D",I64IMAGE2D},
+    {"u64image2D",U64IMAGE2D},
+    {"i64image3D",I64IMAGE3D},
+    {"u64image3D",U64IMAGE3D},
+    {"i64image2DRect",I64IMAGE2DRECT},
+    {"u64image2DRect",U64IMAGE2DRECT},
+    {"i64imageCube",I64IMAGECUBE},
+    {"u64imageCube",U64IMAGECUBE},
+    {"i64imageBuffer",I64IMAGEBUFFER},
+    {"u64imageBuffer",U64IMAGEBUFFER},
+    {"i64image1DArray",I64IMAGE1DARRAY},
+    {"u64image1DArray",U64IMAGE1DARRAY},
+    {"i64image2DArray",I64IMAGE2DARRAY},
+    {"u64image2DArray",U64IMAGE2DARRAY},
+    {"i64imageCubeArray",I64IMAGECUBEARRAY},
+    {"u64imageCubeArray",U64IMAGECUBEARRAY},
+    {"i64image2DMS",I64IMAGE2DMS},
+    {"u64image2DMS",U64IMAGE2DMS},
+    {"i64image2DMSArray",I64IMAGE2DMSARRAY},
+    {"u64image2DMSArray",U64IMAGE2DMSARRAY},
+    {"double",DOUBLE},
+    {"dvec2",DVEC2},
+    {"dvec3",DVEC3},
+    {"dvec4",DVEC4},
+    {"int64_t",INT64_T},
+    {"uint64_t",UINT64_T},
+    {"i64vec2",I64VEC2},
+    {"i64vec3",I64VEC3},
+    {"i64vec4",I64VEC4},
+    {"u64vec2",U64VEC2},
+    {"u64vec3",U64VEC3},
+    {"u64vec4",U64VEC4},
+
+    // GL_EXT_shader_explicit_arithmetic_types
+    {"int8_t",INT8_T},
+    {"i8vec2",I8VEC2},
+    {"i8vec3",I8VEC3},
+    {"i8vec4",I8VEC4},
+    {"uint8_t",UINT8_T},
+    {"u8vec2",U8VEC2},
+    {"u8vec3",U8VEC3},
+    {"u8vec4",U8VEC4},
+
+    {"int16_t",INT16_T},
+    {"i16vec2",I16VEC2},
+    {"i16vec3",I16VEC3},
+    {"i16vec4",I16VEC4},
+    {"uint16_t",UINT16_T},
+    {"u16vec2",U16VEC2},
+    {"u16vec3",U16VEC3},
+    {"u16vec4",U16VEC4},
+
+    {"int32_t",INT32_T},
+    {"i32vec2",I32VEC2},
+    {"i32vec3",I32VEC3},
+    {"i32vec4",I32VEC4},
+    {"uint32_t",UINT32_T},
+    {"u32vec2",U32VEC2},
+    {"u32vec3",U32VEC3},
+    {"u32vec4",U32VEC4},
+
+    {"float16_t",FLOAT16_T},
+    {"f16vec2",F16VEC2},
+    {"f16vec3",F16VEC3},
+    {"f16vec4",F16VEC4},
+    {"f16mat2",F16MAT2},
+    {"f16mat3",F16MAT3},
+    {"f16mat4",F16MAT4},
+    {"f16mat2x2",F16MAT2X2},
+    {"f16mat2x3",F16MAT2X3},
+    {"f16mat2x4",F16MAT2X4},
+    {"f16mat3x2",F16MAT3X2},
+    {"f16mat3x3",F16MAT3X3},
+    {"f16mat3x4",F16MAT3X4},
+    {"f16mat4x2",F16MAT4X2},
+    {"f16mat4x3",F16MAT4X3},
+    {"f16mat4x4",F16MAT4X4},
+
+    {"float32_t",FLOAT32_T},
+    {"f32vec2",F32VEC2},
+    {"f32vec3",F32VEC3},
+    {"f32vec4",F32VEC4},
+    {"f32mat2",F32MAT2},
+    {"f32mat3",F32MAT3},
+    {"f32mat4",F32MAT4},
+    {"f32mat2x2",F32MAT2X2},
+    {"f32mat2x3",F32MAT2X3},
+    {"f32mat2x4",F32MAT2X4},
+    {"f32mat3x2",F32MAT3X2},
+    {"f32mat3x3",F32MAT3X3},
+    {"f32mat3x4",F32MAT3X4},
+    {"f32mat4x2",F32MAT4X2},
+    {"f32mat4x3",F32MAT4X3},
+    {"f32mat4x4",F32MAT4X4},
+    {"float64_t",FLOAT64_T},
+    {"f64vec2",F64VEC2},
+    {"f64vec3",F64VEC3},
+    {"f64vec4",F64VEC4},
+    {"f64mat2",F64MAT2},
+    {"f64mat3",F64MAT3},
+    {"f64mat4",F64MAT4},
+    {"f64mat2x2",F64MAT2X2},
+    {"f64mat2x3",F64MAT2X3},
+    {"f64mat2x4",F64MAT2X4},
+    {"f64mat3x2",F64MAT3X2},
+    {"f64mat3x3",F64MAT3X3},
+    {"f64mat3x4",F64MAT3X4},
+    {"f64mat4x2",F64MAT4X2},
+    {"f64mat4x3",F64MAT4X3},
+    {"f64mat4x4",F64MAT4X4},
+
+    // GL_EXT_spirv_intrinsics
+    {"spirv_instruction",SPIRV_INSTRUCTION},
+    {"spirv_execution_mode",SPIRV_EXECUTION_MODE},
+    {"spirv_execution_mode_id",SPIRV_EXECUTION_MODE_ID},
+    {"spirv_decorate",SPIRV_DECORATE},
+    {"spirv_decorate_id",SPIRV_DECORATE_ID},
+    {"spirv_decorate_string",SPIRV_DECORATE_STRING},
+    {"spirv_type",SPIRV_TYPE},
+    {"spirv_storage_class",SPIRV_STORAGE_CLASS},
+    {"spirv_by_reference",SPIRV_BY_REFERENCE},
+    {"spirv_literal",SPIRV_LITERAL},
+
+    {"sampler2D",SAMPLER2D},
+    {"samplerCube",SAMPLERCUBE},
+    {"samplerCubeShadow",SAMPLERCUBESHADOW},
+    {"sampler2DArray",SAMPLER2DARRAY},
+    {"sampler2DArrayShadow",SAMPLER2DARRAYSHADOW},
+    {"isampler2D",ISAMPLER2D},
+    {"isampler3D",ISAMPLER3D},
+    {"isamplerCube",ISAMPLERCUBE},
+    {"isampler2DArray",ISAMPLER2DARRAY},
+    {"usampler2D",USAMPLER2D},
+    {"usampler3D",USAMPLER3D},
+    {"usamplerCube",USAMPLERCUBE},
+    {"usampler2DArray",USAMPLER2DARRAY},
+    {"sampler3D",SAMPLER3D},
+    {"sampler2DShadow",SAMPLER2DSHADOW},
+
+    {"texture2D",TEXTURE2D},
+    {"textureCube",TEXTURECUBE},
+    {"texture2DArray",TEXTURE2DARRAY},
+    {"itexture2D",ITEXTURE2D},
+    {"itexture3D",ITEXTURE3D},
+    {"itextureCube",ITEXTURECUBE},
+    {"itexture2DArray",ITEXTURE2DARRAY},
+    {"utexture2D",UTEXTURE2D},
+    {"utexture3D",UTEXTURE3D},
+    {"utextureCube",UTEXTURECUBE},
+    {"utexture2DArray",UTEXTURE2DARRAY},
+    {"texture3D",TEXTURE3D},
+
+    {"sampler",SAMPLER},
+    {"samplerShadow",SAMPLERSHADOW},
+
+    {"textureCubeArray",TEXTURECUBEARRAY},
+    {"itextureCubeArray",ITEXTURECUBEARRAY},
+    {"utextureCubeArray",UTEXTURECUBEARRAY},
+    {"samplerCubeArray",SAMPLERCUBEARRAY},
+    {"samplerCubeArrayShadow",SAMPLERCUBEARRAYSHADOW},
+    {"isamplerCubeArray",ISAMPLERCUBEARRAY},
+    {"usamplerCubeArray",USAMPLERCUBEARRAY},
+    {"sampler1DArrayShadow",SAMPLER1DARRAYSHADOW},
+    {"isampler1DArray",ISAMPLER1DARRAY},
+    {"usampler1D",USAMPLER1D},
+    {"isampler1D",ISAMPLER1D},
+    {"usampler1DArray",USAMPLER1DARRAY},
+    {"samplerBuffer",SAMPLERBUFFER},
+    {"isampler2DRect",ISAMPLER2DRECT},
+    {"usampler2DRect",USAMPLER2DRECT},
+    {"isamplerBuffer",ISAMPLERBUFFER},
+    {"usamplerBuffer",USAMPLERBUFFER},
+    {"sampler2DMS",SAMPLER2DMS},
+    {"isampler2DMS",ISAMPLER2DMS},
+    {"usampler2DMS",USAMPLER2DMS},
+    {"sampler2DMSArray",SAMPLER2DMSARRAY},
+    {"isampler2DMSArray",ISAMPLER2DMSARRAY},
+    {"usampler2DMSArray",USAMPLER2DMSARRAY},
+    {"sampler1D",SAMPLER1D},
+    {"sampler1DShadow",SAMPLER1DSHADOW},
+    {"sampler2DRect",SAMPLER2DRECT},
+    {"sampler2DRectShadow",SAMPLER2DRECTSHADOW},
+    {"sampler1DArray",SAMPLER1DARRAY},
+
+    {"samplerExternalOES",     SAMPLEREXTERNALOES}, // GL_OES_EGL_image_external
+    {"__samplerExternal2DY2YEXT", SAMPLEREXTERNAL2DY2YEXT}, // GL_EXT_YUV_target
+
+    {"itexture1DArray",ITEXTURE1DARRAY},
+    {"utexture1D",UTEXTURE1D},
+    {"itexture1D",ITEXTURE1D},
+    {"utexture1DArray",UTEXTURE1DARRAY},
+    {"textureBuffer",TEXTUREBUFFER},
+    {"itexture2DRect",ITEXTURE2DRECT},
+    {"utexture2DRect",UTEXTURE2DRECT},
+    {"itextureBuffer",ITEXTUREBUFFER},
+    {"utextureBuffer",UTEXTUREBUFFER},
+    {"texture2DMS",TEXTURE2DMS},
+    {"itexture2DMS",ITEXTURE2DMS},
+    {"utexture2DMS",UTEXTURE2DMS},
+    {"texture2DMSArray",TEXTURE2DMSARRAY},
+    {"itexture2DMSArray",ITEXTURE2DMSARRAY},
+    {"utexture2DMSArray",UTEXTURE2DMSARRAY},
+    {"texture1D",TEXTURE1D},
+    {"texture2DRect",TEXTURE2DRECT},
+    {"texture1DArray",TEXTURE1DARRAY},
+
+    {"attachmentEXT",ATTACHMENTEXT},
+    {"iattachmentEXT",IATTACHMENTEXT},
+    {"uattachmentEXT",UATTACHMENTEXT},
+
+    {"subpassInput",SUBPASSINPUT},
+    {"subpassInputMS",SUBPASSINPUTMS},
+    {"isubpassInput",ISUBPASSINPUT},
+    {"isubpassInputMS",ISUBPASSINPUTMS},
+    {"usubpassInput",USUBPASSINPUT},
+    {"usubpassInputMS",USUBPASSINPUTMS},
+
+    {"f16sampler1D",F16SAMPLER1D},
+    {"f16sampler2D",F16SAMPLER2D},
+    {"f16sampler3D",F16SAMPLER3D},
+    {"f16sampler2DRect",F16SAMPLER2DRECT},
+    {"f16samplerCube",F16SAMPLERCUBE},
+    {"f16sampler1DArray",F16SAMPLER1DARRAY},
+    {"f16sampler2DArray",F16SAMPLER2DARRAY},
+    {"f16samplerCubeArray",F16SAMPLERCUBEARRAY},
+    {"f16samplerBuffer",F16SAMPLERBUFFER},
+    {"f16sampler2DMS",F16SAMPLER2DMS},
+    {"f16sampler2DMSArray",F16SAMPLER2DMSARRAY},
+    {"f16sampler1DShadow",F16SAMPLER1DSHADOW},
+    {"f16sampler2DShadow",F16SAMPLER2DSHADOW},
+    {"f16sampler2DRectShadow",F16SAMPLER2DRECTSHADOW},
+    {"f16samplerCubeShadow",F16SAMPLERCUBESHADOW},
+    {"f16sampler1DArrayShadow",F16SAMPLER1DARRAYSHADOW},
+    {"f16sampler2DArrayShadow",F16SAMPLER2DARRAYSHADOW},
+    {"f16samplerCubeArrayShadow",F16SAMPLERCUBEARRAYSHADOW},
+
+    {"f16image1D",F16IMAGE1D},
+    {"f16image2D",F16IMAGE2D},
+    {"f16image3D",F16IMAGE3D},
+    {"f16image2DRect",F16IMAGE2DRECT},
+    {"f16imageCube",F16IMAGECUBE},
+    {"f16image1DArray",F16IMAGE1DARRAY},
+    {"f16image2DArray",F16IMAGE2DARRAY},
+    {"f16imageCubeArray",F16IMAGECUBEARRAY},
+    {"f16imageBuffer",F16IMAGEBUFFER},
+    {"f16image2DMS",F16IMAGE2DMS},
+    {"f16image2DMSArray",F16IMAGE2DMSARRAY},
+
+    {"f16texture1D",F16TEXTURE1D},
+    {"f16texture2D",F16TEXTURE2D},
+    {"f16texture3D",F16TEXTURE3D},
+    {"f16texture2DRect",F16TEXTURE2DRECT},
+    {"f16textureCube",F16TEXTURECUBE},
+    {"f16texture1DArray",F16TEXTURE1DARRAY},
+    {"f16texture2DArray",F16TEXTURE2DARRAY},
+    {"f16textureCubeArray",F16TEXTURECUBEARRAY},
+    {"f16textureBuffer",F16TEXTUREBUFFER},
+    {"f16texture2DMS",F16TEXTURE2DMS},
+    {"f16texture2DMSArray",F16TEXTURE2DMSARRAY},
+
+    {"f16subpassInput",F16SUBPASSINPUT},
+    {"f16subpassInputMS",F16SUBPASSINPUTMS},
+    {"__explicitInterpAMD",EXPLICITINTERPAMD},
+    {"pervertexNV",PERVERTEXNV},
+    {"pervertexEXT",PERVERTEXEXT},
+    {"precise",PRECISE},
+
+    {"rayPayloadNV",PAYLOADNV},
+    {"rayPayloadEXT",PAYLOADEXT},
+    {"rayPayloadInNV",PAYLOADINNV},
+    {"rayPayloadInEXT",PAYLOADINEXT},
+    {"hitAttributeNV",HITATTRNV},
+    {"hitAttributeEXT",HITATTREXT},
+    {"callableDataNV",CALLDATANV},
+    {"callableDataEXT",CALLDATAEXT},
+    {"callableDataInNV",CALLDATAINNV},
+    {"callableDataInEXT",CALLDATAINEXT},
+    {"accelerationStructureNV",ACCSTRUCTNV},
+    {"accelerationStructureEXT",ACCSTRUCTEXT},
+    {"rayQueryEXT",RAYQUERYEXT},
+    {"perprimitiveNV",PERPRIMITIVENV},
+    {"perviewNV",PERVIEWNV},
+    {"taskNV",PERTASKNV},
+    {"perprimitiveEXT",PERPRIMITIVEEXT},
+    {"taskPayloadSharedEXT",TASKPAYLOADWORKGROUPEXT},
+
+    {"fcoopmatNV",FCOOPMATNV},
+    {"icoopmatNV",ICOOPMATNV},
+    {"ucoopmatNV",UCOOPMATNV},
+
+    {"coopmat",COOPMAT},
+
+    {"hitObjectNV",HITOBJECTNV},
+    {"hitObjectAttributeNV",HITOBJECTATTRNV},
+};
+const std::unordered_set<const char*, str_hash, str_eq> ReservedSet {
+    "common",
+    "partition",
+    "active",
+    "asm",
+    "class",
+    "union",
+    "enum",
+    "typedef",
+    "template",
+    "this",
+    "goto",
+    "inline",
+    "noinline",
+    "public",
+    "static",
+    "extern",
+    "external",
+    "interface",
+    "long",
+    "short",
+    "half",
+    "fixed",
+    "unsigned",
+    "input",
+    "output",
+    "hvec2",
+    "hvec3",
+    "hvec4",
+    "fvec2",
+    "fvec3",
+    "fvec4",
+    "sampler3DRect",
+    "filter",
+    "sizeof",
+    "cast",
+    "namespace",
+    "using",
+};
 
 }
 
 namespace glslang {
-
-void TScanContext::fillInKeywordMap()
-{
-    if (KeywordMap != nullptr) {
-        // this is really an error, as this should called only once per process
-        // but, the only risk is if two threads called simultaneously
-        return;
-    }
-    KeywordMap = new std::unordered_map<const char*, int, str_hash, str_eq>;
-
-    (*KeywordMap)["const"] =                   CONST;
-    (*KeywordMap)["uniform"] =                 UNIFORM;
-    (*KeywordMap)["tileImageEXT"] =            TILEIMAGEEXT;
-    (*KeywordMap)["buffer"] =                  BUFFER;
-    (*KeywordMap)["in"] =                      IN;
-    (*KeywordMap)["out"] =                     OUT;
-    (*KeywordMap)["smooth"] =                  SMOOTH;
-    (*KeywordMap)["flat"] =                    FLAT;
-    (*KeywordMap)["centroid"] =                CENTROID;
-    (*KeywordMap)["invariant"] =               INVARIANT;
-    (*KeywordMap)["packed"] =                  PACKED;
-    (*KeywordMap)["resource"] =                RESOURCE;
-    (*KeywordMap)["inout"] =                   INOUT;
-    (*KeywordMap)["struct"] =                  STRUCT;
-    (*KeywordMap)["break"] =                   BREAK;
-    (*KeywordMap)["continue"] =                CONTINUE;
-    (*KeywordMap)["do"] =                      DO;
-    (*KeywordMap)["for"] =                     FOR;
-    (*KeywordMap)["while"] =                   WHILE;
-    (*KeywordMap)["switch"] =                  SWITCH;
-    (*KeywordMap)["case"] =                    CASE;
-    (*KeywordMap)["default"] =                 DEFAULT;
-    (*KeywordMap)["if"] =                      IF;
-    (*KeywordMap)["else"] =                    ELSE;
-    (*KeywordMap)["discard"] =                 DISCARD;
-    (*KeywordMap)["terminateInvocation"] =     TERMINATE_INVOCATION;
-    (*KeywordMap)["terminateRayEXT"] =         TERMINATE_RAY;
-    (*KeywordMap)["ignoreIntersectionEXT"] =   IGNORE_INTERSECTION;
-    (*KeywordMap)["return"] =                  RETURN;
-    (*KeywordMap)["void"] =                    VOID;
-    (*KeywordMap)["bool"] =                    BOOL;
-    (*KeywordMap)["float"] =                   FLOAT;
-    (*KeywordMap)["int"] =                     INT;
-    (*KeywordMap)["bvec2"] =                   BVEC2;
-    (*KeywordMap)["bvec3"] =                   BVEC3;
-    (*KeywordMap)["bvec4"] =                   BVEC4;
-    (*KeywordMap)["vec2"] =                    VEC2;
-    (*KeywordMap)["vec3"] =                    VEC3;
-    (*KeywordMap)["vec4"] =                    VEC4;
-    (*KeywordMap)["ivec2"] =                   IVEC2;
-    (*KeywordMap)["ivec3"] =                   IVEC3;
-    (*KeywordMap)["ivec4"] =                   IVEC4;
-    (*KeywordMap)["mat2"] =                    MAT2;
-    (*KeywordMap)["mat3"] =                    MAT3;
-    (*KeywordMap)["mat4"] =                    MAT4;
-    (*KeywordMap)["true"] =                    BOOLCONSTANT;
-    (*KeywordMap)["false"] =                   BOOLCONSTANT;
-    (*KeywordMap)["layout"] =                  LAYOUT;
-    (*KeywordMap)["shared"] =                  SHARED;
-    (*KeywordMap)["highp"] =                   HIGH_PRECISION;
-    (*KeywordMap)["mediump"] =                 MEDIUM_PRECISION;
-    (*KeywordMap)["lowp"] =                    LOW_PRECISION;
-    (*KeywordMap)["superp"] =                  SUPERP;
-    (*KeywordMap)["precision"] =               PRECISION;
-    (*KeywordMap)["mat2x2"] =                  MAT2X2;
-    (*KeywordMap)["mat2x3"] =                  MAT2X3;
-    (*KeywordMap)["mat2x4"] =                  MAT2X4;
-    (*KeywordMap)["mat3x2"] =                  MAT3X2;
-    (*KeywordMap)["mat3x3"] =                  MAT3X3;
-    (*KeywordMap)["mat3x4"] =                  MAT3X4;
-    (*KeywordMap)["mat4x2"] =                  MAT4X2;
-    (*KeywordMap)["mat4x3"] =                  MAT4X3;
-    (*KeywordMap)["mat4x4"] =                  MAT4X4;
-    (*KeywordMap)["uint"] =                    UINT;
-    (*KeywordMap)["uvec2"] =                   UVEC2;
-    (*KeywordMap)["uvec3"] =                   UVEC3;
-    (*KeywordMap)["uvec4"] =                   UVEC4;
-
-    (*KeywordMap)["nonuniformEXT"] =           NONUNIFORM;
-    (*KeywordMap)["demote"] =                  DEMOTE;
-    (*KeywordMap)["attribute"] =               ATTRIBUTE;
-    (*KeywordMap)["varying"] =                 VARYING;
-    (*KeywordMap)["noperspective"] =           NOPERSPECTIVE;
-    (*KeywordMap)["coherent"] =                COHERENT;
-    (*KeywordMap)["devicecoherent"] =          DEVICECOHERENT;
-    (*KeywordMap)["queuefamilycoherent"] =     QUEUEFAMILYCOHERENT;
-    (*KeywordMap)["workgroupcoherent"] =       WORKGROUPCOHERENT;
-    (*KeywordMap)["subgroupcoherent"] =        SUBGROUPCOHERENT;
-    (*KeywordMap)["shadercallcoherent"] =      SHADERCALLCOHERENT;
-    (*KeywordMap)["nonprivate"] =              NONPRIVATE;
-    (*KeywordMap)["restrict"] =                RESTRICT;
-    (*KeywordMap)["readonly"] =                READONLY;
-    (*KeywordMap)["writeonly"] =               WRITEONLY;
-    (*KeywordMap)["atomic_uint"] =             ATOMIC_UINT;
-    (*KeywordMap)["volatile"] =                VOLATILE;
-    (*KeywordMap)["patch"] =                   PATCH;
-    (*KeywordMap)["sample"] =                  SAMPLE;
-    (*KeywordMap)["subroutine"] =              SUBROUTINE;
-    (*KeywordMap)["dmat2"] =                   DMAT2;
-    (*KeywordMap)["dmat3"] =                   DMAT3;
-    (*KeywordMap)["dmat4"] =                   DMAT4;
-    (*KeywordMap)["dmat2x2"] =                 DMAT2X2;
-    (*KeywordMap)["dmat2x3"] =                 DMAT2X3;
-    (*KeywordMap)["dmat2x4"] =                 DMAT2X4;
-    (*KeywordMap)["dmat3x2"] =                 DMAT3X2;
-    (*KeywordMap)["dmat3x3"] =                 DMAT3X3;
-    (*KeywordMap)["dmat3x4"] =                 DMAT3X4;
-    (*KeywordMap)["dmat4x2"] =                 DMAT4X2;
-    (*KeywordMap)["dmat4x3"] =                 DMAT4X3;
-    (*KeywordMap)["dmat4x4"] =                 DMAT4X4;
-    (*KeywordMap)["image1D"] =                 IMAGE1D;
-    (*KeywordMap)["iimage1D"] =                IIMAGE1D;
-    (*KeywordMap)["uimage1D"] =                UIMAGE1D;
-    (*KeywordMap)["image2D"] =                 IMAGE2D;
-    (*KeywordMap)["iimage2D"] =                IIMAGE2D;
-    (*KeywordMap)["uimage2D"] =                UIMAGE2D;
-    (*KeywordMap)["image3D"] =                 IMAGE3D;
-    (*KeywordMap)["iimage3D"] =                IIMAGE3D;
-    (*KeywordMap)["uimage3D"] =                UIMAGE3D;
-    (*KeywordMap)["image2DRect"] =             IMAGE2DRECT;
-    (*KeywordMap)["iimage2DRect"] =            IIMAGE2DRECT;
-    (*KeywordMap)["uimage2DRect"] =            UIMAGE2DRECT;
-    (*KeywordMap)["imageCube"] =               IMAGECUBE;
-    (*KeywordMap)["iimageCube"] =              IIMAGECUBE;
-    (*KeywordMap)["uimageCube"] =              UIMAGECUBE;
-    (*KeywordMap)["imageBuffer"] =             IMAGEBUFFER;
-    (*KeywordMap)["iimageBuffer"] =            IIMAGEBUFFER;
-    (*KeywordMap)["uimageBuffer"] =            UIMAGEBUFFER;
-    (*KeywordMap)["image1DArray"] =            IMAGE1DARRAY;
-    (*KeywordMap)["iimage1DArray"] =           IIMAGE1DARRAY;
-    (*KeywordMap)["uimage1DArray"] =           UIMAGE1DARRAY;
-    (*KeywordMap)["image2DArray"] =            IMAGE2DARRAY;
-    (*KeywordMap)["iimage2DArray"] =           IIMAGE2DARRAY;
-    (*KeywordMap)["uimage2DArray"] =           UIMAGE2DARRAY;
-    (*KeywordMap)["imageCubeArray"] =          IMAGECUBEARRAY;
-    (*KeywordMap)["iimageCubeArray"] =         IIMAGECUBEARRAY;
-    (*KeywordMap)["uimageCubeArray"] =         UIMAGECUBEARRAY;
-    (*KeywordMap)["image2DMS"] =               IMAGE2DMS;
-    (*KeywordMap)["iimage2DMS"] =              IIMAGE2DMS;
-    (*KeywordMap)["uimage2DMS"] =              UIMAGE2DMS;
-    (*KeywordMap)["image2DMSArray"] =          IMAGE2DMSARRAY;
-    (*KeywordMap)["iimage2DMSArray"] =         IIMAGE2DMSARRAY;
-    (*KeywordMap)["uimage2DMSArray"] =         UIMAGE2DMSARRAY;
-    (*KeywordMap)["i64image1D"] =              I64IMAGE1D;
-    (*KeywordMap)["u64image1D"] =              U64IMAGE1D;
-    (*KeywordMap)["i64image2D"] =              I64IMAGE2D;
-    (*KeywordMap)["u64image2D"] =              U64IMAGE2D;
-    (*KeywordMap)["i64image3D"] =              I64IMAGE3D;
-    (*KeywordMap)["u64image3D"] =              U64IMAGE3D;
-    (*KeywordMap)["i64image2DRect"] =          I64IMAGE2DRECT;
-    (*KeywordMap)["u64image2DRect"] =          U64IMAGE2DRECT;
-    (*KeywordMap)["i64imageCube"] =            I64IMAGECUBE;
-    (*KeywordMap)["u64imageCube"] =            U64IMAGECUBE;
-    (*KeywordMap)["i64imageBuffer"] =          I64IMAGEBUFFER;
-    (*KeywordMap)["u64imageBuffer"] =          U64IMAGEBUFFER;
-    (*KeywordMap)["i64image1DArray"] =         I64IMAGE1DARRAY;
-    (*KeywordMap)["u64image1DArray"] =         U64IMAGE1DARRAY;
-    (*KeywordMap)["i64image2DArray"] =         I64IMAGE2DARRAY;
-    (*KeywordMap)["u64image2DArray"] =         U64IMAGE2DARRAY;
-    (*KeywordMap)["i64imageCubeArray"] =       I64IMAGECUBEARRAY;
-    (*KeywordMap)["u64imageCubeArray"] =       U64IMAGECUBEARRAY;
-    (*KeywordMap)["i64image2DMS"] =            I64IMAGE2DMS;
-    (*KeywordMap)["u64image2DMS"] =            U64IMAGE2DMS;
-    (*KeywordMap)["i64image2DMSArray"] =       I64IMAGE2DMSARRAY;
-    (*KeywordMap)["u64image2DMSArray"] =       U64IMAGE2DMSARRAY;
-    (*KeywordMap)["double"] =                  DOUBLE;
-    (*KeywordMap)["dvec2"] =                   DVEC2;
-    (*KeywordMap)["dvec3"] =                   DVEC3;
-    (*KeywordMap)["dvec4"] =                   DVEC4;
-    (*KeywordMap)["int64_t"] =                 INT64_T;
-    (*KeywordMap)["uint64_t"] =                UINT64_T;
-    (*KeywordMap)["i64vec2"] =                 I64VEC2;
-    (*KeywordMap)["i64vec3"] =                 I64VEC3;
-    (*KeywordMap)["i64vec4"] =                 I64VEC4;
-    (*KeywordMap)["u64vec2"] =                 U64VEC2;
-    (*KeywordMap)["u64vec3"] =                 U64VEC3;
-    (*KeywordMap)["u64vec4"] =                 U64VEC4;
-
-    // GL_EXT_shader_explicit_arithmetic_types
-    (*KeywordMap)["int8_t"] =                  INT8_T;
-    (*KeywordMap)["i8vec2"] =                  I8VEC2;
-    (*KeywordMap)["i8vec3"] =                  I8VEC3;
-    (*KeywordMap)["i8vec4"] =                  I8VEC4;
-    (*KeywordMap)["uint8_t"] =                 UINT8_T;
-    (*KeywordMap)["u8vec2"] =                  U8VEC2;
-    (*KeywordMap)["u8vec3"] =                  U8VEC3;
-    (*KeywordMap)["u8vec4"] =                  U8VEC4;
-
-    (*KeywordMap)["int16_t"] =                 INT16_T;
-    (*KeywordMap)["i16vec2"] =                 I16VEC2;
-    (*KeywordMap)["i16vec3"] =                 I16VEC3;
-    (*KeywordMap)["i16vec4"] =                 I16VEC4;
-    (*KeywordMap)["uint16_t"] =                UINT16_T;
-    (*KeywordMap)["u16vec2"] =                 U16VEC2;
-    (*KeywordMap)["u16vec3"] =                 U16VEC3;
-    (*KeywordMap)["u16vec4"] =                 U16VEC4;
-
-    (*KeywordMap)["int32_t"] =                 INT32_T;
-    (*KeywordMap)["i32vec2"] =                 I32VEC2;
-    (*KeywordMap)["i32vec3"] =                 I32VEC3;
-    (*KeywordMap)["i32vec4"] =                 I32VEC4;
-    (*KeywordMap)["uint32_t"] =                UINT32_T;
-    (*KeywordMap)["u32vec2"] =                 U32VEC2;
-    (*KeywordMap)["u32vec3"] =                 U32VEC3;
-    (*KeywordMap)["u32vec4"] =                 U32VEC4;
-
-    (*KeywordMap)["float16_t"] =               FLOAT16_T;
-    (*KeywordMap)["f16vec2"] =                 F16VEC2;
-    (*KeywordMap)["f16vec3"] =                 F16VEC3;
-    (*KeywordMap)["f16vec4"] =                 F16VEC4;
-    (*KeywordMap)["f16mat2"] =                 F16MAT2;
-    (*KeywordMap)["f16mat3"] =                 F16MAT3;
-    (*KeywordMap)["f16mat4"] =                 F16MAT4;
-    (*KeywordMap)["f16mat2x2"] =               F16MAT2X2;
-    (*KeywordMap)["f16mat2x3"] =               F16MAT2X3;
-    (*KeywordMap)["f16mat2x4"] =               F16MAT2X4;
-    (*KeywordMap)["f16mat3x2"] =               F16MAT3X2;
-    (*KeywordMap)["f16mat3x3"] =               F16MAT3X3;
-    (*KeywordMap)["f16mat3x4"] =               F16MAT3X4;
-    (*KeywordMap)["f16mat4x2"] =               F16MAT4X2;
-    (*KeywordMap)["f16mat4x3"] =               F16MAT4X3;
-    (*KeywordMap)["f16mat4x4"] =               F16MAT4X4;
-
-    (*KeywordMap)["float32_t"] =               FLOAT32_T;
-    (*KeywordMap)["f32vec2"] =                 F32VEC2;
-    (*KeywordMap)["f32vec3"] =                 F32VEC3;
-    (*KeywordMap)["f32vec4"] =                 F32VEC4;
-    (*KeywordMap)["f32mat2"] =                 F32MAT2;
-    (*KeywordMap)["f32mat3"] =                 F32MAT3;
-    (*KeywordMap)["f32mat4"] =                 F32MAT4;
-    (*KeywordMap)["f32mat2x2"] =               F32MAT2X2;
-    (*KeywordMap)["f32mat2x3"] =               F32MAT2X3;
-    (*KeywordMap)["f32mat2x4"] =               F32MAT2X4;
-    (*KeywordMap)["f32mat3x2"] =               F32MAT3X2;
-    (*KeywordMap)["f32mat3x3"] =               F32MAT3X3;
-    (*KeywordMap)["f32mat3x4"] =               F32MAT3X4;
-    (*KeywordMap)["f32mat4x2"] =               F32MAT4X2;
-    (*KeywordMap)["f32mat4x3"] =               F32MAT4X3;
-    (*KeywordMap)["f32mat4x4"] =               F32MAT4X4;
-    (*KeywordMap)["float64_t"] =               FLOAT64_T;
-    (*KeywordMap)["f64vec2"] =                 F64VEC2;
-    (*KeywordMap)["f64vec3"] =                 F64VEC3;
-    (*KeywordMap)["f64vec4"] =                 F64VEC4;
-    (*KeywordMap)["f64mat2"] =                 F64MAT2;
-    (*KeywordMap)["f64mat3"] =                 F64MAT3;
-    (*KeywordMap)["f64mat4"] =                 F64MAT4;
-    (*KeywordMap)["f64mat2x2"] =               F64MAT2X2;
-    (*KeywordMap)["f64mat2x3"] =               F64MAT2X3;
-    (*KeywordMap)["f64mat2x4"] =               F64MAT2X4;
-    (*KeywordMap)["f64mat3x2"] =               F64MAT3X2;
-    (*KeywordMap)["f64mat3x3"] =               F64MAT3X3;
-    (*KeywordMap)["f64mat3x4"] =               F64MAT3X4;
-    (*KeywordMap)["f64mat4x2"] =               F64MAT4X2;
-    (*KeywordMap)["f64mat4x3"] =               F64MAT4X3;
-    (*KeywordMap)["f64mat4x4"] =               F64MAT4X4;
-
-    // GL_EXT_spirv_intrinsics
-    (*KeywordMap)["spirv_instruction"] =       SPIRV_INSTRUCTION;
-    (*KeywordMap)["spirv_execution_mode"] =    SPIRV_EXECUTION_MODE;
-    (*KeywordMap)["spirv_execution_mode_id"] = SPIRV_EXECUTION_MODE_ID;
-    (*KeywordMap)["spirv_decorate"] =          SPIRV_DECORATE;
-    (*KeywordMap)["spirv_decorate_id"] =       SPIRV_DECORATE_ID;
-    (*KeywordMap)["spirv_decorate_string"] =   SPIRV_DECORATE_STRING;
-    (*KeywordMap)["spirv_type"] =              SPIRV_TYPE;
-    (*KeywordMap)["spirv_storage_class"] =     SPIRV_STORAGE_CLASS;
-    (*KeywordMap)["spirv_by_reference"] =      SPIRV_BY_REFERENCE;
-    (*KeywordMap)["spirv_literal"] =           SPIRV_LITERAL;
-
-    (*KeywordMap)["sampler2D"] =               SAMPLER2D;
-    (*KeywordMap)["samplerCube"] =             SAMPLERCUBE;
-    (*KeywordMap)["samplerCubeShadow"] =       SAMPLERCUBESHADOW;
-    (*KeywordMap)["sampler2DArray"] =          SAMPLER2DARRAY;
-    (*KeywordMap)["sampler2DArrayShadow"] =    SAMPLER2DARRAYSHADOW;
-    (*KeywordMap)["isampler2D"] =              ISAMPLER2D;
-    (*KeywordMap)["isampler3D"] =              ISAMPLER3D;
-    (*KeywordMap)["isamplerCube"] =            ISAMPLERCUBE;
-    (*KeywordMap)["isampler2DArray"] =         ISAMPLER2DARRAY;
-    (*KeywordMap)["usampler2D"] =              USAMPLER2D;
-    (*KeywordMap)["usampler3D"] =              USAMPLER3D;
-    (*KeywordMap)["usamplerCube"] =            USAMPLERCUBE;
-    (*KeywordMap)["usampler2DArray"] =         USAMPLER2DARRAY;
-    (*KeywordMap)["sampler3D"] =               SAMPLER3D;
-    (*KeywordMap)["sampler2DShadow"] =         SAMPLER2DSHADOW;
-
-    (*KeywordMap)["texture2D"] =               TEXTURE2D;
-    (*KeywordMap)["textureCube"] =             TEXTURECUBE;
-    (*KeywordMap)["texture2DArray"] =          TEXTURE2DARRAY;
-    (*KeywordMap)["itexture2D"] =              ITEXTURE2D;
-    (*KeywordMap)["itexture3D"] =              ITEXTURE3D;
-    (*KeywordMap)["itextureCube"] =            ITEXTURECUBE;
-    (*KeywordMap)["itexture2DArray"] =         ITEXTURE2DARRAY;
-    (*KeywordMap)["utexture2D"] =              UTEXTURE2D;
-    (*KeywordMap)["utexture3D"] =              UTEXTURE3D;
-    (*KeywordMap)["utextureCube"] =            UTEXTURECUBE;
-    (*KeywordMap)["utexture2DArray"] =         UTEXTURE2DARRAY;
-    (*KeywordMap)["texture3D"] =               TEXTURE3D;
-
-    (*KeywordMap)["sampler"] =                 SAMPLER;
-    (*KeywordMap)["samplerShadow"] =           SAMPLERSHADOW;
-
-    (*KeywordMap)["textureCubeArray"] =        TEXTURECUBEARRAY;
-    (*KeywordMap)["itextureCubeArray"] =       ITEXTURECUBEARRAY;
-    (*KeywordMap)["utextureCubeArray"] =       UTEXTURECUBEARRAY;
-    (*KeywordMap)["samplerCubeArray"] =        SAMPLERCUBEARRAY;
-    (*KeywordMap)["samplerCubeArrayShadow"] =  SAMPLERCUBEARRAYSHADOW;
-    (*KeywordMap)["isamplerCubeArray"] =       ISAMPLERCUBEARRAY;
-    (*KeywordMap)["usamplerCubeArray"] =       USAMPLERCUBEARRAY;
-    (*KeywordMap)["sampler1DArrayShadow"] =    SAMPLER1DARRAYSHADOW;
-    (*KeywordMap)["isampler1DArray"] =         ISAMPLER1DARRAY;
-    (*KeywordMap)["usampler1D"] =              USAMPLER1D;
-    (*KeywordMap)["isampler1D"] =              ISAMPLER1D;
-    (*KeywordMap)["usampler1DArray"] =         USAMPLER1DARRAY;
-    (*KeywordMap)["samplerBuffer"] =           SAMPLERBUFFER;
-    (*KeywordMap)["isampler2DRect"] =          ISAMPLER2DRECT;
-    (*KeywordMap)["usampler2DRect"] =          USAMPLER2DRECT;
-    (*KeywordMap)["isamplerBuffer"] =          ISAMPLERBUFFER;
-    (*KeywordMap)["usamplerBuffer"] =          USAMPLERBUFFER;
-    (*KeywordMap)["sampler2DMS"] =             SAMPLER2DMS;
-    (*KeywordMap)["isampler2DMS"] =            ISAMPLER2DMS;
-    (*KeywordMap)["usampler2DMS"] =            USAMPLER2DMS;
-    (*KeywordMap)["sampler2DMSArray"] =        SAMPLER2DMSARRAY;
-    (*KeywordMap)["isampler2DMSArray"] =       ISAMPLER2DMSARRAY;
-    (*KeywordMap)["usampler2DMSArray"] =       USAMPLER2DMSARRAY;
-    (*KeywordMap)["sampler1D"] =               SAMPLER1D;
-    (*KeywordMap)["sampler1DShadow"] =         SAMPLER1DSHADOW;
-    (*KeywordMap)["sampler2DRect"] =           SAMPLER2DRECT;
-    (*KeywordMap)["sampler2DRectShadow"] =     SAMPLER2DRECTSHADOW;
-    (*KeywordMap)["sampler1DArray"] =          SAMPLER1DARRAY;
-
-    (*KeywordMap)["samplerExternalOES"] =      SAMPLEREXTERNALOES; // GL_OES_EGL_image_external
-
-    (*KeywordMap)["__samplerExternal2DY2YEXT"] = SAMPLEREXTERNAL2DY2YEXT; // GL_EXT_YUV_target
-
-    (*KeywordMap)["itexture1DArray"] =         ITEXTURE1DARRAY;
-    (*KeywordMap)["utexture1D"] =              UTEXTURE1D;
-    (*KeywordMap)["itexture1D"] =              ITEXTURE1D;
-    (*KeywordMap)["utexture1DArray"] =         UTEXTURE1DARRAY;
-    (*KeywordMap)["textureBuffer"] =           TEXTUREBUFFER;
-    (*KeywordMap)["itexture2DRect"] =          ITEXTURE2DRECT;
-    (*KeywordMap)["utexture2DRect"] =          UTEXTURE2DRECT;
-    (*KeywordMap)["itextureBuffer"] =          ITEXTUREBUFFER;
-    (*KeywordMap)["utextureBuffer"] =          UTEXTUREBUFFER;
-    (*KeywordMap)["texture2DMS"] =             TEXTURE2DMS;
-    (*KeywordMap)["itexture2DMS"] =            ITEXTURE2DMS;
-    (*KeywordMap)["utexture2DMS"] =            UTEXTURE2DMS;
-    (*KeywordMap)["texture2DMSArray"] =        TEXTURE2DMSARRAY;
-    (*KeywordMap)["itexture2DMSArray"] =       ITEXTURE2DMSARRAY;
-    (*KeywordMap)["utexture2DMSArray"] =       UTEXTURE2DMSARRAY;
-    (*KeywordMap)["texture1D"] =               TEXTURE1D;
-    (*KeywordMap)["texture2DRect"] =           TEXTURE2DRECT;
-    (*KeywordMap)["texture1DArray"] =          TEXTURE1DARRAY;
-
-    (*KeywordMap)["attachmentEXT"] =           ATTACHMENTEXT;
-    (*KeywordMap)["iattachmentEXT"] =          IATTACHMENTEXT;
-    (*KeywordMap)["uattachmentEXT"] =          UATTACHMENTEXT;
-
-    (*KeywordMap)["subpassInput"] =            SUBPASSINPUT;
-    (*KeywordMap)["subpassInputMS"] =          SUBPASSINPUTMS;
-    (*KeywordMap)["isubpassInput"] =           ISUBPASSINPUT;
-    (*KeywordMap)["isubpassInputMS"] =         ISUBPASSINPUTMS;
-    (*KeywordMap)["usubpassInput"] =           USUBPASSINPUT;
-    (*KeywordMap)["usubpassInputMS"] =         USUBPASSINPUTMS;
-
-    (*KeywordMap)["f16sampler1D"] =                 F16SAMPLER1D;
-    (*KeywordMap)["f16sampler2D"] =                 F16SAMPLER2D;
-    (*KeywordMap)["f16sampler3D"] =                 F16SAMPLER3D;
-    (*KeywordMap)["f16sampler2DRect"] =             F16SAMPLER2DRECT;
-    (*KeywordMap)["f16samplerCube"] =               F16SAMPLERCUBE;
-    (*KeywordMap)["f16sampler1DArray"] =            F16SAMPLER1DARRAY;
-    (*KeywordMap)["f16sampler2DArray"] =            F16SAMPLER2DARRAY;
-    (*KeywordMap)["f16samplerCubeArray"] =          F16SAMPLERCUBEARRAY;
-    (*KeywordMap)["f16samplerBuffer"] =             F16SAMPLERBUFFER;
-    (*KeywordMap)["f16sampler2DMS"] =               F16SAMPLER2DMS;
-    (*KeywordMap)["f16sampler2DMSArray"] =          F16SAMPLER2DMSARRAY;
-    (*KeywordMap)["f16sampler1DShadow"] =           F16SAMPLER1DSHADOW;
-    (*KeywordMap)["f16sampler2DShadow"] =           F16SAMPLER2DSHADOW;
-    (*KeywordMap)["f16sampler2DRectShadow"] =       F16SAMPLER2DRECTSHADOW;
-    (*KeywordMap)["f16samplerCubeShadow"] =         F16SAMPLERCUBESHADOW;
-    (*KeywordMap)["f16sampler1DArrayShadow"] =      F16SAMPLER1DARRAYSHADOW;
-    (*KeywordMap)["f16sampler2DArrayShadow"] =      F16SAMPLER2DARRAYSHADOW;
-    (*KeywordMap)["f16samplerCubeArrayShadow"] =    F16SAMPLERCUBEARRAYSHADOW;
-
-    (*KeywordMap)["f16image1D"] =                   F16IMAGE1D;
-    (*KeywordMap)["f16image2D"] =                   F16IMAGE2D;
-    (*KeywordMap)["f16image3D"] =                   F16IMAGE3D;
-    (*KeywordMap)["f16image2DRect"] =               F16IMAGE2DRECT;
-    (*KeywordMap)["f16imageCube"] =                 F16IMAGECUBE;
-    (*KeywordMap)["f16image1DArray"] =              F16IMAGE1DARRAY;
-    (*KeywordMap)["f16image2DArray"] =              F16IMAGE2DARRAY;
-    (*KeywordMap)["f16imageCubeArray"] =            F16IMAGECUBEARRAY;
-    (*KeywordMap)["f16imageBuffer"] =               F16IMAGEBUFFER;
-    (*KeywordMap)["f16image2DMS"] =                 F16IMAGE2DMS;
-    (*KeywordMap)["f16image2DMSArray"] =            F16IMAGE2DMSARRAY;
-
-    (*KeywordMap)["f16texture1D"] =                 F16TEXTURE1D;
-    (*KeywordMap)["f16texture2D"] =                 F16TEXTURE2D;
-    (*KeywordMap)["f16texture3D"] =                 F16TEXTURE3D;
-    (*KeywordMap)["f16texture2DRect"] =             F16TEXTURE2DRECT;
-    (*KeywordMap)["f16textureCube"] =               F16TEXTURECUBE;
-    (*KeywordMap)["f16texture1DArray"] =            F16TEXTURE1DARRAY;
-    (*KeywordMap)["f16texture2DArray"] =            F16TEXTURE2DARRAY;
-    (*KeywordMap)["f16textureCubeArray"] =          F16TEXTURECUBEARRAY;
-    (*KeywordMap)["f16textureBuffer"] =             F16TEXTUREBUFFER;
-    (*KeywordMap)["f16texture2DMS"] =               F16TEXTURE2DMS;
-    (*KeywordMap)["f16texture2DMSArray"] =          F16TEXTURE2DMSARRAY;
-
-    (*KeywordMap)["f16subpassInput"] =              F16SUBPASSINPUT;
-    (*KeywordMap)["f16subpassInputMS"] =            F16SUBPASSINPUTMS;
-    (*KeywordMap)["__explicitInterpAMD"] =     EXPLICITINTERPAMD;
-    (*KeywordMap)["pervertexNV"] =             PERVERTEXNV;
-    (*KeywordMap)["pervertexEXT"] =            PERVERTEXEXT;
-    (*KeywordMap)["precise"] =                 PRECISE;
-
-    (*KeywordMap)["rayPayloadNV"] =            PAYLOADNV;
-    (*KeywordMap)["rayPayloadEXT"] =           PAYLOADEXT;
-    (*KeywordMap)["rayPayloadInNV"] =          PAYLOADINNV;
-    (*KeywordMap)["rayPayloadInEXT"] =         PAYLOADINEXT;
-    (*KeywordMap)["hitAttributeNV"] =          HITATTRNV;
-    (*KeywordMap)["hitAttributeEXT"] =         HITATTREXT;
-    (*KeywordMap)["callableDataNV"] =          CALLDATANV;
-    (*KeywordMap)["callableDataEXT"] =         CALLDATAEXT;
-    (*KeywordMap)["callableDataInNV"] =        CALLDATAINNV;
-    (*KeywordMap)["callableDataInEXT"] =       CALLDATAINEXT;
-    (*KeywordMap)["accelerationStructureNV"] = ACCSTRUCTNV;
-    (*KeywordMap)["accelerationStructureEXT"]   = ACCSTRUCTEXT;
-    (*KeywordMap)["rayQueryEXT"] =              RAYQUERYEXT;
-    (*KeywordMap)["perprimitiveNV"] =          PERPRIMITIVENV;
-    (*KeywordMap)["perviewNV"] =               PERVIEWNV;
-    (*KeywordMap)["taskNV"] =                  PERTASKNV;
-    (*KeywordMap)["perprimitiveEXT"] =         PERPRIMITIVEEXT;
-    (*KeywordMap)["taskPayloadSharedEXT"] =    TASKPAYLOADWORKGROUPEXT;
-
-    (*KeywordMap)["fcoopmatNV"] =              FCOOPMATNV;
-    (*KeywordMap)["icoopmatNV"] =              ICOOPMATNV;
-    (*KeywordMap)["ucoopmatNV"] =              UCOOPMATNV;
-
-    (*KeywordMap)["coopmat"] =                 COOPMAT;
-
-    (*KeywordMap)["hitObjectNV"] =             HITOBJECTNV;
-    (*KeywordMap)["hitObjectAttributeNV"] =    HITOBJECTATTRNV;
-
-    ReservedSet = new std::unordered_set<const char*, str_hash, str_eq>;
-
-    ReservedSet->insert("common");
-    ReservedSet->insert("partition");
-    ReservedSet->insert("active");
-    ReservedSet->insert("asm");
-    ReservedSet->insert("class");
-    ReservedSet->insert("union");
-    ReservedSet->insert("enum");
-    ReservedSet->insert("typedef");
-    ReservedSet->insert("template");
-    ReservedSet->insert("this");
-    ReservedSet->insert("goto");
-    ReservedSet->insert("inline");
-    ReservedSet->insert("noinline");
-    ReservedSet->insert("public");
-    ReservedSet->insert("static");
-    ReservedSet->insert("extern");
-    ReservedSet->insert("external");
-    ReservedSet->insert("interface");
-    ReservedSet->insert("long");
-    ReservedSet->insert("short");
-    ReservedSet->insert("half");
-    ReservedSet->insert("fixed");
-    ReservedSet->insert("unsigned");
-    ReservedSet->insert("input");
-    ReservedSet->insert("output");
-    ReservedSet->insert("hvec2");
-    ReservedSet->insert("hvec3");
-    ReservedSet->insert("hvec4");
-    ReservedSet->insert("fvec2");
-    ReservedSet->insert("fvec3");
-    ReservedSet->insert("fvec4");
-    ReservedSet->insert("sampler3DRect");
-    ReservedSet->insert("filter");
-    ReservedSet->insert("sizeof");
-    ReservedSet->insert("cast");
-    ReservedSet->insert("namespace");
-    ReservedSet->insert("using");
-}
-
-void TScanContext::deleteKeywordMap()
-{
-    delete KeywordMap;
-    KeywordMap = nullptr;
-    delete ReservedSet;
-    ReservedSet = nullptr;
-}
 
 // Called by yylex to get the next token.
 // Returning 0 implies end of input.
@@ -924,11 +902,11 @@ int TScanContext::tokenize(TPpContext* pp, TParserToken& token)
 
 int TScanContext::tokenizeIdentifier()
 {
-    if (ReservedSet->find(tokenText) != ReservedSet->end())
+    if (ReservedSet.find(tokenText) != ReservedSet.end())
         return reservedWord();
 
-    auto it = KeywordMap->find(tokenText);
-    if (it == KeywordMap->end()) {
+    auto it = KeywordMap.find(tokenText);
+    if (it == KeywordMap.end()) {
         // Should have an identifier of some sort
         return identifierOrType();
     }

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1324,11 +1324,6 @@ int ShInitialize()
     if (PerProcessGPA == nullptr)
         PerProcessGPA = new TPoolAllocator();
 
-    glslang::TScanContext::fillInKeywordMap();
-#ifdef ENABLE_HLSL
-    glslang::HlslScanContext::fillInKeywordMap();
-#endif
-
     return 1;
 }
 
@@ -1416,11 +1411,6 @@ int ShFinalize()
         delete PerProcessGPA;
         PerProcessGPA = nullptr;
     }
-
-    glslang::TScanContext::deleteKeywordMap();
-#ifdef ENABLE_HLSL
-    glslang::HlslScanContext::deleteKeywordMap();
-#endif
 
     return 1;
 }


### PR DESCRIPTION
Rather than having a function that needs to be called from ShInitialize to initialize some global costants, convert them to use static initializers. This also ends up saving a bit of space in the binary, especially when building with GCC.