### PR TITLE
Remove redundant calls to spv::Parameterize() from tests

### DIFF
--- a/gtests/GlslMapIO.FromFile.cpp
+++ b/gtests/GlslMapIO.FromFile.cpp
@@ -312,7 +312,6 @@ TEST_P(GlslMapIOTest, FromFile)
                     spirv_binary, &logger, &options());
 
                 std::ostringstream disassembly_stream;
-                spv::Parameterize();
                 spv::Disassemble(disassembly_stream, spirv_binary);
                 result.spirvWarningsErrors += logger.getAllMessages();
                 result.spirv += disassembly_stream.str();

--- a/gtests/Link.FromFile.Vk.cpp
+++ b/gtests/Link.FromFile.Vk.cpp
@@ -86,7 +86,6 @@ TEST_P(LinkTestVulkan, FromFile)
                                 spirv_binary, &logger, &options());
 
         std::ostringstream disassembly_stream;
-        spv::Parameterize();
         spv::Disassemble(disassembly_stream, spirv_binary);
         result.spirvWarningsErrors = logger.getAllMessages();
         result.spirv = disassembly_stream.str();

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -324,7 +324,6 @@ public:
         }
 
         std::ostringstream disassembly_stream;
-        spv::Parameterize();
         spv::Disassemble(disassembly_stream, spirv_binary);
         bool validation_result = !options().validate || logger.getAllMessages().empty();
         return {{
@@ -384,7 +383,6 @@ public:
                                   spirv_binary, &logger, &options());
 
             std::ostringstream disassembly_stream;
-            spv::Parameterize();
             spv::Disassemble(disassembly_stream, spirv_binary);
             bool validation_result = !options().validate || logger.getAllMessages().empty();
             return {{{shaderName, shader.getInfoLog(), shader.getInfoDebugLog()},},
@@ -429,7 +427,6 @@ public:
             spv::spirvbin_t(0 /*verbosity*/).remap(spirv_binary, whiteListStrings, remapOptions);
 
             std::ostringstream disassembly_stream;
-            spv::Parameterize();
             spv::Disassemble(disassembly_stream, spirv_binary);
             bool validation_result = !options().validate || logger.getAllMessages().empty();
             return {{{shaderName, shader.getInfoLog(), shader.getInfoDebugLog()},},
@@ -453,7 +450,6 @@ public:
             spv::spirvbin_t(0 /*verbosity*/).remap(spirv_binary, whiteListStrings, remapOptions);
 
             std::ostringstream disassembly_stream;
-            spv::Parameterize();
             spv::Disassemble(disassembly_stream, spirv_binary);
 
             return {{{shaderName, "", ""},},

--- a/gtests/VkRelaxed.FromFile.cpp
+++ b/gtests/VkRelaxed.FromFile.cpp
@@ -264,7 +264,6 @@ TEST_P(VulkanRelaxedTest, FromFile)
                     spirv_binary, &logger, &options());
 
                 std::ostringstream disassembly_stream;
-                spv::Parameterize();
                 spv::Disassemble(disassembly_stream, spirv_binary);
                 result.spirvWarningsErrors += logger.getAllMessages();
                 result.spirv += disassembly_stream.str();


### PR DESCRIPTION
This means the tests won't need to have this entrypoint exposed when building as a shared library with hidden symbols.