### PR TITLE
Add symbol visibility annotations to glslang-resource-limits library

### DIFF
--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -227,6 +227,7 @@ set_target_properties(glslang-default-resource-limits PROPERTIES
 target_include_directories(glslang-default-resource-limits PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+glslang_only_export_explicit_symbols(glslang-default-resource-limits)
 
 ################################################################################
 # source_groups

--- a/glslang/Public/ResourceLimits.h
+++ b/glslang/Public/ResourceLimits.h
@@ -38,20 +38,21 @@
 #include <string>
 
 #include "../Include/ResourceLimits.h"
+#include "../Include/visibility.h"
 
 // Return pointer to user-writable Resource to pass through API in
 // future-proof way.
-extern TBuiltInResource* GetResources();
+GLSLANG_EXPORT extern TBuiltInResource* GetResources();
 
 // These are the default resources for TBuiltInResources, used for both
 //  - parsing this string for the case where the user didn't supply one,
 //  - dumping out a template for user construction of a config file.
-extern const TBuiltInResource* GetDefaultResources();
+GLSLANG_EXPORT extern const TBuiltInResource* GetDefaultResources();
 
 // Returns the DefaultTBuiltInResource as a human-readable string.
-std::string GetDefaultTBuiltInResourceString();
+GLSLANG_EXPORT std::string GetDefaultTBuiltInResourceString();
 
 // Decodes the resource limits from |config| to |resources|.
-void DecodeResourceLimits(TBuiltInResource* resources, char* config);
+GLSLANG_EXPORT void DecodeResourceLimits(TBuiltInResource* resources, char* config);
 
 #endif  // _STAND_ALONE_RESOURCE_LIMITS_INCLUDED_

--- a/glslang/Public/resource_limits_c.h
+++ b/glslang/Public/resource_limits_c.h
@@ -30,25 +30,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _STAND_ALONE_RESOURCE_LIMITS_C_INCLUDED_
 
 #include "../Include/glslang_c_interface.h"
+#include "../Include/visibility.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 // Returns a struct that can be use to create custom resource values.
-glslang_resource_t* glslang_resource(void);
+GLSLANG_EXPORT glslang_resource_t* glslang_resource(void);
 
 // These are the default resources for TBuiltInResources, used for both
 //  - parsing this string for the case where the user didn't supply one,
 //  - dumping out a template for user construction of a config file.
-const glslang_resource_t* glslang_default_resource(void);
+GLSLANG_EXPORT const glslang_resource_t* glslang_default_resource(void);
 
 // Returns the DefaultTBuiltInResource as a human-readable string.
 // NOTE: User is responsible for freeing this string.
-const char* glslang_default_resource_string();
+GLSLANG_EXPORT const char* glslang_default_resource_string();
 
 // Decodes the resource limits from |config| to |resources|.
-void glslang_decode_resource_limits(glslang_resource_t* resources, char* config);
+GLSLANG_EXPORT void glslang_decode_resource_limits(glslang_resource_t* resources, char* config);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Among other things, this allows using it as a DLL on Windows because unlike Linux, the default on windows is hidden visibility unless things are explicitly exported.