### PR TITLE
Add missing <sstream> header include

### DIFF
--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -52,6 +52,7 @@
 //
 
 #include <array>
+#include <sstream>
 #include "Initialize.h"
 #include "span.h"
 


### PR DESCRIPTION
This is needed to fix the below errors on some compilers:

Initialize.cpp:4476:27: error: implicit instantiation of undefined template 'std::basic_stringstream'
std::stringstream cooperativeMatrixFuncs;