### PR TITLE
disassemble: Add cstdint for uint32_t

### DIFF
--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -36,6 +36,7 @@
 // Disassembler for SPIR-V.
 //
 
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <cassert>


### PR DESCRIPTION
Fixes errors such as
```c++
D:/2702/build/glslang-git/SPIRV/disassemble.cpp:341:8: error: 'uint32_t' does not name a type
  341 | static uint32_t popcount(uint32_t mask)
      |        ^~~~~~~~
D:/2702/build/glslang-git/SPIRV/disassemble.cpp:60:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   59 |         #include "GLSL.ext.QCOM.h"
  +++ |+#include <cstdint>
   60 |     }
D:/2702/build/glslang-git/SPIRV/disassemble.cpp: In member function 'void spv::SpirvStream::disassembleInstruction(spv::Id, spv::Id, spv::Op, int)':
D:/2702/build/glslang-git/SPIRV/disassemble.cpp:574:17: error: 'uint32_t' was not declared in this scope
  574 |                 uint32_t mask = stream[word-1];
      |                 ^~~~~~~~
```