### PR TITLE
cmake: Minor CMake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,13 +36,13 @@ project(glslang)
 set(GLSLANG_TESTS_DEFAULT ON) # Can be turned off, below, based on environment.
 set(GLSLANG_ENABLE_INSTALL_DEFAULT ON) # Can be turned off, below, based on environment.
 
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON) # Can be removed when min is 3.26 see policy CMP0143.
 
 # Adhere to GNU filesystem layout conventions
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-# Needed for CMAKE_DEPENDENT_OPTION macro
+# Needed for cmake_dependent_option macro
 include(CMakeDependentOption)
 
 option(BUILD_SHARED_LIBS "Build Shared Libraries")
@@ -55,7 +55,8 @@ if(BUILD_SHARED_LIBS)
     set(LIB_TYPE SHARED)
 endif()
 
-if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
+get_cmake_property(isMultiConfig "GENERATOR_IS_MULTI_CONFIG")
+if (NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE)
     # This logic inside SPIRV-Tools, which can upset build target dependencies
     # if changed after targets are already defined. To prevent these issues,
     # ensure CMAKE_BUILD_TYPE is assigned early and at the glslang root scope.
@@ -98,11 +99,11 @@ option(ENABLE_SPVREMAPPER "Enables building of SPVRemapper" ON)
 option(ENABLE_GLSLANG_BINARIES "Builds glslang and spirv-remap" ON)
 
 option(ENABLE_GLSLANG_JS "If using Emscripten, build glslang.js. Otherwise, builds a sample executable for binary-size testing.")
-CMAKE_DEPENDENT_OPTION(ENABLE_EMSCRIPTEN_SINGLE_FILE
+cmake_dependent_option(ENABLE_EMSCRIPTEN_SINGLE_FILE
     "If using Emscripten, enables SINGLE_FILE build"
     OFF "ENABLE_GLSLANG_JS AND EMSCRIPTEN"
     OFF)
-CMAKE_DEPENDENT_OPTION(ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE
+cmake_dependent_option(ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE
     "If using Emscripten, builds to run on Node instead of Web"
     OFF "ENABLE_GLSLANG_JS AND EMSCRIPTEN"
     OFF)
@@ -110,7 +111,7 @@ CMAKE_DEPENDENT_OPTION(ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE
 option(ENABLE_HLSL "Enables HLSL input support" ON)
 option(ENABLE_RTTI "Enables RTTI")
 option(ENABLE_EXCEPTIONS "Enables Exceptions")
-CMAKE_DEPENDENT_OPTION(ENABLE_OPT "Enables spirv-opt capability if present" ON "ENABLE_SPIRV" OFF)
+cmake_dependent_option(ENABLE_OPT "Enables spirv-opt capability if present" ON "ENABLE_SPIRV" OFF)
 
 if(MINGW OR (APPLE AND ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU"))
     # Workaround for CMake behavior on Mac OS with gcc, cmake generates -Xarch_* arguments
@@ -131,9 +132,9 @@ endif()
 
 if(WIN32)
     set(CMAKE_DEBUG_POSTFIX "d")
-    add_definitions(-DGLSLANG_OSINCLUDE_WIN32)
+    add_compile_definitions(GLSLANG_OSINCLUDE_WIN32)
 elseif(UNIX OR ANDROID)
-    add_definitions(-DGLSLANG_OSINCLUDE_UNIX)
+    add_compile_definitions(GLSLANG_OSINCLUDE_UNIX)
 else()
     message("unknown platform")
 endif()
@@ -215,9 +216,8 @@ function(glslang_set_link_args TARGET)
     # For MinGW compiles, statically link against the GCC and C++ runtimes.
     # This avoids the need to ship those runtimes as DLLs.
     # This is supported by GCC and Clang.
-    if(WIN32 AND NOT MSVC)
-        set_target_properties(${TARGET} PROPERTIES
-                              LINK_FLAGS "-static -static-libgcc -static-libstdc++")
+    if(MINGW)
+        target_link_options(${TARGET} PRIVATE -static -static-libgcc -static-libstdc++)
     endif()
 endfunction()
 
@@ -301,12 +301,12 @@ endif()
 
 if(ENABLE_OPT)
     message(STATUS "optimizer enabled")
-    add_definitions(-DENABLE_OPT=1)
+    add_compile_definitions(ENABLE_OPT=1)
 else()
     if(ENABLE_HLSL)
         message(STATUS "spirv-tools not linked - illegal SPIRV may be generated for HLSL")
     endif()
-    add_definitions(-DENABLE_OPT=0)
+    add_compile_definitions(ENABLE_OPT=0)
 endif()
 
 if(ENABLE_SPIRV)
@@ -325,17 +325,17 @@ if(GLSLANG_TESTS)
     # Make sure to use '-o igncr' flag to ignore carriage returns (\r).
     set(IGNORE_CR_FLAG "")
     if(WIN32)
-	set(IGNORE_CR_FLAG -o igncr)
+        set(IGNORE_CR_FLAG -o igncr)
     endif()
 
-    if (CMAKE_CONFIGURATION_TYPES)
-	set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/localResults)
-	set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/glslang)
-	set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/spirv-remap)
+    if (isMultiConfig)
+        set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/localResults)
+        set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/glslang)
+        set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/spirv-remap)
     else()
-	set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/localResults)
-	set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/glslang)
-	set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
+        set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/localResults)
+        set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/glslang)
+        set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
     endif()
 
     # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.

--- a/External/CMakeLists.txt
+++ b/External/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 The Khronos Group Inc.
+# Copyright (C) 2020-2025 The Khronos Group Inc.
 #
 # All rights reserved.
 #
@@ -42,7 +42,7 @@ if(GLSLANG_TESTS)
         # global CRT settings on Windows.
         if(WIN32)
             set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-        endif(WIN32)
+        endif()
         # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
         add_subdirectory(googletest EXCLUDE_FROM_ALL)
         set(GTEST_TARGETS

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 The Khronos Group Inc.
+# Copyright (C) 2020-2025 The Khronos Group Inc.
 #
 # All rights reserved.
 #
@@ -118,4 +118,4 @@ if(GLSLANG_ENABLE_INSTALL)
             install(TARGETS spirv-remap EXPORT glslang-targets)
         endif()
     endif()
-endif(GLSLANG_ENABLE_INSTALL)
+endif()


### PR DESCRIPTION
Highlight policy CMP0143 for future reference

Use GENERATOR_IS_MULTI_CONFIG for detecting multi configuration generators

Don't set CMAKE_BUILD_TYPE when using multi configuration generators.

Misc endif cleanup for modernization

Use lower case version of cmake_dependent_option for consistency with rest of codebase.

Use add_compile_definitions instead of add_definitions

Minor indentation for readability

Use MINGW variable where applicable

Use target_link_options instead of old LINK_FLAGS