### PR TITLE
Explicitly export symbols from libSPVRemapper

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -100,6 +100,7 @@ if (ENABLE_SPVREMAPPER)
         POSITION_INDEPENDENT_CODE ON
         VERSION   "${GLSLANG_VERSION}"
         SOVERSION "${GLSLANG_VERSION_MAJOR}")
+    glslang_only_export_explicit_symbols(SPVRemapper)
 endif()
 
 if(WIN32 AND BUILD_SHARED_LIBS)

--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -41,6 +41,21 @@
 #include <cstdlib>
 #include <exception>
 
+#ifdef GLSLANG_IS_SHARED_LIBRARY
+    #ifdef _WIN32
+        #ifdef GLSLANG_EXPORTING
+            #define GLSLANG_EXPORT __declspec(dllexport)
+        #else
+            #define GLSLANG_EXPORT __declspec(dllimport)
+        #endif
+    #elif __GNUC__ >= 4
+        #define GLSLANG_EXPORT __attribute__((visibility("default")))
+    #endif
+#endif // GLSLANG_IS_SHARED_LIBRARY
+#ifndef GLSLANG_EXPORT
+#define GLSLANG_EXPORT
+#endif
+
 namespace spv {
 
 class spirvbin_base_t
@@ -83,7 +98,7 @@ namespace spv {
 static inline constexpr Id NoResult = 0;
 
 // class to hold SPIR-V binary data for remapping, DCE, and debug stripping
-class spirvbin_t : public spirvbin_base_t
+class GLSLANG_EXPORT spirvbin_t : public spirvbin_base_t
 {
 public:
    spirvbin_t(int verbose = 0) : entryPoint(spv::NoResult), largestNewId(0), verbose(verbose), errorLatch(false)


### PR DESCRIPTION
Windows requires symbols to be explicitly exported from DLLs, this change simply marks the entire spirvbin_t class as exported.

The macros from visibility.h are included inline to get around include path issues.

Fixes #3716