### PR TITLE
EXT_nontemporal_keyword: Don't warn when using nontemporal as an identifier

### DIFF
--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -1110,10 +1110,11 @@ int TScanContext::tokenizeIdentifier()
     case NONTEMPORAL:
         if (parseContext.symbolTable.atBuiltInLevel())
             return keyword;
-        if (!parseContext.intermediate.usingVulkanMemoryModel())
-            parseContext.warn(loc, "Nontemporal without the Vulkan Memory Model is ignored", tokenText, "");
-        if (parseContext.extensionTurnedOn(E_GL_EXT_nontemporal_keyword))
+        if (parseContext.extensionTurnedOn(E_GL_EXT_nontemporal_keyword)) {
+            if (!parseContext.intermediate.usingVulkanMemoryModel())
+                parseContext.warn(loc, "Nontemporal without the Vulkan Memory Model is ignored", tokenText, "");
             return keyword;
+        }
         return identifierOrType();
     case PATCH:
         if (parseContext.symbolTable.atBuiltInLevel() ||


### PR DESCRIPTION
When the extension is disabled, `nontemporal` can be used as a normal identifier.