### PR TITLE
Fix pre-gcc-9 builds for libstdc++fs

### DIFF
--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -59,7 +59,8 @@ glslang_set_link_args(glslang-standalone)
 
 set(LIBRARIES
     glslang
-    glslang-default-resource-limits)
+    glslang-default-resource-limits
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
 
 if(WIN32)
     set(LIBRARIES ${LIBRARIES} psapi)

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -88,7 +88,8 @@ if(GLSLANG_TESTS)
         endif()
 
         set(LIBRARIES
-            glslang glslang-default-resource-limits)
+            glslang glslang-default-resource-limits
+            $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
 
         if(ENABLE_SPVREMAPPER)
             set(LIBRARIES ${LIBRARIES} SPVRemapper)


### PR DESCRIPTION
Until gcc 9, users of `std::filesystem` had to explicitly link against libstdc++fs.