### PR TITLE
Fix to allow using the glslang_shader_parse from C API without preprocess

### DIFF
--- a/Test/preprocessor.line_return.glsl.comp
+++ b/Test/preprocessor.line_return.glsl.comp
@@ -1,0 +1,5 @@
+#version 450
+#extension GL_EXT_debug_printf : require
+void main() {
+    debugPrintfEXT("global thread id %v3u\n", gl_GlobalInvocationID);
+}

--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -431,6 +431,9 @@ GLSLANG_EXPORT int glslang_shader_preprocess(glslang_shader_t* shader, const gls
 
 GLSLANG_EXPORT int glslang_shader_parse(glslang_shader_t* shader, const glslang_input_t* input)
 {
+    // Seems glslang is preprocessing files twice if we call preprocess then parse on the preprocessed string.
+    // As we are forcing the use of preprocess before parse, this could lead to some issues with line return being preprocessed twice for example.
+    // Should avoid preprocessing twice in this case ideally, but just allow using C Api without preprocess for now.
     if (shader->preprocessedGLSL.length() > 0) {
         const char* preprocessedCStr = shader->preprocessedGLSL.c_str();
         shader->shader->setStrings(&preprocessedCStr, 1);
@@ -447,6 +450,7 @@ GLSLANG_EXPORT int glslang_shader_parse(glslang_shader_t* shader, const glslang_
         glslang::TShader::Includer& Includer = (input->callbacks.include_local||input->callbacks.include_system)
             ? static_cast<glslang::TShader::Includer&>(callbackIncluder)
             : static_cast<glslang::TShader::Includer&>(dirStackFileIncluder);
+        shader->shader->setStrings(&input->code, 1);
         return shader->shader->parse(
             reinterpret_cast<const TBuiltInResource*>(input->resource),
             input->default_version,

--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -431,15 +431,30 @@ GLSLANG_EXPORT int glslang_shader_preprocess(glslang_shader_t* shader, const gls
 
 GLSLANG_EXPORT int glslang_shader_parse(glslang_shader_t* shader, const glslang_input_t* input)
 {
-    const char* preprocessedCStr = shader->preprocessedGLSL.c_str();
-    shader->shader->setStrings(&preprocessedCStr, 1);
+    if (shader->preprocessedGLSL.length() > 0) {
+        const char* preprocessedCStr = shader->preprocessedGLSL.c_str();
+        shader->shader->setStrings(&preprocessedCStr, 1);
 
-    return shader->shader->parse(
-        reinterpret_cast<const TBuiltInResource*>(input->resource),
-        input->default_version,
-        input->forward_compatible != 0,
-        (EShMessages)c_shader_messages(input->messages)
-    );
+        return shader->shader->parse(
+            reinterpret_cast<const TBuiltInResource*>(input->resource),
+            input->default_version,
+            input->forward_compatible != 0,
+            (EShMessages)c_shader_messages(input->messages)
+        );
+    } else {
+        DirStackFileIncluder dirStackFileIncluder;
+        CallbackIncluder callbackIncluder(input->callbacks, input->callbacks_ctx);
+        glslang::TShader::Includer& Includer = (input->callbacks.include_local||input->callbacks.include_system)
+            ? static_cast<glslang::TShader::Includer&>(callbackIncluder)
+            : static_cast<glslang::TShader::Includer&>(dirStackFileIncluder);
+        return shader->shader->parse(
+            reinterpret_cast<const TBuiltInResource*>(input->resource),
+            input->default_version,
+            input->forward_compatible != 0,
+            (EShMessages)c_shader_messages(input->messages),
+            Includer
+        );
+    }
 }
 
 GLSLANG_EXPORT const char* glslang_shader_get_info_log(glslang_shader_t* shader) { return shader->shader->getInfoLog(); }

--- a/gtests/Pp.FromFile.cpp
+++ b/gtests/Pp.FromFile.cpp
@@ -40,13 +40,26 @@ namespace glslangtest {
 namespace {
 
 using PreprocessingTest = GlslangTest<::testing::TestWithParam<std::string>>;
+using PreprocessingReturnLineTest = GlslangTest<::testing::TestWithParam<std::string>>;
 
 TEST_P(PreprocessingTest, FromFile)
 {
     loadFilePreprocessAndCheck(GlobalTestSettings.testRoot, GetParam());
 }
 
+TEST_P(PreprocessingReturnLineTest, FromFile)
+{
+    loadFilePreprocessFileReturn(GlobalTestSettings.testRoot, GetParam());
+}
+
 // clang-format off
+INSTANTIATE_TEST_SUITE_P(
+    Glsl, PreprocessingReturnLineTest,
+    ::testing::ValuesIn(std::vector<std::string>({
+        "preprocessor.line_return.glsl.comp",
+    })),
+    FileNameAsCustomTestSuffix
+);
 INSTANTIATE_TEST_SUITE_P(
     Glsl, PreprocessingTest,
     ::testing::ValuesIn(std::vector<std::string>({

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -52,6 +52,7 @@
 #include "glslang/Include/Types.h"
 #include "glslang/Public/ResourceLimits.h"
 #include "glslang/Public/ShaderLang.h"
+#include "glslang/Include/glslang_c_interface.h"
 
 #include "Initializer.h"
 #include "Settings.h"
@@ -706,6 +707,189 @@ public:
         } else {
             return std::make_tuple(false, "", log);
         }
+    }
+
+    std::tuple<bool, std::string> preprocessAndCompileWithCAPI(const std::string& source)
+    {
+        const char * shaderStrings = source.data();
+        const int shaderLengths = static_cast<int>(source.size());
+
+        // Done by framework
+        //glslang_initialize_process();
+
+        glslang_resource_t resources = glslang_resource_t{
+            /* .MaxLights = */ 32,
+            /* .MaxClipPlanes = */ 6,
+            /* .MaxTextureUnits = */ 32,
+            /* .MaxTextureCoords = */ 32,
+            /* .MaxVertexAttribs = */ 64,
+            /* .MaxVertexUniformComponents = */ 4096,
+            /* .MaxVaryingFloats = */ 64,
+            /* .MaxVertexTextureImageUnits = */ 32,
+            /* .MaxCombinedTextureImageUnits = */ 80,
+            /* .MaxTextureImageUnits = */ 32,
+            /* .MaxFragmentUniformComponents = */ 4096,
+            /* .MaxDrawBuffers = */ 32,
+            /* .MaxVertexUniformVectors = */ 128,
+            /* .MaxVaryingVectors = */ 8,
+            /* .MaxFragmentUniformVectors = */ 16,
+            /* .MaxVertexOutputVectors = */ 16,
+            /* .MaxFragmentInputVectors = */ 15,
+            /* .MinProgramTexelOffset = */ -8,
+            /* .MaxProgramTexelOffset = */ 7,
+            /* .MaxClipDistances = */ 8,
+            /* .MaxComputeWorkGroupCountX = */ 65535,
+            /* .MaxComputeWorkGroupCountY = */ 65535,
+            /* .MaxComputeWorkGroupCountZ = */ 65535,
+            /* .MaxComputeWorkGroupSizeX = */ 1024,
+            /* .MaxComputeWorkGroupSizeY = */ 1024,
+            /* .MaxComputeWorkGroupSizeZ = */ 64,
+            /* .MaxComputeUniformComponents = */ 1024,
+            /* .MaxComputeTextureImageUnits = */ 16,
+            /* .MaxComputeImageUniforms = */ 8,
+            /* .MaxComputeAtomicCounters = */ 8,
+            /* .MaxComputeAtomicCounterBuffers = */ 1,
+            /* .MaxVaryingComponents = */ 60,
+            /* .MaxVertexOutputComponents = */ 64,
+            /* .MaxGeometryInputComponents = */ 64,
+            /* .MaxGeometryOutputComponents = */ 128,
+            /* .MaxFragmentInputComponents = */ 128,
+            /* .MaxImageUnits = */ 8,
+            /* .MaxCombinedImageUnitsAndFragmentOutputs = */ 8,
+            /* .MaxCombinedShaderOutputResources = */ 8,
+            /* .MaxImageSamples = */ 0,
+            /* .MaxVertexImageUniforms = */ 0,
+            /* .MaxTessControlImageUniforms = */ 0,
+            /* .MaxTessEvaluationImageUniforms = */ 0,
+            /* .MaxGeometryImageUniforms = */ 0,
+            /* .MaxFragmentImageUniforms = */ 8,
+            /* .MaxCombinedImageUniforms = */ 8,
+            /* .MaxGeometryTextureImageUnits = */ 16,
+            /* .MaxGeometryOutputVertices = */ 256,
+            /* .MaxGeometryTotalOutputComponents = */ 1024,
+            /* .MaxGeometryUniformComponents = */ 1024,
+            /* .MaxGeometryVaryingComponents = */ 64,
+            /* .MaxTessControlInputComponents = */ 128,
+            /* .MaxTessControlOutputComponents = */ 128,
+            /* .MaxTessControlTextureImageUnits = */ 16,
+            /* .MaxTessControlUniformComponents = */ 1024,
+            /* .MaxTessControlTotalOutputComponents = */ 4096,
+            /* .MaxTessEvaluationInputComponents = */ 128,
+            /* .MaxTessEvaluationOutputComponents = */ 128,
+            /* .MaxTessEvaluationTextureImageUnits = */ 16,
+            /* .MaxTessEvaluationUniformComponents = */ 1024,
+            /* .MaxTessPatchComponents = */ 120,
+            /* .MaxPatchVertices = */ 32,
+            /* .MaxTessGenLevel = */ 64,
+            /* .MaxViewports = */ 16,
+            /* .MaxVertexAtomicCounters = */ 0,
+            /* .MaxTessControlAtomicCounters = */ 0,
+            /* .MaxTessEvaluationAtomicCounters = */ 0,
+            /* .MaxGeometryAtomicCounters = */ 0,
+            /* .MaxFragmentAtomicCounters = */ 8,
+            /* .MaxCombinedAtomicCounters = */ 8,
+            /* .MaxAtomicCounterBindings = */ 1,
+            /* .MaxVertexAtomicCounterBuffers = */ 0,
+            /* .MaxTessControlAtomicCounterBuffers = */ 0,
+            /* .MaxTessEvaluationAtomicCounterBuffers = */ 0,
+            /* .MaxGeometryAtomicCounterBuffers = */ 0,
+            /* .MaxFragmentAtomicCounterBuffers = */ 1,
+            /* .MaxCombinedAtomicCounterBuffers = */ 1,
+            /* .MaxAtomicCounterBufferSize = */ 16384,
+            /* .MaxTransformFeedbackBuffers = */ 4,
+            /* .MaxTransformFeedbackInterleavedComponents = */ 64,
+            /* .MaxCullDistances = */ 8,
+            /* .MaxCombinedClipAndCullDistances = */ 8,
+            /* .MaxSamples = */ 4,
+            /* .maxMeshOutputVerticesNV = */ 256,
+            /* .maxMeshOutputPrimitivesNV = */ 512,
+            /* .maxMeshWorkGroupSizeX_NV = */ 32,
+            /* .maxMeshWorkGroupSizeY_NV = */ 1,
+            /* .maxMeshWorkGroupSizeZ_NV = */ 1,
+            /* .maxTaskWorkGroupSizeX_NV = */ 32,
+            /* .maxTaskWorkGroupSizeY_NV = */ 1,
+            /* .maxTaskWorkGroupSizeZ_NV = */ 1,
+            /* .maxMeshViewCountNV = */ 4,
+            /* .maxMeshOutputVerticesEXT = */ 256,
+            /* .maxMeshOutputPrimitivesEXT = */ 512,
+            /* .maxMeshWorkGroupSizeX_EXT = */ 32,
+            /* .maxMeshWorkGroupSizeY_EXT = */ 1,
+            /* .maxMeshWorkGroupSizeZ_EXT = */ 1,
+            /* .maxTaskWorkGroupSizeX_EXT = */ 32,
+            /* .maxTaskWorkGroupSizeY_EXT = */ 1,
+            /* .maxTaskWorkGroupSizeZ_EXT = */ 1,
+            /* .maxMeshViewCountEXT = */ 4,
+            /* .maxDualSourceDrawBuffersEXT = */ 1,
+
+            /* .limits = */
+            {
+                /* .nonInductiveForLoops = */ 1,
+                /* .whileLoops = */ 1,
+                /* .doWhileLoops = */ 1,
+                /* .generalUniformIndexing = */ 1,
+                /* .generalAttributeMatrixVectorIndexing = */ 1,
+                /* .generalVaryingIndexing = */ 1,
+                /* .generalSamplerIndexing = */ 1,
+                /* .generalVariableIndexing = */ 1,
+                /* .generalConstantMatrixVectorIndexing = */ 1,
+            }};
+
+        glslang_input_t shader_input{};
+        shader_input.language = GLSLANG_SOURCE_GLSL;
+        shader_input.stage = GLSLANG_STAGE_COMPUTE;
+        shader_input.client = GLSLANG_CLIENT_VULKAN;
+        shader_input.client_version = GLSLANG_TARGET_VULKAN_1_3;
+        shader_input.target_language = GLSLANG_TARGET_SPV;
+        shader_input.target_language_version = GLSLANG_TARGET_SPV_1_6;
+        shader_input.code = source.data();
+        shader_input.default_version = 100;
+        shader_input.default_profile = GLSLANG_NO_PROFILE;
+        shader_input.force_default_version_and_profile = 0;
+        shader_input.forward_compatible = GLSLANG_MSG_DEFAULT_BIT;
+        shader_input.messages = GLSLANG_MSG_DEFAULT_BIT;
+        shader_input.resource = &resources;
+        shader_input.callbacks = glsl_include_callbacks_s{
+            NULL,
+            NULL,
+            NULL
+        };
+        shader_input.callbacks_ctx = NULL;
+
+        glslang_shader_t* shader = glslang_shader_create(&shader_input);
+        if (glslang_shader_preprocess(shader, &shader_input) != 1) {
+            const std::string logs = std::string(glslang_shader_get_info_log(shader));
+            glslang_shader_delete(shader);
+            return std::make_tuple(false, logs);
+        }
+        if (glslang_shader_parse(shader, &shader_input) != 1) {
+            const std::string logs = std::string(glslang_shader_get_info_log(shader));
+            glslang_shader_delete(shader);
+            return std::make_tuple(false, logs);
+        }
+        const std::string logs = std::string(glslang_shader_get_info_log(shader));
+        glslang_shader_delete(shader);
+
+        return std::make_tuple(true, logs);
+    }
+
+    void loadFilePreprocessFileReturn(const std::string& testDir, const std::string& testName)
+    {
+        const std::string inputFname = testDir + "/" + testName;
+        const std::string expectedErrorFname = testDir + "/baseResults/" + testName + ".err";
+        std::string input, expectedOutput, expectedError;
+
+        tryLoadFile(inputFname, "input", &input);
+        tryLoadFile(expectedErrorFname, "expected error", &expectedError);
+
+        bool ppOk;
+        std::string error;
+        std::tie(ppOk, error) = preprocessAndCompileWithCAPI(input);
+        if (!error.empty())
+            error += '\n';
+
+        checkEqAndUpdateIfRequested(expectedError, error, expectedErrorFname);
+        
+        EXPECT_TRUE(ppOk);
     }
 
     void loadFilePreprocessAndCheck(const std::string& testDir,

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -856,11 +856,12 @@ public:
         shader_input.callbacks_ctx = NULL;
 
         glslang_shader_t* shader = glslang_shader_create(&shader_input);
-        if (glslang_shader_preprocess(shader, &shader_input) != 1) {
+        // Uncommenting following code will make code being preprocessed twice
+        /*if (glslang_shader_preprocess(shader, &shader_input) != 1) {
             const std::string logs = std::string(glslang_shader_get_info_log(shader));
             glslang_shader_delete(shader);
             return std::make_tuple(false, logs);
-        }
+        }*/
         if (glslang_shader_parse(shader, &shader_input) != 1) {
             const std::string logs = std::string(glslang_shader_get_info_log(shader));
             glslang_shader_delete(shader);
@@ -875,20 +876,13 @@ public:
     void loadFilePreprocessFileReturn(const std::string& testDir, const std::string& testName)
     {
         const std::string inputFname = testDir + "/" + testName;
-        const std::string expectedErrorFname = testDir + "/baseResults/" + testName + ".err";
-        std::string input, expectedOutput, expectedError;
-
+        std::string input;
         tryLoadFile(inputFname, "input", &input);
-        tryLoadFile(expectedErrorFname, "expected error", &expectedError);
 
         bool ppOk;
         std::string error;
         std::tie(ppOk, error) = preprocessAndCompileWithCAPI(input);
-        if (!error.empty())
-            error += '\n';
-
-        checkEqAndUpdateIfRequested(expectedError, error, expectedErrorFname);
-        
+        EXPECT_TRUE(error.empty());
         EXPECT_TRUE(ppOk);
     }
 


### PR DESCRIPTION
Hello,

I went into problem with the C API of glslang. Here is a small repro sample of the issue:

```glsl
#version 450
#extension GL_EXT_debug_printf : require
void main() {
    debugPrintfEXT("global thread id %v3u\n", gl_GlobalInvocationID);
}
```

```c
// Simple C code to run 
glslang_shader_t* shader = glslang_shader_create(&shader_input);
glslang_shader_preprocess(shader, &shader_input);
glslang_shader_parse(shader.handle.as_ptr(), &shader_input);
```
This will produce an `End of line in string` error for `\n` within string, but glslangValidator does not produce this error. After digging into it, it seems calling preprocess will replace `\n` string by a newline feed character (Code at `MachineIndependant/preprocessor/PpScanner.cpp:1136`), which will then be used by parse & produce this error. 

With this CL, I try to fix this by not forcing the parse function to have preprocess executed before. Right now the C API dont allow parsing without preprocessing while the C++ API allow it. This issue should probably be solved more deeply to allow preprocess & parsing aswell but as its a very minor issue, I dont think it should really be a problem.
