### PR TITLE
ci: Add find_package testing

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -39,6 +39,10 @@ jobs:
         run: cmake --build build
       - name: Install
         run: cmake --install build --prefix build/install
+      - name: Test find_package support
+        run: |
+          cmake -S Test/find_package -B build/find_package && \
+          cmake --build build/find_package
       - name: Test
         run: ctest --output-on-failure --test-dir build
       - name: Check known validation failure list
@@ -74,6 +78,10 @@ jobs:
         run: cmake --build build
       - name: Install
         run: cmake --install build --prefix build/install
+      - name: Test find_package support
+        run: |
+          cmake -S Test/find_package -B build/find_package && \
+          cmake --build build/find_package
       - name: Test
         run: ctest --output-on-failure --test-dir build
 
@@ -145,6 +153,10 @@ jobs:
         run: cmake --build build
       - name: Install
         run: cmake --install build --prefix build/install
+      - name: Test find_package support
+        run: |
+          cmake -S Test/find_package -B build/find_package && \
+          cmake --build build/find_package
       - name: Test
         run: ctest --output-on-failure --test-dir build
 
@@ -166,6 +178,10 @@ jobs:
           CXX: ${{matrix.compiler.cxx}}
       - run: cmake --build build
       - run: cmake --install build --prefix build/install
+      - name: Test find_package support
+        run: |
+          cmake -S Test/find_package -B build/find_package && \
+          cmake --build build/find_package
       - run: ctest --output-on-failure --test-dir build
 
   macos-shared:
@@ -186,6 +202,10 @@ jobs:
           CXX: ${{matrix.compiler.cxx}}
       - run: cmake --build build
       - run: cmake --install build --prefix build/install
+      - name: Test find_package support
+        run: |
+          cmake -S Test/find_package -B build/find_package && \
+          cmake --build build/find_package
       - run: ctest --output-on-failure --test-dir build
 
   windows:
@@ -208,6 +228,10 @@ jobs:
         run: |
           cmake -S. -Bbuild -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$PWD/build/install" -DBUILD_WERROR=ON -D GLSLANG_TESTS=ON
           cmake --build build --config ${{matrix.cmake_build_type}} --target install
+      - name: Test find_package support
+        run: |
+          cmake -S Test/find_package -B build/find_package
+          cmake --build build/find_package
       - name: Test
         run: ctest -C ${{matrix.cmake_build_type}} --output-on-failure --test-dir build
 
@@ -231,6 +255,10 @@ jobs:
         run: |
           cmake -S. -Bbuild -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$PWD/build/install" -DBUILD_WERROR=ON -D GLSLANG_TESTS=ON -DBUILD_SHARED_LIBS=ON
           cmake --build build --config ${{matrix.cmake_build_type}} --target install
+      - name: Test find_package support
+        run: |
+          cmake -S Test/find_package -B build/find_package
+          cmake --build build/find_package
       - name: Test
         run: ctest -C ${{matrix.cmake_build_type}} --output-on-failure --test-dir build
 

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -128,7 +128,9 @@ if(GLSLANG_ENABLE_INSTALL)
         install(TARGETS SPVRemapper EXPORT glslang-targets)
     endif()
 
-    install(TARGETS SPIRV EXPORT glslang-targets)
+    if (NOT BUILD_SHARED_LIBS)
+        install(TARGETS SPIRV EXPORT glslang-targets)
+    endif()
 
     install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/SPIRV/)
 endif()

--- a/StandAlone/spirv-remap.cpp
+++ b/StandAlone/spirv-remap.cpp
@@ -182,7 +182,7 @@ namespace {
         std::cout << "  " << basename(name) << " [--version | -V]" << std::endl;
         std::cout << "  " << basename(name) << " [--help | -?]" << std::endl;
 
-        exit(5);
+        exit(0);
     }
 
     // grind through each SPIR in turn

