### PR TITLE
Add missing include headers

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -60,6 +60,7 @@
 #include <memory>
 #include <set>
 #include <thread>
+#include <type_traits>
 
 #include "../glslang/OSDependent/osinclude.h"
 


### PR DESCRIPTION
This is for C++ modules build in chromium.