### PR TITLE
cmake: Cleanup CMake code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 The Khronos Group Inc.
+# Copyright (C) 2020-2025 The Khronos Group Inc.
 #
 # All rights reserved.
 #
@@ -175,12 +175,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
     endif()
 elseif(MSVC)
     if(NOT ENABLE_RTTI)
-        string(FIND "${CMAKE_CXX_FLAGS}" "/GR" MSVC_HAS_GR)
-        if(MSVC_HAS_GR)
-            string(REGEX REPLACE "/GR" "/GR-" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-        else()
-            add_compile_options(/GR-) # Disable RTTI
-        endif()
+        add_compile_options(/GR-) # Disable RTTI
     endif()
     if(ENABLE_EXCEPTIONS)
         add_compile_options(/EHsc) # Enable Exceptions
@@ -224,7 +219,7 @@ function(glslang_set_link_args TARGET)
         set_target_properties(${TARGET} PROPERTIES
                               LINK_FLAGS "-static -static-libgcc -static-libstdc++")
     endif()
-endfunction(glslang_set_link_args)
+endfunction()
 
 # Root directory for build-time generated include files
 set(GLSLANG_GENERATED_INCLUDEDIR "${CMAKE_BINARY_DIR}/include")
@@ -357,7 +352,7 @@ if(GLSLANG_TESTS)
             set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:spirv-remap>,\;>")
         endif()
     endif()
-endif(GLSLANG_TESTS)
+endif()
 
 if (GLSLANG_ENABLE_INSTALL)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in" [=[
@@ -403,4 +398,4 @@ if (GLSLANG_ENABLE_INSTALL)
         DESTINATION
             "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
     )
-endif(GLSLANG_ENABLE_INSTALL)
+endif()

--- a/glslang/OSDependent/Web/CMakeLists.txt
+++ b/glslang/OSDependent/Web/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 The Khronos Group Inc.
+# Copyright (C) 2020-2025 The Khronos Group Inc.
 #
 # All rights reserved.
 #
@@ -67,28 +67,9 @@ if(ENABLE_GLSLANG_JS)
         endif()
 
         if(NOT ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE)
-            if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.18")
-                add_custom_command(TARGET glslang.js POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_CURRENT_SOURCE_DIR}/glslang.after.js >> ${CMAKE_CURRENT_BINARY_DIR}/glslang.js
-                )
-            else()
-                if (MINGW)
-                    message(FATAL_ERROR "Must use at least CMake 3.18")
-                endif()
-
-                if (CMAKE_HOST_SYSTEM MATCHES "Windows.*")
-                    # There are several ways we could append one file to another on Windows, but unfortunately 'cat' is not one of them
-                    # (there is no 'cat' command in cmd). Also, since this will ultimately run in cmd and not pwsh, we need to ensure
-                    # Windows path separators are used.
-                    file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/glslang.js" glslang_js_path)
-                    file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/glslang.after.js" glslang_after_js_path)
-                    add_custom_command(TARGET glslang.js POST_BUILD
-                        COMMAND type "${glslang_after_js_path}" >> "${glslang_js_path}")
-                else()
-                    add_custom_command(TARGET glslang.js POST_BUILD
-                        COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/glslang.after.js >> ${CMAKE_CURRENT_BINARY_DIR}/glslang.js)
-                endif()
-            endif()
+            add_custom_command(TARGET glslang.js POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_CURRENT_SOURCE_DIR}/glslang.after.js >> ${CMAKE_CURRENT_BINARY_DIR}/glslang.js
+            )
         endif()
     endif()
 endif()


### PR DESCRIPTION
- Remove old style of ending functions/conditions
- MSVC RTTI flag /GR is not added to CMAKE_CXX_FLAGS by default anymore.
- Remove unneccessary pre 3.18 code path