### PR TITLE
Improved iomapper api

### DIFF
--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -262,7 +262,6 @@ if(GLSLANG_ENABLE_INSTALL)
         Include/glslang_c_interface.h
         Include/glslang_c_shader_types.h
         Include/ResourceLimits.h
-        MachineIndependent/iomapper.h
         Include/visibility.h
         MachineIndependent/Versions.h)
 

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1716,6 +1716,10 @@ public:
     virtual bool compile(TIntermNode*, int = 0, EProfile = ENoProfile) { return true; }
 };
 
+TIoMapper* GetGlslIoMapper() {
+    return static_cast<TIoMapper*>(new TGlslIoMapper());
+}
+
 TShader::TShader(EShLanguage s)
     : stage(s), lengths(nullptr), stringNames(nullptr), preamble(""), overrideVersion(0)
 {
@@ -2164,6 +2168,12 @@ int TProgram::getNumAtomicCounters() const                            { return r
 const TObjectReflection& TProgram::getAtomicCounter(int index) const  { return reflection->getAtomicCounter(index); }
 void TProgram::dumpReflection() { if (reflection != nullptr) reflection->dump(); }
 
+TIoMapResolver* TProgram::getGlslIoResolver(EShLanguage stage) {
+    auto *intermediate = getIntermediate(stage);
+    if (!intermediate)
+        return NULL;
+    return static_cast<TIoMapResolver*>(new TDefaultGlslIoResolver(*intermediate));
+}
 //
 // I/O mapping implementation.
 //

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -189,16 +189,6 @@ protected:
 
 typedef std::map<TString, TVarEntryInfo> TVarLiveMap;
 
-// I/O mapper
-class TIoMapper {
-public:
-    TIoMapper() {}
-    virtual ~TIoMapper() {}
-    // grow the reflection stage by stage
-    bool virtual addStage(EShLanguage, TIntermediate&, TInfoSink&, TIoMapResolver*);
-    bool virtual doMap(TIoMapResolver*, TInfoSink&) { return true; }
-};
-
 // I/O mapper for GLSL
 class TGlslIoMapper : public TIoMapper {
 public:

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -400,6 +400,7 @@ GLSLANG_EXPORT int GetKhronosToolId();
 class TIntermediate;
 class TProgram;
 class TPoolAllocator;
+class TIoMapResolver;
 
 // Call this exactly once per process before using anything else
 GLSLANG_EXPORT bool InitializeProcess();
@@ -838,6 +839,19 @@ public:
     virtual void addStage(EShLanguage stage, TIntermediate& stageIntermediate) = 0;
 };
 
+// I/O mapper
+class TIoMapper {
+public:
+    TIoMapper() {}
+    virtual ~TIoMapper() {}
+    // grow the reflection stage by stage
+    bool virtual addStage(EShLanguage, TIntermediate&, TInfoSink&, TIoMapResolver*);
+    bool virtual doMap(TIoMapResolver*, TInfoSink&) { return true; }
+};
+
+// Get the default GLSL IO mapper
+GLSLANG_EXPORT TIoMapper* GetGlslIoMapper();
+
 // Make one TProgram per set of shaders that will get linked together.  Add all
 // the shaders that are to be linked together.  After calling shader.parse()
 // for all shaders, call link().
@@ -945,6 +959,10 @@ public:
     const TType *getAttributeTType(int index) const    { return getPipeInput(index).getType(); }
 
     GLSLANG_EXPORT void dumpReflection();
+
+    // Get the IO resolver to use for mapIO
+    GLSLANG_EXPORT TIoMapResolver* getGlslIoResolver(EShLanguage stage);
+
     // I/O mapping: apply base offsets and map live unbound variables
     // If resolver is not provided it uses the previous approach
     // and respects auto assignment and offsets.

--- a/gtests/GlslMapIO.FromFile.cpp
+++ b/gtests/GlslMapIO.FromFile.cpp
@@ -285,19 +285,21 @@ TEST_P(GlslMapIOTest, FromFile)
     result.linkingOutput = program.getInfoLog();
     result.linkingError = program.getInfoDebugLog();
 
-    unsigned int stage = 0;
-    glslang::TIntermediate* firstIntermediate = nullptr;
-    while (!program.getIntermediate((EShLanguage)stage) && stage < EShLangCount) { stage++; }
-    firstIntermediate = program.getIntermediate((EShLanguage)stage);
-
-    glslang::TDefaultGlslIoResolver resolver(*firstIntermediate);
-    glslang::TGlslIoMapper ioMapper;
+    glslang::TIoMapResolver *resolver;
+    for (unsigned stage = 0; stage < EShLangCount; stage++) {
+        resolver = program.getGlslIoResolver((EShLanguage)stage);
+        if (resolver)
+            break;
+    }
+    glslang::TIoMapper *ioMapper = glslang::GetGlslIoMapper();
 
     if (success) {
-        success &= program.mapIO(&resolver, &ioMapper);
+        success &= program.mapIO(resolver, ioMapper);
         result.linkingOutput = program.getInfoLog();
         result.linkingError = program.getInfoDebugLog();
     }
+    delete ioMapper;
+    delete resolver;
 
     success &= verifyIOMapping(result.linkingError, program);
     result.validationResult = success;

--- a/gtests/VkRelaxed.FromFile.cpp
+++ b/gtests/VkRelaxed.FromFile.cpp
@@ -237,19 +237,21 @@ TEST_P(VulkanRelaxedTest, FromFile)
             shaders[i]->setResourceSetBinding(resourceSetBindings[i]);
     }
 
-    unsigned int stage = 0;
-    glslang::TIntermediate* firstIntermediate = nullptr;
-    while (!program.getIntermediate((EShLanguage)stage) && stage < EShLangCount) { stage++; }
-    firstIntermediate = program.getIntermediate((EShLanguage)stage);
-
-    glslang::TDefaultGlslIoResolver resolver(*firstIntermediate);
-    glslang::TGlslIoMapper ioMapper;
+    glslang::TIoMapResolver *resolver;
+    for (unsigned stage = 0; stage < EShLangCount; stage++) {
+        resolver = program.getGlslIoResolver((EShLanguage)stage);
+        if (resolver)
+            break;
+    }
+    glslang::TIoMapper *ioMapper = glslang::GetGlslIoMapper();
 
     if (success) {
-        success &= program.mapIO(&resolver, &ioMapper);
+        success &= program.mapIO(resolver, ioMapper);
         result.linkingOutput = program.getInfoLog();
         result.linkingError = program.getInfoDebugLog();
     }
+    delete ioMapper;
+    delete resolver;
 
     success &= verifyIOMapping(result.linkingError, program);
     result.validationResult = success;


### PR DESCRIPTION
The TProgram::mapIO method takes a TIoMapResolver and a TIoMapper, however the only way to obtain instances of these was from methods in iomapper.h. Rather than try to expose that header as part of the API, new methods are added to the public ShaderLang.h header to create a TDefaultGlslIoResolver and a TGlslIoMapper and return them as pointers to their respective base classes, which are defined in the public header.

Also update the tests to use these new public entry points, rather than relying on private ones.

Fixes #3681