### PR TITLE
Emit SPV_EXT_opacity_micromap if GL extension is present

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1,7 +1,7 @@
 //
 // Copyright (C) 2014-2016 LunarG, Inc.
 // Copyright (C) 2015-2020 Google, Inc.
-// Copyright (C) 2017, 2022-2024 Arm Limited.
+// Copyright (C) 2017, 2022-2025 Arm Limited.
 // Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
 //
 // All rights reserved.
@@ -1913,6 +1913,10 @@ TGlslangToSpvTraverser::TGlslangToSpvTraverser(unsigned int spvVersion,
     case EShLangCallable:
     {
         auto& extensions = glslangIntermediate->getRequestedExtensions();
+        if (extensions.find("GL_EXT_opacity_micromap") != extensions.end()) {
+            builder.addCapability(spv::CapabilityRayTracingOpacityMicromapEXT);
+            builder.addExtension("SPV_EXT_opacity_micromap");
+        }
         if (extensions.find("GL_NV_ray_tracing") == extensions.end()) {
             builder.addCapability(spv::CapabilityRayTracingKHR);
             builder.addExtension("SPV_KHR_ray_tracing");

--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (C) 2014-2015 LunarG, Inc.
-// Copyright (C) 2022-2024 Arm Limited.
+// Copyright (C) 2022-2025 Arm Limited.
 // Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
 //
 // All rights reserved.
@@ -1009,6 +1009,7 @@ const char* CapabilityString(int info)
     case CapabilityRayTraversalPrimitiveCullingKHR: return "RayTraversalPrimitiveCullingKHR";
     case CapabilityRayTracingPositionFetchKHR:      return "RayTracingPositionFetchKHR";
     case CapabilityDisplacementMicromapNV:           return "DisplacementMicromapNV";
+    case CapabilityRayTracingOpacityMicromapEXT:    return "RayTracingOpacityMicromapEXT";
     case CapabilityRayTracingDisplacementMicromapNV: return "CapabilityRayTracingDisplacementMicromapNV";
     case CapabilityRayQueryPositionFetchKHR:        return "RayQueryPositionFetchKHR";
     case CapabilityComputeDerivativeGroupQuadsNV:   return "ComputeDerivativeGroupQuadsNV";

--- a/Test/baseResults/spv.ext.RayGenShader.rgen.out
+++ b/Test/baseResults/spv.ext.RayGenShader.rgen.out
@@ -5,6 +5,8 @@ spv.ext.RayGenShader.rgen
 
                               Capability RayTraversalPrimitiveCullingKHR
                               Capability RayTracingKHR
+                              Capability RayTracingOpacityMicromapEXT
+                              Extension  "SPV_EXT_opacity_micromap"
                               Extension  "SPV_KHR_ray_tracing"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450


### PR DESCRIPTION
If the `GL_EXT_opacity_micromap` extension was requested in the input, emit the corresponding `SPV_EXT_opacity_micromap` extension and RayTracingOpacityMicromapEXT Capability in the SPIR-V output.