### PR TITLE
Re-add linux back compat test

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -119,6 +119,35 @@ jobs:
           UBSAN_OPTIONS: 'halt_on_error=1:print_stacktrace=1'
         run: ctest --output-on-failure --test-dir build
 
+  # Ensure we can compile/run on an older distro
+  linux_min:
+    name: Linux Backcompat
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.7'
+      - uses: lukka/get-cmake@5979409e62bdf841487c5fb3c053149de97a86d3 # v3.31.2
+        with:
+          cmakeVersion: 3.17.2
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@ed74d11c0b343532753ecead8a951bb09bb34bc9 # v1.2.14
+        with:
+          key: linux_backcompat
+      - run: ./update_glslang_sources.py
+      - name: Configure
+        run: cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D GLSLANG_TESTS=ON
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      - name: Build
+        run: cmake --build build
+      - name: Install
+        run: cmake --install build --prefix build/install
+      - name: Test
+        run: ctest --output-on-failure --test-dir build
+
   macos:
     runs-on: ${{matrix.os}}
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.17.2)
 project(glslang)
 
 if (CMAKE_VERSION VERSION_LESS "3.21")
@@ -348,16 +348,20 @@ if(GLSLANG_TESTS)
 	set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
     endif()
 
-    add_test(NAME glslang-testsuite
-	COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
+    # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
+    if(WIN32 AND BUILD_SHARED_LIBS AND CMAKE_VERSION VERSION_LESS "3.27")
+        message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
+    else()
+        add_test(NAME glslang-testsuite
+            COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
 
-    # Prepend paths to DLLs for Windows tests.
-    if(WIN32)
-        set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslang-standalone>,\;>")
-        set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:spirv-remap>,\;>")
+        # Prepend paths to shared libraries.
+        if (BUILD_SHARED_LIBS)
+            set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslang-standalone>,\;>")
+            set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:spirv-remap>,\;>")
+        endif()
     endif()
-
 endif(GLSLANG_TESTS)
 
 if (GLSLANG_ENABLE_INSTALL)

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -96,12 +96,17 @@ if(GLSLANG_TESTS)
 
         target_link_libraries(glslangtests PRIVATE ${LIBRARIES} gmock)
 
-        add_test(NAME glslang-gtests
-                 COMMAND glslangtests --test-root "${GLSLANG_TEST_DIRECTORY}")
+        # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
+        if(WIN32 AND BUILD_SHARED_LIBS AND CMAKE_VERSION VERSION_LESS "3.27")
+            message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
+        else()
+            add_test(NAME glslang-gtests
+                     COMMAND glslangtests --test-root "${GLSLANG_TEST_DIRECTORY}")
 
-        # Prepend paths to DLLs for Windows tests.
-        if(WIN32)
-            set_tests_properties(glslang-gtests PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslangtests>,\;>")
+            # Prepend paths to shared libraries.
+            if (BUILD_SHARED_LIBS)
+                set_tests_properties(glslang-gtests PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslangtests>,\;>")
+            endif()
         endif()
     endif()
 endif()


### PR DESCRIPTION
Enable building on older versions of CMake.
Add warning for Windows shared library test configuration.