### PR TITLE
Fix Wformat warnings for printf `%p`

### DIFF
--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -324,7 +324,7 @@ static EProfile c_shader_profile(glslang_profile_t profile)
 GLSLANG_EXPORT glslang_shader_t* glslang_shader_create(const glslang_input_t* input)
 {
     if (!input || !input->code) {
-        printf("Error creating shader: null input(%p)/input->code\n", input);
+        printf("Error creating shader: null input(%p)/input->code\n", (void*)input);
 
         if (input)
             printf("input->code = %p\n", input->code);

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -169,7 +169,7 @@ void TType::buildMangledName(TString& mangledName) const
                 if (arraySizes->getDimNode(i)->getAsSymbolNode())
                     snprintf(buf, maxSize, "s%lld", arraySizes->getDimNode(i)->getAsSymbolNode()->getId());
                 else
-                    snprintf(buf, maxSize, "s%p", arraySizes->getDimNode(i));
+                    snprintf(buf, maxSize, "s%p", (void*)(arraySizes->getDimNode(i)));
             } else
                 snprintf(buf, maxSize, "%d", arraySizes->getDimSize(i));
             mangledName += '[';


### PR DESCRIPTION
The `%p` specifier expects a void pointer argument, so explicitly cast to `void *`.

No functional changes.