### PR TITLE
Expose setResourceSetBinding() method to the C API

### DIFF
--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -63,6 +63,7 @@ static_assert(sizeof(glslang_version_t) == sizeof(glslang::Version), "");
 typedef struct glslang_shader_s {
     glslang::TShader* shader;
     std::string preprocessedGLSL;
+    std::vector<std::string> baseResourceSetBinding;
 } glslang_shader_t;
 
 typedef struct glslang_program_s {
@@ -387,6 +388,16 @@ GLSLANG_EXPORT void glslang_shader_set_default_uniform_block_set_and_binding(gls
 
 GLSLANG_EXPORT void glslang_shader_set_default_uniform_block_name(glslang_shader_t* shader, const char *name) {
     shader->shader->setGlobalUniformBlockName(name);
+}
+
+GLSLANG_EXPORT void glslang_shader_set_resource_set_binding(glslang_shader_t* shader, const char *const *bindings, unsigned int num_bindings) {
+    shader->baseResourceSetBinding.clear();
+
+    for (unsigned int i = 0; i < num_bindings; ++i) {
+        shader->baseResourceSetBinding.push_back(std::string(bindings[i]));
+    }
+
+    shader->shader->setResourceSetBinding(shader->baseResourceSetBinding);
 }
 
 GLSLANG_EXPORT const char* glslang_shader_get_preprocessed_code(glslang_shader_t* shader)

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -259,6 +259,7 @@ GLSLANG_EXPORT void glslang_shader_set_options(glslang_shader_t* shader, int opt
 GLSLANG_EXPORT void glslang_shader_set_glsl_version(glslang_shader_t* shader, int version);
 GLSLANG_EXPORT void glslang_shader_set_default_uniform_block_set_and_binding(glslang_shader_t* shader, unsigned int set, unsigned int binding);
 GLSLANG_EXPORT void glslang_shader_set_default_uniform_block_name(glslang_shader_t* shader, const char *name);
+GLSLANG_EXPORT void glslang_shader_set_resource_set_binding(glslang_shader_t* shader, const char *const *bindings, unsigned int num_bindings);
 GLSLANG_EXPORT int glslang_shader_preprocess(glslang_shader_t* shader, const glslang_input_t* input);
 GLSLANG_EXPORT int glslang_shader_parse(glslang_shader_t* shader, const glslang_input_t* input);
 GLSLANG_EXPORT const char* glslang_shader_get_preprocessed_code(glslang_shader_t* shader);


### PR DESCRIPTION
This adds `glslang_shader_set_resource_set_binding()` to the C API as a counterpart to `setResourceSetBinding()`. I need this to set the descriptor set for automatically mapped samplers when compiling legacy OpenGL shaders in Vulkan mode with relaxed semantics.