--- a/Test/find_package/CMakeLists.txt
+++ b/Test/find_package/CMakeLists.txt
@@ -1,0 +1,86 @@
+# Copyright (C) 2025 The Khronos Group Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#    Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+#    Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+#    Neither the name of The Khronos Group Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+cmake_minimum_required(VERSION 3.22.1)
+
+# NOTE: The whole point of this file is to test what the client will
+# see when they install glslang via a package manager.
+project(FP_TEST LANGUAGES C CXX)
+
+# Assume the user install here to simplify CI
+# It also makes local testing easier.
+list(APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/../../build/install")
+find_package(glslang REQUIRED CONFIG)
+
+if (NOT DEFINED glslang_VERSION)
+    message(FATAL_ERROR "glslang_VERSION not defined!")
+endif()
+message(STATUS "glslang_VERSION = ${glslang_VERSION}")
+
+get_target_property(target_type glslang::glslang TYPE)
+message(STATUS "glslang::glslang is ${target_type}")
+
+add_executable(example example.c)
+target_link_libraries(example PRIVATE
+    glslang::glslang
+    glslang::glslang-default-resource-limits    
+)
+
+if (NOT TARGET glslang::SPVRemapper)
+    message(FATAL_ERROR "glslang::SPVRemapper does not exist!")
+endif()
+
+if (NOT TARGET glslang::glslang-standalone)
+    message(FATAL_ERROR "glslang::glslang-standalone does not exist!")
+endif()
+
+if (NOT TARGET glslang::spirv-remap)
+    message(FATAL_ERROR "glslang::spirv-remap does not exist!")
+endif()
+
+if (target_type STREQUAL STATIC_LIBRARY)
+    # When these stub libraries are removed from  the future. Simply remove this code.
+    # For now it ensures backcompat is preserved.
+    add_library(stub STATIC stub.cpp)
+    target_link_libraries(example PRIVATE
+        glslang::GenericCodeGen
+        glslang::MachineIndependent
+        glslang::OSDependent
+        glslang::SPIRV
+    )
+
+    # Ensure these executables run without issue
+    add_custom_target(test-executables ALL
+        COMMAND glslang::glslang-standalone --version
+        COMMAND glslang::spirv-remap --help
+    )
+endif()

--- a/Test/find_package/example.c
+++ b/Test/find_package/example.c
@@ -1,0 +1,118 @@
+//
+// Copyright (C) 2025 The Khronos Group Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of 3Dlabs Inc. Ltd. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include <glslang/Include/glslang_c_interface.h>
+
+// Required for use of glslang_default_resource
+#include <glslang/Public/resource_limits_c.h>
+
+typedef struct SpirVBinary {
+    uint32_t* words; // SPIR-V words
+    int size;        // number of words in SPIR-V binary
+} SpirVBinary;
+
+SpirVBinary compileShaderToSPIRV_Vulkan(glslang_stage_t stage, const char* shaderSource, const char* fileName)
+{
+    const glslang_input_t input = {
+        .language = GLSLANG_SOURCE_GLSL,
+        .stage = stage,
+        .client = GLSLANG_CLIENT_VULKAN,
+        .client_version = GLSLANG_TARGET_VULKAN_1_2,
+        .target_language = GLSLANG_TARGET_SPV,
+        .target_language_version = GLSLANG_TARGET_SPV_1_5,
+        .code = shaderSource,
+        .default_version = 100,
+        .default_profile = GLSLANG_NO_PROFILE,
+        .force_default_version_and_profile = false,
+        .forward_compatible = false,
+        .messages = GLSLANG_MSG_DEFAULT_BIT,
+        .resource = glslang_default_resource(),
+    };
+
+    glslang_shader_t* shader = glslang_shader_create(&input);
+
+    SpirVBinary bin = {
+        .words = NULL,
+        .size = 0,
+    };
+    if (!glslang_shader_preprocess(shader, &input)) {
+        printf("GLSL preprocessing failed %s\n", fileName);
+        printf("%s\n", glslang_shader_get_info_log(shader));
+        printf("%s\n", glslang_shader_get_info_debug_log(shader));
+        printf("%s\n", input.code);
+        glslang_shader_delete(shader);
+        return bin;
+    }
+
+    if (!glslang_shader_parse(shader, &input)) {
+        printf("GLSL parsing failed %s\n", fileName);
+        printf("%s\n", glslang_shader_get_info_log(shader));
+        printf("%s\n", glslang_shader_get_info_debug_log(shader));
+        printf("%s\n", glslang_shader_get_preprocessed_code(shader));
+        glslang_shader_delete(shader);
+        return bin;
+    }
+
+    glslang_program_t* program = glslang_program_create();
+    glslang_program_add_shader(program, shader);
+
+    if (!glslang_program_link(program, GLSLANG_MSG_SPV_RULES_BIT | GLSLANG_MSG_VULKAN_RULES_BIT)) {
+        printf("GLSL linking failed %s\n", fileName);
+        printf("%s\n", glslang_program_get_info_log(program));
+        printf("%s\n", glslang_program_get_info_debug_log(program));
+        glslang_program_delete(program);
+        glslang_shader_delete(shader);
+        return bin;
+    }
+
+    glslang_program_SPIRV_generate(program, stage);
+
+    bin.size = glslang_program_SPIRV_get_size(program);
+    bin.words = malloc(bin.size * sizeof(uint32_t));
+    glslang_program_SPIRV_get(program, bin.words);
+
+    const char* spirv_messages = glslang_program_SPIRV_get_messages(program);
+    if (spirv_messages)
+        printf("(%s) %s\b", fileName, spirv_messages);
+
+    glslang_program_delete(program);
+    glslang_shader_delete(shader);
+
+    return bin;
+}
+
+int main() { return 0; }

--- a/Test/find_package/stub.cpp
+++ b/Test/find_package/stub.cpp
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2025 The Khronos Group Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of 3Dlabs Inc. Ltd. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//


### PR DESCRIPTION
Fix find_package breaking on Windows when BUILD_SHARED_LIBS=ON due to SPIRV stub library.

Changed exit code for spirv-remap to 0 when requesting help, to allow for better integration testing.

closes #3462