### PR TITLE
ci: Remove gcc from macos matrix

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -154,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14, macos-13]
-        compiler: [{cc: clang, cxx: clang++}, {cc: gcc, cxx: g++}]
+        compiler: [{cc: clang, cxx: clang++}]
         cmake_build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Turns out gcc on macos by default is just an alias for clang, so these configurations were adding no value at all.