### PR TITLE
Fix Windows DLL test configuration

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -119,35 +119,6 @@ jobs:
           UBSAN_OPTIONS: 'halt_on_error=1:print_stacktrace=1'
         run: ctest --output-on-failure --test-dir build
 
-  # Ensure we can compile/run on an older distro
-  linux_min:
-    name: Linux Backcompat
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
-        with:
-          python-version: '3.7'
-      - uses: lukka/get-cmake@5979409e62bdf841487c5fb3c053149de97a86d3 # v3.31.2
-        with:
-          cmakeVersion: 3.17.2
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@ed74d11c0b343532753ecead8a951bb09bb34bc9 # v1.2.14
-        with:
-          key: linux_backcompat
-      - run: ./update_glslang_sources.py
-      - name: Configure
-        run: cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D GLSLANG_TESTS=ON
-        env:
-          CMAKE_C_COMPILER_LAUNCHER: ccache
-          CMAKE_CXX_COMPILER_LAUNCHER: ccache
-      - name: Build
-        run: cmake --build build
-      - name: Install
-        run: cmake --install build --prefix build/install
-      - name: Test
-        run: ctest --output-on-failure --test-dir build
-
   macos:
     runs-on: ${{matrix.os}}
     strategy:
@@ -231,9 +202,8 @@ jobs:
         run: |
           cmake -S. -Bbuild -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$PWD/build/install" -DBUILD_WERROR=ON -D GLSLANG_TESTS=ON -DBUILD_SHARED_LIBS=ON
           cmake --build build --config ${{matrix.cmake_build_type}} --target install
-      # disabled until we figure out DLL issues.
-      # - name: Test
-      #   run: ctest -C ${{matrix.cmake_build_type}} --output-on-failure --test-dir build
+      - name: Test
+        run: ctest -C ${{matrix.cmake_build_type}} --output-on-failure --test-dir build
 
   iOS:
     runs-on: macos-13

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-cmake_minimum_required(VERSION 3.17.2)
+cmake_minimum_required(VERSION 3.27)
 project(glslang)
 
 if (CMAKE_VERSION VERSION_LESS "3.21")
@@ -351,6 +351,13 @@ if(GLSLANG_TESTS)
     add_test(NAME glslang-testsuite
 	COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
+
+    # Prepend paths to DLLs for Windows tests.
+    if(WIN32)
+        set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslang-standalone>,\;>")
+        set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:spirv-remap>,\;>")
+    endif()
+
 endif(GLSLANG_TESTS)
 
 if (GLSLANG_ENABLE_INSTALL)

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -98,5 +98,10 @@ if(GLSLANG_TESTS)
 
         add_test(NAME glslang-gtests
                  COMMAND glslangtests --test-root "${GLSLANG_TEST_DIRECTORY}")
+
+        # Prepend paths to DLLs for Windows tests.
+        if(WIN32)
+            set_tests_properties(glslang-gtests PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslangtests>,\;>")
+        endif()
     endif()
 endif()

--- a/kokoro/linux-clang-cmake/build-docker.sh
+++ b/kokoro/linux-clang-cmake/build-docker.sh
@@ -39,7 +39,7 @@ set -e # Fail on any error.
 
 set -x # Display commands being run.
 
-using cmake-3.17.2
+using cmake-3.31.2
 using clang-10.0.0
 using ninja-1.10.0
 using python-3.12

--- a/kokoro/linux-gcc-cmake/build-docker.sh
+++ b/kokoro/linux-gcc-cmake/build-docker.sh
@@ -39,7 +39,7 @@ set -e # Fail on any error.
 
 set -x # Display commands being run.
 
-using cmake-3.17.2
+using cmake-3.31.2
 using gcc-9
 using ninja-1.10.0
 using python-3.12


### PR DESCRIPTION
Enable Windows DLL test configuration.
Configure tests to pull in DLL dependencies using `TARGET_RUNTIME_DLL_DIRS`.
Bump cmake version to 3.27 to use `TARGET_RUNTIME_DLL_DIRS`.
Remove Ubuntu 20.04 test configuration.