### PR TITLE
ci: Update macOS runner to macOS-latest

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -100,7 +100,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [{genus: macos-13, family: osx}]
+                os: [{genus: macos-latest, family: osx}]
                 compiler: [{cc: clang, cxx: clang++}]
                 cmake_build_type: [Debug, Release]
         steps:


### PR DESCRIPTION
That way it doesn't need to be updated manually in the future.