### PR TITLE
kokoro: linux: use cpp-builder image instead of radial-build

### DIFF
--- a/kokoro/android-ndk-build/build.sh
+++ b/kokoro/android-ndk-build/build.sh
@@ -44,4 +44,4 @@ docker run --rm -i \
   --env ROOT_DIR="${ROOT_DIR}" \
   --env SCRIPT_DIR="${SCRIPT_DIR}" \
   --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
-  "gcr.io/shaderc-build/radial-build:latest"
+  us-east4-docker.pkg.dev/shaderc-build/radial-docker/ubuntu-24.04-amd64/cpp-builder

--- a/kokoro/linux-clang-cmake/build.sh
+++ b/kokoro/linux-clang-cmake/build.sh
@@ -45,4 +45,4 @@ docker run --rm -i \
   --env SCRIPT_DIR="${SCRIPT_DIR}" \
   --env BUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-0}" \
   --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
-  "gcr.io/shaderc-build/radial-build:latest"
+  us-east4-docker.pkg.dev/shaderc-build/radial-docker/ubuntu-24.04-amd64/cpp-builder

--- a/kokoro/linux-clang-gn/build.sh
+++ b/kokoro/linux-clang-gn/build.sh
@@ -45,7 +45,7 @@ docker run --rm -i \
   --env ROOT_DIR="${ROOT_DIR}" \
   --env SCRIPT_DIR="${SCRIPT_DIR}" \
   --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
-  "gcr.io/shaderc-build/radial-build:latest"
+  us-east4-docker.pkg.dev/shaderc-build/radial-docker/ubuntu-24.04-amd64/cpp-builder
 
 # This is important. If the permissions are not fixed, kokoro will fail
 # to pull build artifacts, and put the build in tool-failure state, which

--- a/kokoro/linux-gcc-cmake/build.sh
+++ b/kokoro/linux-gcc-cmake/build.sh
@@ -45,4 +45,4 @@ docker run --rm -i \
   --env SCRIPT_DIR="${SCRIPT_DIR}" \
   --env BUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-0}" \
   --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
-  "gcr.io/shaderc-build/radial-build:latest"
+  us-east4-docker.pkg.dev/shaderc-build/radial-docker/ubuntu-24.04-amd64/cpp-builder


### PR DESCRIPTION
Bug: crbug.com/391948942