### PR TITLE
Add warning if Forward Declaration uses layout qualifiers

### DIFF
--- a/Test/baseResults/spv.bufferhandle_Error.frag.out
+++ b/Test/baseResults/spv.bufferhandle_Error.frag.out
@@ -12,16 +12,18 @@ ERROR: 0:13: 'buffer_reference' : can only be used with buffer
 ERROR: 0:14: 'output block' : not supported in this stage: fragment
 ERROR: 0:14: 'buffer_reference' : can only be used with buffer 
 ERROR: 0:14: 'buffer_reference' : can only be used with buffer 
-ERROR: 0:30: 'length' :  array must be declared with a size before using this method
-ERROR: 0:31: 'length' :  array must be declared with a size before using this method
-ERROR: 0:32: 'buffer reference indexing' : required extension not requested: GL_EXT_buffer_reference2
-ERROR: 0:32: '' : cannot index reference to buffer containing an unsized array 
-ERROR: 0:32: '' : cannot index buffer reference 
-ERROR: 0:36: '=' :  cannot convert from 'layout( column_major std430) buffer reference' to ' temp reference'
-ERROR: 0:41: 'assign' :  cannot convert from 'layout( column_major std430) buffer reference' to 'layout( column_major std430) buffer reference'
-ERROR: 0:42: 'assign' :  cannot convert from 'layout( column_major std430) buffer reference' to 'layout( column_major std430) buffer reference'
-ERROR: 0:43: 'assign' :  cannot convert from 'layout( column_major std430) buffer reference' to 'layout( column_major std430) buffer reference'
-ERROR: 0:46: '' :  syntax error, unexpected LEFT_BRACE, expecting COMMA or SEMICOLON
+WARNING: 0:20: 'bufType7' : the buffer_reference_align layout is ignored when defined in forward declaration 
+WARNING: 0:20: 'bufType7' : the packing layout (scalar, std430, etc) is ignored when defined in forward declaration 
+ERROR: 0:34: 'length' :  array must be declared with a size before using this method
+ERROR: 0:35: 'length' :  array must be declared with a size before using this method
+ERROR: 0:36: 'buffer reference indexing' : required extension not requested: GL_EXT_buffer_reference2
+ERROR: 0:36: '' : cannot index reference to buffer containing an unsized array 
+ERROR: 0:36: '' : cannot index buffer reference 
+ERROR: 0:40: '=' :  cannot convert from 'layout( column_major std430) buffer reference' to ' temp reference'
+ERROR: 0:45: 'assign' :  cannot convert from 'layout( column_major std430) buffer reference' to 'layout( column_major std430) buffer reference'
+ERROR: 0:46: 'assign' :  cannot convert from 'layout( column_major std430) buffer reference' to 'layout( column_major std430) buffer reference'
+ERROR: 0:47: 'assign' :  cannot convert from 'layout( column_major std430) buffer reference' to 'layout( column_major std430) buffer reference'
+ERROR: 0:50: '' :  syntax error, unexpected LEFT_BRACE, expecting COMMA or SEMICOLON
 ERROR: 23 compilation errors.  No code generated.
 
 

--- a/Test/spv.bufferhandle_Error.frag
+++ b/Test/spv.bufferhandle_Error.frag
@@ -17,11 +17,15 @@ layout(buffer_reference) buffer bufType5;
 
 layout(buffer_reference) buffer bufType6 { int x[]; };
 
+layout(buffer_reference, std140, buffer_reference_align = 16) buffer bufType7;
+layout(buffer_reference) buffer bufType7 { int x[]; };
+
 buffer bufType4 {
     bufType1 b1;
     bufType2 b2;
     bufType3 b3;
     bufType6 b6;
+    bufType7 b7;
 } b4;
 
 void f()

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -2348,7 +2348,7 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
                 TSampler s = arg0->getType().getSampler();
                 if (s.is2D() && s.isArrayed() && s.isShadow()) {
                     if (
-                        ((*argp)[1]->getAsTyped()->getType().getBasicType() == EbtFloat) && 
+                        ((*argp)[1]->getAsTyped()->getType().getBasicType() == EbtFloat) &&
                         ((*argp)[1]->getAsTyped()->getType().getVectorSize() == 4) &&
                         (fnCandidate.getParamCount() == 4)) {
                         featureString = fnCandidate.getName() + " for sampler2DArrayShadow";
@@ -2532,7 +2532,7 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
                 error(loc, "only supported on image with format r64i", fnCandidate.getName().c_str(), "");
             else if (callNode.getType().getBasicType() == EbtUint64 && imageType.getQualifier().getFormat() != ElfR64ui)
                 error(loc, "only supported on image with format r64ui", fnCandidate.getName().c_str(), "");
-        } else if(callNode.getType().getBasicType() == EbtFloat16 && 
+        } else if(callNode.getType().getBasicType() == EbtFloat16 &&
                 ((callNode.getType().getVectorSize() == 2 && arg0->getType().getQualifier().getFormat() == ElfRg16f) ||
                   (callNode.getType().getVectorSize() == 4 && arg0->getType().getQualifier().getFormat() == ElfRgba16f))) {
             if (StartsWith(fnCandidate.getName(), "imageAtomicAdd") ||
@@ -2603,7 +2603,7 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
             requireExtensions(loc, 2, extensions, fnCandidate.getName().c_str());
         } else if ((callNode.getOp() == EOpAtomicAdd || callNode.getOp() == EOpAtomicExchange ||
                     callNode.getOp() == EOpAtomicMin || callNode.getOp() == EOpAtomicMax) &&
-                   arg0->getType().getBasicType() == EbtFloat16 && 
+                   arg0->getType().getBasicType() == EbtFloat16 &&
                    (arg0->getType().getVectorSize() == 2 || arg0->getType().getVectorSize() == 4 )) {
             requireExtensions(loc, 1, &E_GL_NV_shader_atomic_fp16_vector, fnCandidate.getName().c_str());
         } else if ((callNode.getOp() == EOpAtomicAdd || callNode.getOp() == EOpAtomicExchange) &&
@@ -9605,6 +9605,15 @@ void TParseContext::addQualifierToExisting(const TSourceLoc& loc, TQualifier qua
     // type with an empty type list, which will be filled in later in
     // TParseContext::declareBlock.
     if (!symbol && qualifier.hasBufferReference()) {
+        // The layout qualifiers are ignored in forward declaration, give warning for the most probable to be seen
+        if (qualifier.hasBufferReferenceAlign()) {
+            warn(loc, "the buffer_reference_align layout is ignored when defined in forward declaration",
+                 identifier.c_str(), "");
+        }
+        if (qualifier.hasPacking()) {
+            warn(loc, "the packing layout (scalar, std430, etc) is ignored when defined in forward declaration",
+                 identifier.c_str(), "");
+        }
         TTypeList typeList;
         TType blockType(&typeList, identifier, qualifier);
         TType blockNameType(EbtReference, blockType, identifier);


### PR DESCRIPTION
closes https://github.com/KhronosGroup/glslang/issues/3774

Now something like

```
#version 450
#extension GL_EXT_buffer_reference : enable

layout(buffer_reference, std140) buffer StructB;
layout(buffer_reference) buffer StructB {
    vec4 x;
};

void main() {}
```

will give a warning of

`WARNING: test.comp:4: 'StructB' : the packing layout (scalar, std430, etc) is ignored when defined in forward declaration `