### PR TITLE
Implement optional cross-stage check for input with no matching output

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -112,6 +112,7 @@ enum TOptions : uint64_t {
     EOptionCompileOnly = (1ull << 32),
     EOptionDisplayErrorColumn = (1ull << 33),
     EOptionLinkTimeOptimization = (1ull << 34),
+    EOptionValidateCrossStageIO = (1ull << 35),
 };
 bool targetHlslFunctionality1 = false;
 bool SpvToolsDisassembler = false;
@@ -907,6 +908,8 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                         Options |= EOptionDisplayErrorColumn;
                     } else if (lowerword == "lto") {
                         Options |= EOptionLinkTimeOptimization;
+                    } else if (lowerword == "validate-io") {
+                        Options |= EOptionValidateCrossStageIO;
                     } else if (lowerword == "help") {
                         usage();
                         break;
@@ -1095,6 +1098,10 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
     if ((Options & EOptionLinkTimeOptimization) && !(Options & EOptionLinkProgram))
         Error("link time optimization requires -l for linking");
 
+    // cross stage IO validation makes no sense unless linking
+    if ((Options & EOptionValidateCrossStageIO) && !(Options & EOptionLinkProgram))
+        Error("cross stage IO validation requires -l for linking");
+
     // -o or -x makes no sense if there is no target binary
     if (binaryFileName && (Options & EOptionSpv) == 0)
         Error("no binary generation requested (e.g., -V)");
@@ -1185,6 +1192,8 @@ void SetMessageOptions(EShMessages& messages)
         messages = (EShMessages)(messages | EShMsgDisplayErrorColumn);
     if (Options & EOptionLinkTimeOptimization)
         messages = (EShMessages)(messages | EShMsgLinkTimeOptimization);
+    if (Options & EOptionValidateCrossStageIO)
+        messages = (EShMessages)(messages | EShMsgValidateCrossStageIO);
 }
 
 //
@@ -2154,7 +2163,8 @@ void usage()
            "  --no-link                         Only compile shader; do not link (GLSL-only)\n"
            "                                    NOTE: this option will set the export linkage\n"
            "                                          attribute on all functions\n"
-           "  --lto                             perform link time optimization\n");
+           "  --lto                             perform link time optimization\n"
+           "  --validate-io                     validate cross stage IO\n");
 
     exit(EFailUsage);
 }

--- a/Test/baseResults/link.crossStageIO.0.vert.out
+++ b/Test/baseResults/link.crossStageIO.0.vert.out
@@ -1,0 +1,1701 @@
+link.crossStageIO.0.vert
+Shader version: 460
+0:? Sequence
+0:66  Function Definition: main( ( global void)
+0:66    Function Parameters: 
+0:67    Sequence
+0:67      Test condition and select ( temp void)
+0:67        Condition
+0:67        Constant:
+0:67          false (const bool)
+0:67        true case
+0:68        Sequence
+0:68          move second child to first child ( temp 4-component vector of float)
+0:68            'a0' (layout( location=40) smooth out 4-component vector of float)
+0:68            Constant:
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:70      move second child to first child ( temp 4-component vector of float)
+0:70        a1: direct index for structure ( out 4-component vector of float)
+0:70          'anon@0' (layout( location=1) out block{ out 4-component vector of float a1})
+0:70          Constant:
+0:70            0 (const uint)
+0:70        Constant:
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:71      move second child to first child ( temp 4-component vector of float)
+0:71        a2: direct index for structure (layout( location=3) out 4-component vector of float)
+0:71          'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:71          Constant:
+0:71            0 (const uint)
+0:71        Constant:
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:72      move second child to first child ( temp 4-component vector of float)
+0:72        a3: direct index for structure (layout( location=2) out 4-component vector of float)
+0:72          'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:72          Constant:
+0:72            1 (const uint)
+0:72        Constant:
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:73      move second child to first child ( temp 4-component vector of float)
+0:73        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:73          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:73          Constant:
+0:73            0 (const int)
+0:73        Constant:
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:74      move second child to first child ( temp 4-component vector of float)
+0:74        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:74          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:74          Constant:
+0:74            1 (const int)
+0:74        Constant:
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:75      move second child to first child ( temp 4-component vector of float)
+0:75        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:75          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:75          Constant:
+0:75            2 (const int)
+0:75        Constant:
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        a5: direct index for structure (layout( location=4) out 4-component vector of float)
+0:76          'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        Constant:
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:77      move second child to first child ( temp 4-component vector of float)
+0:77        direct index (layout( location=8) temp 4-component vector of float)
+0:77          a6: direct index for structure (layout( location=8) out 2-element array of 4-component vector of float)
+0:77            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:77            Constant:
+0:77              1 (const uint)
+0:77          Constant:
+0:77            0 (const int)
+0:77        Constant:
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:78      move second child to first child ( temp 4-component vector of float)
+0:78        direct index (layout( location=8) temp 4-component vector of float)
+0:78          a6: direct index for structure (layout( location=8) out 2-element array of 4-component vector of float)
+0:78            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:78            Constant:
+0:78              1 (const uint)
+0:78          Constant:
+0:78            1 (const int)
+0:78        Constant:
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:79      move second child to first child ( temp 4-component vector of float)
+0:79        direct index (layout( location=10) temp 4-component vector of float)
+0:79          a7: direct index for structure (layout( location=10) out 2-element array of 4-component vector of float)
+0:79            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:79            Constant:
+0:79              2 (const uint)
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:80      move second child to first child ( temp 4-component vector of float)
+0:80        direct index (layout( location=10) temp 4-component vector of float)
+0:80          a7: direct index for structure (layout( location=10) out 2-element array of 4-component vector of float)
+0:80            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:80            Constant:
+0:80              2 (const uint)
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:81      move second child to first child ( temp float)
+0:81        a8: direct index for structure (layout( location=12) out float)
+0:81          'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:81          Constant:
+0:81            0 (const uint)
+0:81        Constant:
+0:81          0.000000
+0:82      move second child to first child ( temp float)
+0:82        direct index ( temp float)
+0:82          direct index (layout( location=15) temp 2-component vector of float)
+0:82            a9: direct index for structure (layout( location=15) out 2-element array of 2-component vector of float)
+0:82              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:82              Constant:
+0:82                1 (const uint)
+0:82            Constant:
+0:82              0 (const int)
+0:82          Constant:
+0:82            0 (const int)
+0:82        Constant:
+0:82          0.000000
+0:83      move second child to first child ( temp float)
+0:83        direct index ( temp float)
+0:83          direct index (layout( location=15) temp 2-component vector of float)
+0:83            a9: direct index for structure (layout( location=15) out 2-element array of 2-component vector of float)
+0:83              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:83              Constant:
+0:83                1 (const uint)
+0:83            Constant:
+0:83              1 (const int)
+0:83          Constant:
+0:83            1 (const int)
+0:83        Constant:
+0:83          0.000000
+0:84      move second child to first child ( temp 4-component vector of float)
+0:84        direct index (layout( location=17) temp 4-component vector of float)
+0:84          a10: direct index for structure (layout( location=17) out 2-element array of 4-component vector of float)
+0:84            'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:84            Constant:
+0:84              2 (const uint)
+0:84          Constant:
+0:84            0 (const int)
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:85      move second child to first child ( temp 4-component vector of float)
+0:85        direct index (layout( location=17) temp 4-component vector of float)
+0:85          a10: direct index for structure (layout( location=17) out 2-element array of 4-component vector of float)
+0:85            'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:85            Constant:
+0:85              2 (const uint)
+0:85          Constant:
+0:85            1 (const int)
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:86      move second child to first child ( temp float)
+0:86        direct index ( temp float)
+0:86          a: direct index for structure ( global 3-element array of float)
+0:86            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:86              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:86                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:86                Constant:
+0:86                  3 (const uint)
+0:86              Constant:
+0:86                0 (const int)
+0:86            Constant:
+0:86              0 (const int)
+0:86          Constant:
+0:86            0 (const int)
+0:86        Constant:
+0:86          0.000000
+0:87      move second child to first child ( temp float)
+0:87        direct index ( temp float)
+0:87          a: direct index for structure ( global 3-element array of float)
+0:87            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:87              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:87                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:87                Constant:
+0:87                  3 (const uint)
+0:87              Constant:
+0:87                0 (const int)
+0:87            Constant:
+0:87              0 (const int)
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          0.000000
+0:88      move second child to first child ( temp float)
+0:88        direct index ( temp float)
+0:88          a: direct index for structure ( global 3-element array of float)
+0:88            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:88              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:88                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:88                Constant:
+0:88                  3 (const uint)
+0:88              Constant:
+0:88                0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88          Constant:
+0:88            2 (const int)
+0:88        Constant:
+0:88          0.000000
+0:89      move second child to first child ( temp float)
+0:89        b: direct index for structure ( global float)
+0:89          direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:89            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:89              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:89              Constant:
+0:89                3 (const uint)
+0:89            Constant:
+0:89              0 (const int)
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          0.000000
+0:90      move second child to first child ( temp float)
+0:90        direct index ( temp float)
+0:90          a: direct index for structure ( global 3-element array of float)
+0:90            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:90              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:90                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:90                Constant:
+0:90                  3 (const uint)
+0:90              Constant:
+0:90                1 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:90          Constant:
+0:90            0 (const int)
+0:90        Constant:
+0:90          0.000000
+0:91      move second child to first child ( temp float)
+0:91        direct index ( temp float)
+0:91          a: direct index for structure ( global 3-element array of float)
+0:91            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:91              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:91                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:91                Constant:
+0:91                  3 (const uint)
+0:91              Constant:
+0:91                1 (const int)
+0:91            Constant:
+0:91              0 (const int)
+0:91          Constant:
+0:91            1 (const int)
+0:91        Constant:
+0:91          0.000000
+0:92      move second child to first child ( temp float)
+0:92        direct index ( temp float)
+0:92          a: direct index for structure ( global 3-element array of float)
+0:92            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:92              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:92                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:92                Constant:
+0:92                  3 (const uint)
+0:92              Constant:
+0:92                1 (const int)
+0:92            Constant:
+0:92              0 (const int)
+0:92          Constant:
+0:92            2 (const int)
+0:92        Constant:
+0:92          0.000000
+0:93      move second child to first child ( temp float)
+0:93        b: direct index for structure ( global float)
+0:93          direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:93            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:93              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:93              Constant:
+0:93                3 (const uint)
+0:93            Constant:
+0:93              1 (const int)
+0:93          Constant:
+0:93            1 (const int)
+0:93        Constant:
+0:93          0.000000
+0:94      move second child to first child ( temp float)
+0:94        direct index (layout( location=27) smooth temp float)
+0:94          'a12' (layout( location=27) smooth out 3-element array of float)
+0:94          Constant:
+0:94            0 (const int)
+0:94        Constant:
+0:94          0.000000
+0:95      move second child to first child ( temp float)
+0:95        direct index (layout( location=27) smooth temp float)
+0:95          'a12' (layout( location=27) smooth out 3-element array of float)
+0:95          Constant:
+0:95            1 (const int)
+0:95        Constant:
+0:95          0.000000
+0:96      move second child to first child ( temp float)
+0:96        direct index (layout( location=27) smooth temp float)
+0:96          'a12' (layout( location=27) smooth out 3-element array of float)
+0:96          Constant:
+0:96            2 (const int)
+0:96        Constant:
+0:96          0.000000
+0:97      move second child to first child ( temp float)
+0:97        direct index ( temp float)
+0:97          a13: direct index for structure ( global 2-component vector of float)
+0:97            's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:97            Constant:
+0:97              0 (const int)
+0:97          Constant:
+0:97            1 (const int)
+0:97        Constant:
+0:97          0.000000
+0:98      move second child to first child ( temp float)
+0:98        direct index ( temp float)
+0:98          a: direct index for structure ( global 3-element array of float)
+0:98            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:98              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:98              Constant:
+0:98                1 (const int)
+0:98            Constant:
+0:98              0 (const int)
+0:98          Constant:
+0:98            0 (const int)
+0:98        Constant:
+0:98          0.000000
+0:99      move second child to first child ( temp float)
+0:99        direct index ( temp float)
+0:99          a: direct index for structure ( global 3-element array of float)
+0:99            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:99              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:99              Constant:
+0:99                1 (const int)
+0:99            Constant:
+0:99              0 (const int)
+0:99          Constant:
+0:99            1 (const int)
+0:99        Constant:
+0:99          0.000000
+0:100      move second child to first child ( temp float)
+0:100        direct index ( temp float)
+0:100          a: direct index for structure ( global 3-element array of float)
+0:100            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:100              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:100              Constant:
+0:100                1 (const int)
+0:100            Constant:
+0:100              0 (const int)
+0:100          Constant:
+0:100            2 (const int)
+0:100        Constant:
+0:100          0.000000
+0:101      move second child to first child ( temp float)
+0:101        b: direct index for structure ( global float)
+0:101          a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:101            's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:101            Constant:
+0:101              1 (const int)
+0:101          Constant:
+0:101            1 (const int)
+0:101        Constant:
+0:101          0.000000
+0:102      move second child to first child ( temp 4X4 matrix of float)
+0:102        a15: direct index for structure ( global 4X4 matrix of float)
+0:102          's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:102          Constant:
+0:102            2 (const int)
+0:102        Constant:
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:104      move second child to first child ( temp 4-component vector of float)
+0:104        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:104          'a17' (layout( location=46) smooth out 4-element array of 4-component vector of float)
+0:104          i: direct index for structure (layout( column_major shared) uniform int)
+0:104            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:104            Constant:
+0:104              0 (const int)
+0:104        Constant:
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:105      move second child to first child ( temp 4-component vector of float)
+0:105        direct index ( temp 4-component vector of float)
+0:105          a18: direct index for structure ( out 10-element array of 4-component vector of float)
+0:105            'anon@4' (layout( location=50) out block{ out 10-element array of 4-component vector of float a18})
+0:105            Constant:
+0:105              0 (const uint)
+0:105          Constant:
+0:105            5 (const int)
+0:105        Constant:
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:106      move second child to first child ( temp 2-component vector of float)
+0:106        a19: direct index for structure (layout( location=60) out 2-component vector of float)
+0:106          'anon@5' ( out block{layout( location=60) out 2-component vector of float a19})
+0:106          Constant:
+0:106            0 (const uint)
+0:106        Constant:
+0:106          0.000000
+0:106          0.000000
+0:107      move second child to first child ( temp 4-component vector of float)
+0:107        a20: direct index for structure ( out 4-component vector of float)
+0:107          'anon@6' ( out block{ out 4-component vector of float a20})
+0:107          Constant:
+0:107            0 (const uint)
+0:107        Constant:
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:108      move second child to first child ( temp 2-component vector of float)
+0:108        direct index ( smooth temp 2-component vector of float)
+0:108          'a21' ( smooth out 2-element array of 2-component vector of float)
+0:108          Constant:
+0:108            0 (const int)
+0:108        Constant:
+0:108          0.000000
+0:108          0.000000
+0:109      move second child to first child ( temp 2-component vector of float)
+0:109        direct index ( smooth temp 2-component vector of float)
+0:109          'a21' ( smooth out 2-element array of 2-component vector of float)
+0:109          Constant:
+0:109            1 (const int)
+0:109        Constant:
+0:109          0.000000
+0:109          0.000000
+0:?   Linker Objects
+0:?     'a0' (layout( location=40) smooth out 4-component vector of float)
+0:?     'anon@0' (layout( location=1) out block{ out 4-component vector of float a1})
+0:?     'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:?     'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:?     'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:?     'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:?     'a12' (layout( location=27) smooth out 3-element array of float)
+0:?     's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:?     'a16' (layout( location=39) smooth out float)
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'a17' (layout( location=46) smooth out 4-element array of 4-component vector of float)
+0:?     'anon@4' (layout( location=50) out block{ out 10-element array of 4-component vector of float a18})
+0:?     'anon@5' ( out block{layout( location=60) out 2-component vector of float a19})
+0:?     'anon@6' ( out block{ out 4-component vector of float a20})
+0:?     'a21' ( smooth out 2-element array of 2-component vector of float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+link.crossStageIO.0.frag
+Shader version: 460
+0:? Sequence
+0:71  Function Definition: uncalled( ( global uint)
+0:71    Function Parameters: 
+0:72    Sequence
+0:72      Branch: Return with expression
+0:72        'b16' ( flat in uint)
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        'o' ( out 4-component vector of float)
+0:76        b1: direct index for structure ( in 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp 4-component vector of float)
+0:77        'o' ( out 4-component vector of float)
+0:77        b2: direct index for structure ( in 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp 4-component vector of float)
+0:78        'o' ( out 4-component vector of float)
+0:78        b3: direct index for structure ( in 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp 4-component vector of float)
+0:79        'o' ( out 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp 4-component vector of float)
+0:80        'o' ( out 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp 4-component vector of float)
+0:81        'o' ( out 4-component vector of float)
+0:81        b5: direct index for structure ( in 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp 4-component vector of float)
+0:82        'o' ( out 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp 4-component vector of float)
+0:83        'o' ( out 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp 4-component vector of float)
+0:84        'o' ( out 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp 4-component vector of float)
+0:85        'o' ( out 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp 4-component vector of float)
+0:86        'o' ( out 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp 4-component vector of float)
+0:87        'o' ( out 4-component vector of float)
+0:87        Construct vec4 ( temp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp 4-component vector of float)
+0:88        'o' ( out 4-component vector of float)
+0:88        vector swizzle ( temp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp 4-component vector of float)
+0:89        'o' ( out 4-component vector of float)
+0:89        Construct vec4 ( temp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in float)
+0:89            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp 4-component vector of float)
+0:90        'o' ( out 4-component vector of float)
+0:90        vector swizzle ( temp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp 4-component vector of float)
+0:91        'o' ( out 4-component vector of float)
+0:91        Construct vec4 ( temp 4-component vector of float)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp 4-component vector of float)
+0:92        'o' ( out 4-component vector of float)
+0:92        Construct vec4 ( temp 4-component vector of float)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp float)
+0:92            add ( temp float)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp float)
+0:92              b12: direct index for structure ( in 6-element array of float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp 4-component vector of float)
+0:93        'o' ( out 4-component vector of float)
+0:93        Construct vec4 ( temp 4-component vector of float)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp 4-component vector of float)
+0:95            'o' ( out 4-component vector of float)
+0:95            vector swizzle ( temp 4-component vector of float)
+0:95              matrix-times-vector ( temp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp 4-component vector of float)
+0:96            'o' ( out 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp 4-component vector of float)
+0:97            'o' ( out 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp 4-component vector of float)
+0:99        'o' ( out 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major shared) uniform int)
+0:99            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp 4-component vector of float)
+0:100        'o' ( out 4-component vector of float)
+0:100        indirect index ( temp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major shared) uniform int)
+0:100            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp 4-component vector of float)
+0:101        'o' ( out 4-component vector of float)
+0:101        vector swizzle ( temp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp 4-component vector of float)
+0:102        'o' ( out 4-component vector of float)
+0:102        a20: direct index for structure ( in 4-component vector of float)
+0:102          'anon@8' ( in block{ in 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp 4-component vector of float)
+0:103        'o' ( out 4-component vector of float)
+0:103        Construct vec4 ( temp 4-component vector of float)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of float)
+0:?     'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:?     'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:?     'b16' ( flat in uint)
+0:?     'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in 2-component vector of float)
+0:?     'anon@8' ( in block{ in 4-component vector of float a20})
+0:?     'a21' ( smooth in 2-element array of 2-component vector of float)
+0:?     'o' ( out 4-component vector of float)
+
+
+Linked vertex stage:
+
+
+Linked fragment stage:
+
+
+Shader version: 460
+0:? Sequence
+0:66  Function Definition: main( ( global void)
+0:66    Function Parameters: 
+0:67    Sequence
+0:67      Test condition and select ( temp void)
+0:67        Condition
+0:67        Constant:
+0:67          false (const bool)
+0:67        true case
+0:68        Sequence
+0:68          move second child to first child ( temp 4-component vector of float)
+0:68            'a0' (layout( location=40) smooth out 4-component vector of float)
+0:68            Constant:
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:70      move second child to first child ( temp 4-component vector of float)
+0:70        a1: direct index for structure ( out 4-component vector of float)
+0:70          'anon@0' (layout( location=1) out block{ out 4-component vector of float a1})
+0:70          Constant:
+0:70            0 (const uint)
+0:70        Constant:
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:71      move second child to first child ( temp 4-component vector of float)
+0:71        a2: direct index for structure (layout( location=3) out 4-component vector of float)
+0:71          'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:71          Constant:
+0:71            0 (const uint)
+0:71        Constant:
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:72      move second child to first child ( temp 4-component vector of float)
+0:72        a3: direct index for structure (layout( location=2) out 4-component vector of float)
+0:72          'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:72          Constant:
+0:72            1 (const uint)
+0:72        Constant:
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:73      move second child to first child ( temp 4-component vector of float)
+0:73        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:73          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:73          Constant:
+0:73            0 (const int)
+0:73        Constant:
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:74      move second child to first child ( temp 4-component vector of float)
+0:74        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:74          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:74          Constant:
+0:74            1 (const int)
+0:74        Constant:
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:75      move second child to first child ( temp 4-component vector of float)
+0:75        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:75          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:75          Constant:
+0:75            2 (const int)
+0:75        Constant:
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        a5: direct index for structure (layout( location=4) out 4-component vector of float)
+0:76          'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        Constant:
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:77      move second child to first child ( temp 4-component vector of float)
+0:77        direct index (layout( location=8) temp 4-component vector of float)
+0:77          a6: direct index for structure (layout( location=8) out 2-element array of 4-component vector of float)
+0:77            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:77            Constant:
+0:77              1 (const uint)
+0:77          Constant:
+0:77            0 (const int)
+0:77        Constant:
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:78      move second child to first child ( temp 4-component vector of float)
+0:78        direct index (layout( location=8) temp 4-component vector of float)
+0:78          a6: direct index for structure (layout( location=8) out 2-element array of 4-component vector of float)
+0:78            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:78            Constant:
+0:78              1 (const uint)
+0:78          Constant:
+0:78            1 (const int)
+0:78        Constant:
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:79      move second child to first child ( temp 4-component vector of float)
+0:79        direct index (layout( location=10) temp 4-component vector of float)
+0:79          a7: direct index for structure (layout( location=10) out 2-element array of 4-component vector of float)
+0:79            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:79            Constant:
+0:79              2 (const uint)
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:80      move second child to first child ( temp 4-component vector of float)
+0:80        direct index (layout( location=10) temp 4-component vector of float)
+0:80          a7: direct index for structure (layout( location=10) out 2-element array of 4-component vector of float)
+0:80            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:80            Constant:
+0:80              2 (const uint)
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:81      move second child to first child ( temp float)
+0:81        a8: direct index for structure (layout( location=12) out float)
+0:81          'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:81          Constant:
+0:81            0 (const uint)
+0:81        Constant:
+0:81          0.000000
+0:82      move second child to first child ( temp float)
+0:82        direct index ( temp float)
+0:82          direct index (layout( location=15) temp 2-component vector of float)
+0:82            a9: direct index for structure (layout( location=15) out 2-element array of 2-component vector of float)
+0:82              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:82              Constant:
+0:82                1 (const uint)
+0:82            Constant:
+0:82              0 (const int)
+0:82          Constant:
+0:82            0 (const int)
+0:82        Constant:
+0:82          0.000000
+0:83      move second child to first child ( temp float)
+0:83        direct index ( temp float)
+0:83          direct index (layout( location=15) temp 2-component vector of float)
+0:83            a9: direct index for structure (layout( location=15) out 2-element array of 2-component vector of float)
+0:83              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:83              Constant:
+0:83                1 (const uint)
+0:83            Constant:
+0:83              1 (const int)
+0:83          Constant:
+0:83            1 (const int)
+0:83        Constant:
+0:83          0.000000
+0:84      move second child to first child ( temp 4-component vector of float)
+0:84        direct index (layout( location=17) temp 4-component vector of float)
+0:84          a10: direct index for structure (layout( location=17) out 2-element array of 4-component vector of float)
+0:84            'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:84            Constant:
+0:84              2 (const uint)
+0:84          Constant:
+0:84            0 (const int)
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:85      move second child to first child ( temp 4-component vector of float)
+0:85        direct index (layout( location=17) temp 4-component vector of float)
+0:85          a10: direct index for structure (layout( location=17) out 2-element array of 4-component vector of float)
+0:85            'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:85            Constant:
+0:85              2 (const uint)
+0:85          Constant:
+0:85            1 (const int)
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:86      move second child to first child ( temp float)
+0:86        direct index ( temp float)
+0:86          a: direct index for structure ( global 3-element array of float)
+0:86            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:86              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:86                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:86                Constant:
+0:86                  3 (const uint)
+0:86              Constant:
+0:86                0 (const int)
+0:86            Constant:
+0:86              0 (const int)
+0:86          Constant:
+0:86            0 (const int)
+0:86        Constant:
+0:86          0.000000
+0:87      move second child to first child ( temp float)
+0:87        direct index ( temp float)
+0:87          a: direct index for structure ( global 3-element array of float)
+0:87            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:87              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:87                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:87                Constant:
+0:87                  3 (const uint)
+0:87              Constant:
+0:87                0 (const int)
+0:87            Constant:
+0:87              0 (const int)
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          0.000000
+0:88      move second child to first child ( temp float)
+0:88        direct index ( temp float)
+0:88          a: direct index for structure ( global 3-element array of float)
+0:88            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:88              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:88                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:88                Constant:
+0:88                  3 (const uint)
+0:88              Constant:
+0:88                0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88          Constant:
+0:88            2 (const int)
+0:88        Constant:
+0:88          0.000000
+0:89      move second child to first child ( temp float)
+0:89        b: direct index for structure ( global float)
+0:89          direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:89            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:89              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:89              Constant:
+0:89                3 (const uint)
+0:89            Constant:
+0:89              0 (const int)
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          0.000000
+0:90      move second child to first child ( temp float)
+0:90        direct index ( temp float)
+0:90          a: direct index for structure ( global 3-element array of float)
+0:90            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:90              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:90                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:90                Constant:
+0:90                  3 (const uint)
+0:90              Constant:
+0:90                1 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:90          Constant:
+0:90            0 (const int)
+0:90        Constant:
+0:90          0.000000
+0:91      move second child to first child ( temp float)
+0:91        direct index ( temp float)
+0:91          a: direct index for structure ( global 3-element array of float)
+0:91            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:91              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:91                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:91                Constant:
+0:91                  3 (const uint)
+0:91              Constant:
+0:91                1 (const int)
+0:91            Constant:
+0:91              0 (const int)
+0:91          Constant:
+0:91            1 (const int)
+0:91        Constant:
+0:91          0.000000
+0:92      move second child to first child ( temp float)
+0:92        direct index ( temp float)
+0:92          a: direct index for structure ( global 3-element array of float)
+0:92            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:92              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:92                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:92                Constant:
+0:92                  3 (const uint)
+0:92              Constant:
+0:92                1 (const int)
+0:92            Constant:
+0:92              0 (const int)
+0:92          Constant:
+0:92            2 (const int)
+0:92        Constant:
+0:92          0.000000
+0:93      move second child to first child ( temp float)
+0:93        b: direct index for structure ( global float)
+0:93          direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:93            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:93              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:93              Constant:
+0:93                3 (const uint)
+0:93            Constant:
+0:93              1 (const int)
+0:93          Constant:
+0:93            1 (const int)
+0:93        Constant:
+0:93          0.000000
+0:94      move second child to first child ( temp float)
+0:94        direct index (layout( location=27) smooth temp float)
+0:94          'a12' (layout( location=27) smooth out 3-element array of float)
+0:94          Constant:
+0:94            0 (const int)
+0:94        Constant:
+0:94          0.000000
+0:95      move second child to first child ( temp float)
+0:95        direct index (layout( location=27) smooth temp float)
+0:95          'a12' (layout( location=27) smooth out 3-element array of float)
+0:95          Constant:
+0:95            1 (const int)
+0:95        Constant:
+0:95          0.000000
+0:96      move second child to first child ( temp float)
+0:96        direct index (layout( location=27) smooth temp float)
+0:96          'a12' (layout( location=27) smooth out 3-element array of float)
+0:96          Constant:
+0:96            2 (const int)
+0:96        Constant:
+0:96          0.000000
+0:97      move second child to first child ( temp float)
+0:97        direct index ( temp float)
+0:97          a13: direct index for structure ( global 2-component vector of float)
+0:97            's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:97            Constant:
+0:97              0 (const int)
+0:97          Constant:
+0:97            1 (const int)
+0:97        Constant:
+0:97          0.000000
+0:98      move second child to first child ( temp float)
+0:98        direct index ( temp float)
+0:98          a: direct index for structure ( global 3-element array of float)
+0:98            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:98              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:98              Constant:
+0:98                1 (const int)
+0:98            Constant:
+0:98              0 (const int)
+0:98          Constant:
+0:98            0 (const int)
+0:98        Constant:
+0:98          0.000000
+0:99      move second child to first child ( temp float)
+0:99        direct index ( temp float)
+0:99          a: direct index for structure ( global 3-element array of float)
+0:99            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:99              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:99              Constant:
+0:99                1 (const int)
+0:99            Constant:
+0:99              0 (const int)
+0:99          Constant:
+0:99            1 (const int)
+0:99        Constant:
+0:99          0.000000
+0:100      move second child to first child ( temp float)
+0:100        direct index ( temp float)
+0:100          a: direct index for structure ( global 3-element array of float)
+0:100            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:100              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:100              Constant:
+0:100                1 (const int)
+0:100            Constant:
+0:100              0 (const int)
+0:100          Constant:
+0:100            2 (const int)
+0:100        Constant:
+0:100          0.000000
+0:101      move second child to first child ( temp float)
+0:101        b: direct index for structure ( global float)
+0:101          a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:101            's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:101            Constant:
+0:101              1 (const int)
+0:101          Constant:
+0:101            1 (const int)
+0:101        Constant:
+0:101          0.000000
+0:102      move second child to first child ( temp 4X4 matrix of float)
+0:102        a15: direct index for structure ( global 4X4 matrix of float)
+0:102          's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:102          Constant:
+0:102            2 (const int)
+0:102        Constant:
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:104      move second child to first child ( temp 4-component vector of float)
+0:104        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:104          'a17' (layout( location=46) smooth out 4-element array of 4-component vector of float)
+0:104          i: direct index for structure (layout( column_major shared) uniform int)
+0:104            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:104            Constant:
+0:104              0 (const int)
+0:104        Constant:
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:105      move second child to first child ( temp 4-component vector of float)
+0:105        direct index ( temp 4-component vector of float)
+0:105          a18: direct index for structure ( out 10-element array of 4-component vector of float)
+0:105            'anon@4' (layout( location=50) out block{ out 10-element array of 4-component vector of float a18})
+0:105            Constant:
+0:105              0 (const uint)
+0:105          Constant:
+0:105            5 (const int)
+0:105        Constant:
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:106      move second child to first child ( temp 2-component vector of float)
+0:106        a19: direct index for structure (layout( location=60) out 2-component vector of float)
+0:106          'anon@5' ( out block{layout( location=60) out 2-component vector of float a19})
+0:106          Constant:
+0:106            0 (const uint)
+0:106        Constant:
+0:106          0.000000
+0:106          0.000000
+0:107      move second child to first child ( temp 4-component vector of float)
+0:107        a20: direct index for structure ( out 4-component vector of float)
+0:107          'anon@6' ( out block{ out 4-component vector of float a20})
+0:107          Constant:
+0:107            0 (const uint)
+0:107        Constant:
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:108      move second child to first child ( temp 2-component vector of float)
+0:108        direct index ( smooth temp 2-component vector of float)
+0:108          'a21' ( smooth out 2-element array of 2-component vector of float)
+0:108          Constant:
+0:108            0 (const int)
+0:108        Constant:
+0:108          0.000000
+0:108          0.000000
+0:109      move second child to first child ( temp 2-component vector of float)
+0:109        direct index ( smooth temp 2-component vector of float)
+0:109          'a21' ( smooth out 2-element array of 2-component vector of float)
+0:109          Constant:
+0:109            1 (const int)
+0:109        Constant:
+0:109          0.000000
+0:109          0.000000
+0:?   Linker Objects
+0:?     'a0' (layout( location=40) smooth out 4-component vector of float)
+0:?     'anon@0' (layout( location=1) out block{ out 4-component vector of float a1})
+0:?     'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:?     'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:?     'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:?     'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:?     'a12' (layout( location=27) smooth out 3-element array of float)
+0:?     's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:?     'a16' (layout( location=39) smooth out float)
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'a17' (layout( location=46) smooth out 4-element array of 4-component vector of float)
+0:?     'anon@4' (layout( location=50) out block{ out 10-element array of 4-component vector of float a18})
+0:?     'anon@5' ( out block{layout( location=60) out 2-component vector of float a19})
+0:?     'anon@6' ( out block{ out 4-component vector of float a20})
+0:?     'a21' ( smooth out 2-element array of 2-component vector of float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+Shader version: 460
+0:? Sequence
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        'o' ( out 4-component vector of float)
+0:76        b1: direct index for structure ( in 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp 4-component vector of float)
+0:77        'o' ( out 4-component vector of float)
+0:77        b2: direct index for structure ( in 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp 4-component vector of float)
+0:78        'o' ( out 4-component vector of float)
+0:78        b3: direct index for structure ( in 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp 4-component vector of float)
+0:79        'o' ( out 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp 4-component vector of float)
+0:80        'o' ( out 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp 4-component vector of float)
+0:81        'o' ( out 4-component vector of float)
+0:81        b5: direct index for structure ( in 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp 4-component vector of float)
+0:82        'o' ( out 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp 4-component vector of float)
+0:83        'o' ( out 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp 4-component vector of float)
+0:84        'o' ( out 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp 4-component vector of float)
+0:85        'o' ( out 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp 4-component vector of float)
+0:86        'o' ( out 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp 4-component vector of float)
+0:87        'o' ( out 4-component vector of float)
+0:87        Construct vec4 ( temp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp 4-component vector of float)
+0:88        'o' ( out 4-component vector of float)
+0:88        vector swizzle ( temp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp 4-component vector of float)
+0:89        'o' ( out 4-component vector of float)
+0:89        Construct vec4 ( temp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in float)
+0:89            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp 4-component vector of float)
+0:90        'o' ( out 4-component vector of float)
+0:90        vector swizzle ( temp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp 4-component vector of float)
+0:91        'o' ( out 4-component vector of float)
+0:91        Construct vec4 ( temp 4-component vector of float)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp 4-component vector of float)
+0:92        'o' ( out 4-component vector of float)
+0:92        Construct vec4 ( temp 4-component vector of float)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp float)
+0:92            add ( temp float)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp float)
+0:92              b12: direct index for structure ( in 6-element array of float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp 4-component vector of float)
+0:93        'o' ( out 4-component vector of float)
+0:93        Construct vec4 ( temp 4-component vector of float)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp 4-component vector of float)
+0:95            'o' ( out 4-component vector of float)
+0:95            vector swizzle ( temp 4-component vector of float)
+0:95              matrix-times-vector ( temp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp 4-component vector of float)
+0:96            'o' ( out 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp 4-component vector of float)
+0:97            'o' ( out 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp 4-component vector of float)
+0:99        'o' ( out 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major shared) uniform int)
+0:99            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp 4-component vector of float)
+0:100        'o' ( out 4-component vector of float)
+0:100        indirect index ( temp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major shared) uniform int)
+0:100            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp 4-component vector of float)
+0:101        'o' ( out 4-component vector of float)
+0:101        vector swizzle ( temp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp 4-component vector of float)
+0:102        'o' ( out 4-component vector of float)
+0:102        a20: direct index for structure ( in 4-component vector of float)
+0:102          'anon@8' ( in block{ in 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp 4-component vector of float)
+0:103        'o' ( out 4-component vector of float)
+0:103        Construct vec4 ( temp 4-component vector of float)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of float)
+0:?     'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:?     'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:?     'b16' ( flat in uint)
+0:?     'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in 2-component vector of float)
+0:?     'anon@8' ( in block{ in 4-component vector of float a20})
+0:?     'a21' ( smooth in 2-element array of 2-component vector of float)
+0:?     'o' ( out 4-component vector of float)
+

--- a/Test/baseResults/link.crossStageIO.1.vert.out
+++ b/Test/baseResults/link.crossStageIO.1.vert.out
@@ -1,0 +1,1898 @@
+link.crossStageIO.1.vert
+Shader version: 460
+0:? Sequence
+0:66  Function Definition: main( ( global void)
+0:66    Function Parameters: 
+0:67    Sequence
+0:67      Test condition and select ( temp void)
+0:67        Condition
+0:67        Constant:
+0:67          false (const bool)
+0:67        true case
+0:68        Sequence
+0:68          move second child to first child ( temp 4-component vector of float)
+0:68            'a0' (layout( location=40) smooth out 4-component vector of float)
+0:68            Constant:
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:70      move second child to first child ( temp 4-component vector of float)
+0:70        a1: direct index for structure ( out 4-component vector of float)
+0:70          'anon@0' (layout( location=1) out block{ out 4-component vector of float a1})
+0:70          Constant:
+0:70            0 (const uint)
+0:70        Constant:
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:71      move second child to first child ( temp 4-component vector of float)
+0:71        a2: direct index for structure (layout( location=3) out 4-component vector of float)
+0:71          'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:71          Constant:
+0:71            0 (const uint)
+0:71        Constant:
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:72      move second child to first child ( temp 4-component vector of float)
+0:72        a3: direct index for structure (layout( location=2) out 4-component vector of float)
+0:72          'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:72          Constant:
+0:72            1 (const uint)
+0:72        Constant:
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:73      move second child to first child ( temp 4-component vector of float)
+0:73        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:73          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:73          Constant:
+0:73            0 (const int)
+0:73        Constant:
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:74      move second child to first child ( temp 4-component vector of float)
+0:74        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:74          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:74          Constant:
+0:74            1 (const int)
+0:74        Constant:
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:75      move second child to first child ( temp 4-component vector of float)
+0:75        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:75          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:75          Constant:
+0:75            2 (const int)
+0:75        Constant:
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        a5: direct index for structure (layout( location=4) out 4-component vector of float)
+0:76          'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        Constant:
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:77      move second child to first child ( temp 4-component vector of float)
+0:77        direct index (layout( location=8) temp 4-component vector of float)
+0:77          a6: direct index for structure (layout( location=8) out 2-element array of 4-component vector of float)
+0:77            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:77            Constant:
+0:77              1 (const uint)
+0:77          Constant:
+0:77            0 (const int)
+0:77        Constant:
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:78      move second child to first child ( temp 4-component vector of float)
+0:78        direct index (layout( location=8) temp 4-component vector of float)
+0:78          a6: direct index for structure (layout( location=8) out 2-element array of 4-component vector of float)
+0:78            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:78            Constant:
+0:78              1 (const uint)
+0:78          Constant:
+0:78            1 (const int)
+0:78        Constant:
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:79      move second child to first child ( temp 4-component vector of float)
+0:79        direct index (layout( location=10) temp 4-component vector of float)
+0:79          a7: direct index for structure (layout( location=10) out 2-element array of 4-component vector of float)
+0:79            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:79            Constant:
+0:79              2 (const uint)
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:80      move second child to first child ( temp 4-component vector of float)
+0:80        direct index (layout( location=10) temp 4-component vector of float)
+0:80          a7: direct index for structure (layout( location=10) out 2-element array of 4-component vector of float)
+0:80            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:80            Constant:
+0:80              2 (const uint)
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:81      move second child to first child ( temp float)
+0:81        a8: direct index for structure (layout( location=12) out float)
+0:81          'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:81          Constant:
+0:81            0 (const uint)
+0:81        Constant:
+0:81          0.000000
+0:82      move second child to first child ( temp float)
+0:82        direct index ( temp float)
+0:82          direct index (layout( location=15) temp 2-component vector of float)
+0:82            a9: direct index for structure (layout( location=15) out 2-element array of 2-component vector of float)
+0:82              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:82              Constant:
+0:82                1 (const uint)
+0:82            Constant:
+0:82              0 (const int)
+0:82          Constant:
+0:82            0 (const int)
+0:82        Constant:
+0:82          0.000000
+0:83      move second child to first child ( temp float)
+0:83        direct index ( temp float)
+0:83          direct index (layout( location=15) temp 2-component vector of float)
+0:83            a9: direct index for structure (layout( location=15) out 2-element array of 2-component vector of float)
+0:83              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:83              Constant:
+0:83                1 (const uint)
+0:83            Constant:
+0:83              1 (const int)
+0:83          Constant:
+0:83            1 (const int)
+0:83        Constant:
+0:83          0.000000
+0:84      move second child to first child ( temp 4-component vector of float)
+0:84        direct index (layout( location=17) temp 4-component vector of float)
+0:84          a10: direct index for structure (layout( location=17) out 2-element array of 4-component vector of float)
+0:84            'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:84            Constant:
+0:84              2 (const uint)
+0:84          Constant:
+0:84            0 (const int)
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:85      move second child to first child ( temp 4-component vector of float)
+0:85        direct index (layout( location=17) temp 4-component vector of float)
+0:85          a10: direct index for structure (layout( location=17) out 2-element array of 4-component vector of float)
+0:85            'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:85            Constant:
+0:85              2 (const uint)
+0:85          Constant:
+0:85            1 (const int)
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:86      move second child to first child ( temp float)
+0:86        direct index ( temp float)
+0:86          a: direct index for structure ( global 3-element array of float)
+0:86            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:86              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:86                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:86                Constant:
+0:86                  3 (const uint)
+0:86              Constant:
+0:86                0 (const int)
+0:86            Constant:
+0:86              0 (const int)
+0:86          Constant:
+0:86            0 (const int)
+0:86        Constant:
+0:86          0.000000
+0:87      move second child to first child ( temp float)
+0:87        direct index ( temp float)
+0:87          a: direct index for structure ( global 3-element array of float)
+0:87            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:87              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:87                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:87                Constant:
+0:87                  3 (const uint)
+0:87              Constant:
+0:87                0 (const int)
+0:87            Constant:
+0:87              0 (const int)
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          0.000000
+0:88      move second child to first child ( temp float)
+0:88        direct index ( temp float)
+0:88          a: direct index for structure ( global 3-element array of float)
+0:88            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:88              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:88                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:88                Constant:
+0:88                  3 (const uint)
+0:88              Constant:
+0:88                0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88          Constant:
+0:88            2 (const int)
+0:88        Constant:
+0:88          0.000000
+0:89      move second child to first child ( temp float)
+0:89        b: direct index for structure ( global float)
+0:89          direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:89            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:89              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:89              Constant:
+0:89                3 (const uint)
+0:89            Constant:
+0:89              0 (const int)
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          0.000000
+0:90      move second child to first child ( temp float)
+0:90        direct index ( temp float)
+0:90          a: direct index for structure ( global 3-element array of float)
+0:90            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:90              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:90                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:90                Constant:
+0:90                  3 (const uint)
+0:90              Constant:
+0:90                1 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:90          Constant:
+0:90            0 (const int)
+0:90        Constant:
+0:90          0.000000
+0:91      move second child to first child ( temp float)
+0:91        direct index ( temp float)
+0:91          a: direct index for structure ( global 3-element array of float)
+0:91            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:91              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:91                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:91                Constant:
+0:91                  3 (const uint)
+0:91              Constant:
+0:91                1 (const int)
+0:91            Constant:
+0:91              0 (const int)
+0:91          Constant:
+0:91            1 (const int)
+0:91        Constant:
+0:91          0.000000
+0:92      move second child to first child ( temp float)
+0:92        direct index ( temp float)
+0:92          a: direct index for structure ( global 3-element array of float)
+0:92            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:92              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:92                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:92                Constant:
+0:92                  3 (const uint)
+0:92              Constant:
+0:92                1 (const int)
+0:92            Constant:
+0:92              0 (const int)
+0:92          Constant:
+0:92            2 (const int)
+0:92        Constant:
+0:92          0.000000
+0:93      move second child to first child ( temp float)
+0:93        b: direct index for structure ( global float)
+0:93          direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:93            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:93              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:93              Constant:
+0:93                3 (const uint)
+0:93            Constant:
+0:93              1 (const int)
+0:93          Constant:
+0:93            1 (const int)
+0:93        Constant:
+0:93          0.000000
+0:94      move second child to first child ( temp float)
+0:94        direct index (layout( location=27) smooth temp float)
+0:94          'a12' (layout( location=27) smooth out 3-element array of float)
+0:94          Constant:
+0:94            0 (const int)
+0:94        Constant:
+0:94          0.000000
+0:95      move second child to first child ( temp float)
+0:95        direct index (layout( location=27) smooth temp float)
+0:95          'a12' (layout( location=27) smooth out 3-element array of float)
+0:95          Constant:
+0:95            1 (const int)
+0:95        Constant:
+0:95          0.000000
+0:96      move second child to first child ( temp float)
+0:96        direct index (layout( location=27) smooth temp float)
+0:96          'a12' (layout( location=27) smooth out 3-element array of float)
+0:96          Constant:
+0:96            2 (const int)
+0:96        Constant:
+0:96          0.000000
+0:97      move second child to first child ( temp float)
+0:97        direct index ( temp float)
+0:97          a13: direct index for structure ( global 2-component vector of float)
+0:97            's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:97            Constant:
+0:97              0 (const int)
+0:97          Constant:
+0:97            1 (const int)
+0:97        Constant:
+0:97          0.000000
+0:98      move second child to first child ( temp float)
+0:98        direct index ( temp float)
+0:98          a: direct index for structure ( global 3-element array of float)
+0:98            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:98              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:98              Constant:
+0:98                1 (const int)
+0:98            Constant:
+0:98              0 (const int)
+0:98          Constant:
+0:98            0 (const int)
+0:98        Constant:
+0:98          0.000000
+0:99      move second child to first child ( temp float)
+0:99        direct index ( temp float)
+0:99          a: direct index for structure ( global 3-element array of float)
+0:99            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:99              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:99              Constant:
+0:99                1 (const int)
+0:99            Constant:
+0:99              0 (const int)
+0:99          Constant:
+0:99            1 (const int)
+0:99        Constant:
+0:99          0.000000
+0:100      move second child to first child ( temp float)
+0:100        direct index ( temp float)
+0:100          a: direct index for structure ( global 3-element array of float)
+0:100            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:100              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:100              Constant:
+0:100                1 (const int)
+0:100            Constant:
+0:100              0 (const int)
+0:100          Constant:
+0:100            2 (const int)
+0:100        Constant:
+0:100          0.000000
+0:101      move second child to first child ( temp float)
+0:101        b: direct index for structure ( global float)
+0:101          a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:101            's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:101            Constant:
+0:101              1 (const int)
+0:101          Constant:
+0:101            1 (const int)
+0:101        Constant:
+0:101          0.000000
+0:102      move second child to first child ( temp 4X4 matrix of float)
+0:102        a15: direct index for structure ( global 4X4 matrix of float)
+0:102          's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:102          Constant:
+0:102            2 (const int)
+0:102        Constant:
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:104      move second child to first child ( temp 4-component vector of float)
+0:104        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:104          'a17' (layout( location=46) smooth out 4-element array of 4-component vector of float)
+0:104          i: direct index for structure (layout( column_major shared) uniform int)
+0:104            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:104            Constant:
+0:104              0 (const int)
+0:104        Constant:
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:105      move second child to first child ( temp 4-component vector of float)
+0:105        direct index ( temp 4-component vector of float)
+0:105          a18: direct index for structure ( out 10-element array of 4-component vector of float)
+0:105            'anon@4' (layout( location=50) out block{ out 10-element array of 4-component vector of float a18})
+0:105            Constant:
+0:105              0 (const uint)
+0:105          Constant:
+0:105            5 (const int)
+0:105        Constant:
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:106      move second child to first child ( temp 2-component vector of float)
+0:106        a19: direct index for structure (layout( location=60) out 2-component vector of float)
+0:106          'anon@5' ( out block{layout( location=60) out 2-component vector of float a19})
+0:106          Constant:
+0:106            0 (const uint)
+0:106        Constant:
+0:106          0.000000
+0:106          0.000000
+0:107      move second child to first child ( temp 4-component vector of float)
+0:107        a20: direct index for structure ( out 4-component vector of float)
+0:107          'anon@6' ( out block{ out 4-component vector of float a20})
+0:107          Constant:
+0:107            0 (const uint)
+0:107        Constant:
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:108      move second child to first child ( temp 2-component vector of float)
+0:108        direct index ( smooth temp 2-component vector of float)
+0:108          'a21' ( smooth out 2-element array of 2-component vector of float)
+0:108          Constant:
+0:108            0 (const int)
+0:108        Constant:
+0:108          0.000000
+0:108          0.000000
+0:109      move second child to first child ( temp 2-component vector of float)
+0:109        direct index ( smooth temp 2-component vector of float)
+0:109          'a21' ( smooth out 2-element array of 2-component vector of float)
+0:109          Constant:
+0:109            1 (const int)
+0:109        Constant:
+0:109          0.000000
+0:109          0.000000
+0:?   Linker Objects
+0:?     'a0' (layout( location=40) smooth out 4-component vector of float)
+0:?     'anon@0' (layout( location=1) out block{ out 4-component vector of float a1})
+0:?     'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:?     'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:?     'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:?     'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:?     'a12' (layout( location=27) smooth out 3-element array of float)
+0:?     's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:?     'a16' (layout( location=39) smooth out float)
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'a17' (layout( location=46) smooth out 4-element array of 4-component vector of float)
+0:?     'anon@4' (layout( location=50) out block{ out 10-element array of 4-component vector of float a18})
+0:?     'anon@5' ( out block{layout( location=60) out 2-component vector of float a19})
+0:?     'anon@6' ( out block{ out 4-component vector of float a20})
+0:?     'a21' ( smooth out 2-element array of 2-component vector of float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+link.crossStageIO.1.geom
+Shader version: 460
+invocations = -1
+max_vertices = 3
+input primitive = triangles
+output primitive = triangle_strip
+0:? Sequence
+0:28  Function Definition: main( ( global void)
+0:28    Function Parameters: 
+0:29    Sequence
+0:29      Sequence
+0:29        Sequence
+0:29          move second child to first child ( temp int)
+0:29            'i' ( temp int)
+0:29            Constant:
+0:29              0 (const int)
+0:29        Loop with condition tested first
+0:29          Loop Condition
+0:29          Compare Less Than ( temp bool)
+0:29            'i' ( temp int)
+0:29            Constant:
+0:29              32 (const int)
+0:29          Loop Body
+0:30          Sequence
+0:30            move second child to first child ( temp 4-component vector of float)
+0:30              indirect index (layout( location=0 stream=0) temp 4-component vector of float)
+0:30                'o0' (layout( location=0 stream=0) out 64-element array of 4-component vector of float)
+0:30                'i' ( temp int)
+0:30              indirect index (layout( location=0) temp 4-component vector of float)
+0:30                a0: direct index for structure (layout( location=0) in 64-element array of 4-component vector of float)
+0:30                  direct index ( temp block{layout( location=0) in 64-element array of 4-component vector of float a0})
+0:30                    'gs_in1' ( in 3-element array of block{layout( location=0) in 64-element array of 4-component vector of float a0})
+0:30                    Constant:
+0:30                      0 (const int)
+0:30                  Constant:
+0:30                    0 (const int)
+0:30                'i' ( temp int)
+0:29          Loop Terminal Expression
+0:29          Pre-Increment ( temp int)
+0:29            'i' ( temp int)
+0:33      move second child to first child ( temp 4-component vector of float)
+0:33        a20: direct index for structure (layout( stream=0) out 4-component vector of float)
+0:33          'gs_out0' (layout( stream=0) out block{layout( stream=0) out 4-component vector of float a20})
+0:33          Constant:
+0:33            0 (const int)
+0:33        a20: direct index for structure ( in 4-component vector of float)
+0:33          direct index ( temp block{ in 4-component vector of float a20})
+0:33            'gs_in0' ( in 3-element array of block{ in 4-component vector of float a20})
+0:33            Constant:
+0:33              0 (const int)
+0:33          Constant:
+0:33            0 (const int)
+0:34      move second child to first child ( temp 2-component vector of float)
+0:34        direct index (layout( stream=0) temp 2-component vector of float)
+0:34          'g_a21' (layout( stream=0) out 2-element array of 2-component vector of float)
+0:34          Constant:
+0:34            0 (const int)
+0:34        direct index ( temp 2-component vector of float)
+0:34          direct index ( temp 2-element array of 2-component vector of float)
+0:34            'a21' ( in 3-element array of 2-element array of 2-component vector of float)
+0:34            Constant:
+0:34              0 (const int)
+0:34          Constant:
+0:34            0 (const int)
+0:35      move second child to first child ( temp 2-component vector of float)
+0:35        direct index (layout( stream=0) temp 2-component vector of float)
+0:35          'g_a21' (layout( stream=0) out 2-element array of 2-component vector of float)
+0:35          Constant:
+0:35            0 (const int)
+0:35        direct index ( temp 2-component vector of float)
+0:35          direct index ( temp 2-element array of 2-component vector of float)
+0:35            'a21' ( in 3-element array of 2-element array of 2-component vector of float)
+0:35            Constant:
+0:35              0 (const int)
+0:35          Constant:
+0:35            1 (const int)
+0:37      move second child to first child ( temp 4-component vector of float)
+0:37        gl_Position: direct index for structure (layout( stream=0) gl_Position 4-component vector of float Position)
+0:37          'anon@0' (layout( stream=0) out block{layout( stream=0) gl_Position 4-component vector of float Position gl_Position, layout( stream=0) gl_PointSize float PointSize gl_PointSize, layout( stream=0) out unsized 1-element array of float ClipDistance gl_ClipDistance, layout( stream=0) out unsized 1-element array of float CullDistance gl_CullDistance})
+0:37          Constant:
+0:37            0 (const uint)
+0:37        Constant:
+0:37          0.000000
+0:37          0.000000
+0:37          0.000000
+0:37          0.000000
+0:39      EmitVertex ( global void)
+0:40      EmitVertex ( global void)
+0:41      EmitVertex ( global void)
+0:?   Linker Objects
+0:?     'gs_in0' ( in 3-element array of block{ in 4-component vector of float a20})
+0:?     'a21' ( in 3-element array of 2-element array of 2-component vector of float)
+0:?     'gs_out0' (layout( stream=0) out block{layout( stream=0) out 4-component vector of float a20})
+0:?     'g_a21' (layout( stream=0) out 2-element array of 2-component vector of float)
+0:?     'gs_in1' ( in 3-element array of block{layout( location=0) in 64-element array of 4-component vector of float a0})
+0:?     'o0' (layout( location=0 stream=0) out 64-element array of 4-component vector of float)
+0:?     'anon@0' (layout( stream=0) out block{layout( stream=0) gl_Position 4-component vector of float Position gl_Position, layout( stream=0) gl_PointSize float PointSize gl_PointSize, layout( stream=0) out unsized 1-element array of float ClipDistance gl_ClipDistance, layout( stream=0) out unsized 1-element array of float CullDistance gl_CullDistance})
+
+link.crossStageIO.1.frag
+Shader version: 460
+0:? Sequence
+0:71  Function Definition: uncalled( ( global uint)
+0:71    Function Parameters: 
+0:72    Sequence
+0:72      Branch: Return with expression
+0:72        'b16' ( flat in uint)
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        'o' ( out 4-component vector of float)
+0:76        b1: direct index for structure ( in 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp 4-component vector of float)
+0:77        'o' ( out 4-component vector of float)
+0:77        b2: direct index for structure ( in 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp 4-component vector of float)
+0:78        'o' ( out 4-component vector of float)
+0:78        b3: direct index for structure ( in 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp 4-component vector of float)
+0:79        'o' ( out 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp 4-component vector of float)
+0:80        'o' ( out 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp 4-component vector of float)
+0:81        'o' ( out 4-component vector of float)
+0:81        b5: direct index for structure ( in 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp 4-component vector of float)
+0:82        'o' ( out 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp 4-component vector of float)
+0:83        'o' ( out 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp 4-component vector of float)
+0:84        'o' ( out 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp 4-component vector of float)
+0:85        'o' ( out 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp 4-component vector of float)
+0:86        'o' ( out 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp 4-component vector of float)
+0:87        'o' ( out 4-component vector of float)
+0:87        Construct vec4 ( temp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp 4-component vector of float)
+0:88        'o' ( out 4-component vector of float)
+0:88        vector swizzle ( temp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp 4-component vector of float)
+0:89        'o' ( out 4-component vector of float)
+0:89        Construct vec4 ( temp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in float)
+0:89            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp 4-component vector of float)
+0:90        'o' ( out 4-component vector of float)
+0:90        vector swizzle ( temp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp 4-component vector of float)
+0:91        'o' ( out 4-component vector of float)
+0:91        Construct vec4 ( temp 4-component vector of float)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp 4-component vector of float)
+0:92        'o' ( out 4-component vector of float)
+0:92        Construct vec4 ( temp 4-component vector of float)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp float)
+0:92            add ( temp float)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp float)
+0:92              b12: direct index for structure ( in 6-element array of float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp 4-component vector of float)
+0:93        'o' ( out 4-component vector of float)
+0:93        Construct vec4 ( temp 4-component vector of float)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp 4-component vector of float)
+0:95            'o' ( out 4-component vector of float)
+0:95            vector swizzle ( temp 4-component vector of float)
+0:95              matrix-times-vector ( temp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp 4-component vector of float)
+0:96            'o' ( out 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp 4-component vector of float)
+0:97            'o' ( out 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp 4-component vector of float)
+0:99        'o' ( out 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major shared) uniform int)
+0:99            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp 4-component vector of float)
+0:100        'o' ( out 4-component vector of float)
+0:100        indirect index ( temp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major shared) uniform int)
+0:100            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp 4-component vector of float)
+0:101        'o' ( out 4-component vector of float)
+0:101        vector swizzle ( temp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp 4-component vector of float)
+0:102        'o' ( out 4-component vector of float)
+0:102        a20: direct index for structure ( in 4-component vector of float)
+0:102          'anon@8' ( in block{ in 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp 4-component vector of float)
+0:103        'o' ( out 4-component vector of float)
+0:103        Construct vec4 ( temp 4-component vector of float)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'g_a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'g_a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of float)
+0:?     'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:?     'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:?     'b16' ( flat in uint)
+0:?     'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in 2-component vector of float)
+0:?     'anon@8' ( in block{ in 4-component vector of float a20})
+0:?     'g_a21' ( smooth in 2-element array of 2-component vector of float)
+0:?     'o' ( out 4-component vector of float)
+
+
+Linked vertex stage:
+
+
+Linked geometry stage:
+
+
+Linked fragment stage:
+
+
+Shader version: 460
+0:? Sequence
+0:66  Function Definition: main( ( global void)
+0:66    Function Parameters: 
+0:67    Sequence
+0:67      Test condition and select ( temp void)
+0:67        Condition
+0:67        Constant:
+0:67          false (const bool)
+0:67        true case
+0:68        Sequence
+0:68          move second child to first child ( temp 4-component vector of float)
+0:68            'a0' (layout( location=40) smooth out 4-component vector of float)
+0:68            Constant:
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:70      move second child to first child ( temp 4-component vector of float)
+0:70        a1: direct index for structure ( out 4-component vector of float)
+0:70          'anon@0' (layout( location=1) out block{ out 4-component vector of float a1})
+0:70          Constant:
+0:70            0 (const uint)
+0:70        Constant:
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:71      move second child to first child ( temp 4-component vector of float)
+0:71        a2: direct index for structure (layout( location=3) out 4-component vector of float)
+0:71          'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:71          Constant:
+0:71            0 (const uint)
+0:71        Constant:
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:72      move second child to first child ( temp 4-component vector of float)
+0:72        a3: direct index for structure (layout( location=2) out 4-component vector of float)
+0:72          'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:72          Constant:
+0:72            1 (const uint)
+0:72        Constant:
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:73      move second child to first child ( temp 4-component vector of float)
+0:73        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:73          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:73          Constant:
+0:73            0 (const int)
+0:73        Constant:
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:74      move second child to first child ( temp 4-component vector of float)
+0:74        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:74          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:74          Constant:
+0:74            1 (const int)
+0:74        Constant:
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:75      move second child to first child ( temp 4-component vector of float)
+0:75        direct index (layout( location=5) smooth temp 4-component vector of float)
+0:75          'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:75          Constant:
+0:75            2 (const int)
+0:75        Constant:
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        a5: direct index for structure (layout( location=4) out 4-component vector of float)
+0:76          'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        Constant:
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:77      move second child to first child ( temp 4-component vector of float)
+0:77        direct index (layout( location=8) temp 4-component vector of float)
+0:77          a6: direct index for structure (layout( location=8) out 2-element array of 4-component vector of float)
+0:77            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:77            Constant:
+0:77              1 (const uint)
+0:77          Constant:
+0:77            0 (const int)
+0:77        Constant:
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:78      move second child to first child ( temp 4-component vector of float)
+0:78        direct index (layout( location=8) temp 4-component vector of float)
+0:78          a6: direct index for structure (layout( location=8) out 2-element array of 4-component vector of float)
+0:78            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:78            Constant:
+0:78              1 (const uint)
+0:78          Constant:
+0:78            1 (const int)
+0:78        Constant:
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:79      move second child to first child ( temp 4-component vector of float)
+0:79        direct index (layout( location=10) temp 4-component vector of float)
+0:79          a7: direct index for structure (layout( location=10) out 2-element array of 4-component vector of float)
+0:79            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:79            Constant:
+0:79              2 (const uint)
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:80      move second child to first child ( temp 4-component vector of float)
+0:80        direct index (layout( location=10) temp 4-component vector of float)
+0:80          a7: direct index for structure (layout( location=10) out 2-element array of 4-component vector of float)
+0:80            'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:80            Constant:
+0:80              2 (const uint)
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:81      move second child to first child ( temp float)
+0:81        a8: direct index for structure (layout( location=12) out float)
+0:81          'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:81          Constant:
+0:81            0 (const uint)
+0:81        Constant:
+0:81          0.000000
+0:82      move second child to first child ( temp float)
+0:82        direct index ( temp float)
+0:82          direct index (layout( location=15) temp 2-component vector of float)
+0:82            a9: direct index for structure (layout( location=15) out 2-element array of 2-component vector of float)
+0:82              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:82              Constant:
+0:82                1 (const uint)
+0:82            Constant:
+0:82              0 (const int)
+0:82          Constant:
+0:82            0 (const int)
+0:82        Constant:
+0:82          0.000000
+0:83      move second child to first child ( temp float)
+0:83        direct index ( temp float)
+0:83          direct index (layout( location=15) temp 2-component vector of float)
+0:83            a9: direct index for structure (layout( location=15) out 2-element array of 2-component vector of float)
+0:83              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:83              Constant:
+0:83                1 (const uint)
+0:83            Constant:
+0:83              1 (const int)
+0:83          Constant:
+0:83            1 (const int)
+0:83        Constant:
+0:83          0.000000
+0:84      move second child to first child ( temp 4-component vector of float)
+0:84        direct index (layout( location=17) temp 4-component vector of float)
+0:84          a10: direct index for structure (layout( location=17) out 2-element array of 4-component vector of float)
+0:84            'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:84            Constant:
+0:84              2 (const uint)
+0:84          Constant:
+0:84            0 (const int)
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:85      move second child to first child ( temp 4-component vector of float)
+0:85        direct index (layout( location=17) temp 4-component vector of float)
+0:85          a10: direct index for structure (layout( location=17) out 2-element array of 4-component vector of float)
+0:85            'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:85            Constant:
+0:85              2 (const uint)
+0:85          Constant:
+0:85            1 (const int)
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:86      move second child to first child ( temp float)
+0:86        direct index ( temp float)
+0:86          a: direct index for structure ( global 3-element array of float)
+0:86            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:86              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:86                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:86                Constant:
+0:86                  3 (const uint)
+0:86              Constant:
+0:86                0 (const int)
+0:86            Constant:
+0:86              0 (const int)
+0:86          Constant:
+0:86            0 (const int)
+0:86        Constant:
+0:86          0.000000
+0:87      move second child to first child ( temp float)
+0:87        direct index ( temp float)
+0:87          a: direct index for structure ( global 3-element array of float)
+0:87            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:87              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:87                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:87                Constant:
+0:87                  3 (const uint)
+0:87              Constant:
+0:87                0 (const int)
+0:87            Constant:
+0:87              0 (const int)
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          0.000000
+0:88      move second child to first child ( temp float)
+0:88        direct index ( temp float)
+0:88          a: direct index for structure ( global 3-element array of float)
+0:88            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:88              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:88                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:88                Constant:
+0:88                  3 (const uint)
+0:88              Constant:
+0:88                0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88          Constant:
+0:88            2 (const int)
+0:88        Constant:
+0:88          0.000000
+0:89      move second child to first child ( temp float)
+0:89        b: direct index for structure ( global float)
+0:89          direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:89            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:89              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:89              Constant:
+0:89                3 (const uint)
+0:89            Constant:
+0:89              0 (const int)
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          0.000000
+0:90      move second child to first child ( temp float)
+0:90        direct index ( temp float)
+0:90          a: direct index for structure ( global 3-element array of float)
+0:90            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:90              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:90                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:90                Constant:
+0:90                  3 (const uint)
+0:90              Constant:
+0:90                1 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:90          Constant:
+0:90            0 (const int)
+0:90        Constant:
+0:90          0.000000
+0:91      move second child to first child ( temp float)
+0:91        direct index ( temp float)
+0:91          a: direct index for structure ( global 3-element array of float)
+0:91            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:91              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:91                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:91                Constant:
+0:91                  3 (const uint)
+0:91              Constant:
+0:91                1 (const int)
+0:91            Constant:
+0:91              0 (const int)
+0:91          Constant:
+0:91            1 (const int)
+0:91        Constant:
+0:91          0.000000
+0:92      move second child to first child ( temp float)
+0:92        direct index ( temp float)
+0:92          a: direct index for structure ( global 3-element array of float)
+0:92            direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:92              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:92                'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:92                Constant:
+0:92                  3 (const uint)
+0:92              Constant:
+0:92                1 (const int)
+0:92            Constant:
+0:92              0 (const int)
+0:92          Constant:
+0:92            2 (const int)
+0:92        Constant:
+0:92          0.000000
+0:93      move second child to first child ( temp float)
+0:93        b: direct index for structure ( global float)
+0:93          direct index (layout( location=19) temp structure{ global 3-element array of float a,  global float b})
+0:93            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b})
+0:93              'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:93              Constant:
+0:93                3 (const uint)
+0:93            Constant:
+0:93              1 (const int)
+0:93          Constant:
+0:93            1 (const int)
+0:93        Constant:
+0:93          0.000000
+0:94      move second child to first child ( temp float)
+0:94        direct index (layout( location=27) smooth temp float)
+0:94          'a12' (layout( location=27) smooth out 3-element array of float)
+0:94          Constant:
+0:94            0 (const int)
+0:94        Constant:
+0:94          0.000000
+0:95      move second child to first child ( temp float)
+0:95        direct index (layout( location=27) smooth temp float)
+0:95          'a12' (layout( location=27) smooth out 3-element array of float)
+0:95          Constant:
+0:95            1 (const int)
+0:95        Constant:
+0:95          0.000000
+0:96      move second child to first child ( temp float)
+0:96        direct index (layout( location=27) smooth temp float)
+0:96          'a12' (layout( location=27) smooth out 3-element array of float)
+0:96          Constant:
+0:96            2 (const int)
+0:96        Constant:
+0:96          0.000000
+0:97      move second child to first child ( temp float)
+0:97        direct index ( temp float)
+0:97          a13: direct index for structure ( global 2-component vector of float)
+0:97            's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:97            Constant:
+0:97              0 (const int)
+0:97          Constant:
+0:97            1 (const int)
+0:97        Constant:
+0:97          0.000000
+0:98      move second child to first child ( temp float)
+0:98        direct index ( temp float)
+0:98          a: direct index for structure ( global 3-element array of float)
+0:98            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:98              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:98              Constant:
+0:98                1 (const int)
+0:98            Constant:
+0:98              0 (const int)
+0:98          Constant:
+0:98            0 (const int)
+0:98        Constant:
+0:98          0.000000
+0:99      move second child to first child ( temp float)
+0:99        direct index ( temp float)
+0:99          a: direct index for structure ( global 3-element array of float)
+0:99            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:99              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:99              Constant:
+0:99                1 (const int)
+0:99            Constant:
+0:99              0 (const int)
+0:99          Constant:
+0:99            1 (const int)
+0:99        Constant:
+0:99          0.000000
+0:100      move second child to first child ( temp float)
+0:100        direct index ( temp float)
+0:100          a: direct index for structure ( global 3-element array of float)
+0:100            a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:100              's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:100              Constant:
+0:100                1 (const int)
+0:100            Constant:
+0:100              0 (const int)
+0:100          Constant:
+0:100            2 (const int)
+0:100        Constant:
+0:100          0.000000
+0:101      move second child to first child ( temp float)
+0:101        b: direct index for structure ( global float)
+0:101          a14: direct index for structure ( global structure{ global 3-element array of float a,  global float b})
+0:101            's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:101            Constant:
+0:101              1 (const int)
+0:101          Constant:
+0:101            1 (const int)
+0:101        Constant:
+0:101          0.000000
+0:102      move second child to first child ( temp 4X4 matrix of float)
+0:102        a15: direct index for structure ( global 4X4 matrix of float)
+0:102          's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:102          Constant:
+0:102            2 (const int)
+0:102        Constant:
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:104      move second child to first child ( temp 4-component vector of float)
+0:104        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:104          'a17' (layout( location=46) smooth out 4-element array of 4-component vector of float)
+0:104          i: direct index for structure (layout( column_major shared) uniform int)
+0:104            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:104            Constant:
+0:104              0 (const int)
+0:104        Constant:
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:105      move second child to first child ( temp 4-component vector of float)
+0:105        direct index ( temp 4-component vector of float)
+0:105          a18: direct index for structure ( out 10-element array of 4-component vector of float)
+0:105            'anon@4' (layout( location=50) out block{ out 10-element array of 4-component vector of float a18})
+0:105            Constant:
+0:105              0 (const uint)
+0:105          Constant:
+0:105            5 (const int)
+0:105        Constant:
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:106      move second child to first child ( temp 2-component vector of float)
+0:106        a19: direct index for structure (layout( location=60) out 2-component vector of float)
+0:106          'anon@5' ( out block{layout( location=60) out 2-component vector of float a19})
+0:106          Constant:
+0:106            0 (const uint)
+0:106        Constant:
+0:106          0.000000
+0:106          0.000000
+0:107      move second child to first child ( temp 4-component vector of float)
+0:107        a20: direct index for structure ( out 4-component vector of float)
+0:107          'anon@6' ( out block{ out 4-component vector of float a20})
+0:107          Constant:
+0:107            0 (const uint)
+0:107        Constant:
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:108      move second child to first child ( temp 2-component vector of float)
+0:108        direct index ( smooth temp 2-component vector of float)
+0:108          'a21' ( smooth out 2-element array of 2-component vector of float)
+0:108          Constant:
+0:108            0 (const int)
+0:108        Constant:
+0:108          0.000000
+0:108          0.000000
+0:109      move second child to first child ( temp 2-component vector of float)
+0:109        direct index ( smooth temp 2-component vector of float)
+0:109          'a21' ( smooth out 2-element array of 2-component vector of float)
+0:109          Constant:
+0:109            1 (const int)
+0:109        Constant:
+0:109          0.000000
+0:109          0.000000
+0:?   Linker Objects
+0:?     'a0' (layout( location=40) smooth out 4-component vector of float)
+0:?     'anon@0' (layout( location=1) out block{ out 4-component vector of float a1})
+0:?     'anon@1' ( out block{layout( location=3) out 4-component vector of float a2, layout( location=2) out 4-component vector of float a3})
+0:?     'a4' (layout( location=5) smooth out 3-element array of 4-component vector of float)
+0:?     'anon@2' ( out block{layout( location=4) out 4-component vector of float a5, layout( location=8) out 2-element array of 4-component vector of float a6, layout( location=10) out 2-element array of 4-component vector of float a7})
+0:?     'anon@3' ( out block{layout( location=12) out float a8, layout( location=15) out 2-element array of 2-component vector of float a9, layout( location=17) out 2-element array of 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of float a,  global float b} a11})
+0:?     'a12' (layout( location=27) smooth out 3-element array of float)
+0:?     's0' (layout( location=30) smooth out structure{ global 2-component vector of float a13,  global structure{ global 3-element array of float a,  global float b} a14,  global 4X4 matrix of float a15})
+0:?     'a16' (layout( location=39) smooth out float)
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'a17' (layout( location=46) smooth out 4-element array of 4-component vector of float)
+0:?     'anon@4' (layout( location=50) out block{ out 10-element array of 4-component vector of float a18})
+0:?     'anon@5' ( out block{layout( location=60) out 2-component vector of float a19})
+0:?     'anon@6' ( out block{ out 4-component vector of float a20})
+0:?     'a21' ( smooth out 2-element array of 2-component vector of float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+Shader version: 460
+invocations = 1
+max_vertices = 3
+input primitive = triangles
+output primitive = triangle_strip
+0:? Sequence
+0:28  Function Definition: main( ( global void)
+0:28    Function Parameters: 
+0:29    Sequence
+0:29      Sequence
+0:29        Sequence
+0:29          move second child to first child ( temp int)
+0:29            'i' ( temp int)
+0:29            Constant:
+0:29              0 (const int)
+0:29        Loop with condition tested first
+0:29          Loop Condition
+0:29          Compare Less Than ( temp bool)
+0:29            'i' ( temp int)
+0:29            Constant:
+0:29              32 (const int)
+0:29          Loop Body
+0:30          Sequence
+0:30            move second child to first child ( temp 4-component vector of float)
+0:30              indirect index (layout( location=0 stream=0) temp 4-component vector of float)
+0:30                'o0' (layout( location=0 stream=0) out 64-element array of 4-component vector of float)
+0:30                'i' ( temp int)
+0:30              indirect index (layout( location=0) temp 4-component vector of float)
+0:30                a0: direct index for structure (layout( location=0) in 64-element array of 4-component vector of float)
+0:30                  direct index ( temp block{layout( location=0) in 64-element array of 4-component vector of float a0})
+0:30                    'gs_in1' ( in 3-element array of block{layout( location=0) in 64-element array of 4-component vector of float a0})
+0:30                    Constant:
+0:30                      0 (const int)
+0:30                  Constant:
+0:30                    0 (const int)
+0:30                'i' ( temp int)
+0:29          Loop Terminal Expression
+0:29          Pre-Increment ( temp int)
+0:29            'i' ( temp int)
+0:33      move second child to first child ( temp 4-component vector of float)
+0:33        a20: direct index for structure (layout( stream=0) out 4-component vector of float)
+0:33          'gs_out0' (layout( stream=0) out block{layout( stream=0) out 4-component vector of float a20})
+0:33          Constant:
+0:33            0 (const int)
+0:33        a20: direct index for structure ( in 4-component vector of float)
+0:33          direct index ( temp block{ in 4-component vector of float a20})
+0:33            'gs_in0' ( in 3-element array of block{ in 4-component vector of float a20})
+0:33            Constant:
+0:33              0 (const int)
+0:33          Constant:
+0:33            0 (const int)
+0:34      move second child to first child ( temp 2-component vector of float)
+0:34        direct index (layout( stream=0) temp 2-component vector of float)
+0:34          'g_a21' (layout( stream=0) out 2-element array of 2-component vector of float)
+0:34          Constant:
+0:34            0 (const int)
+0:34        direct index ( temp 2-component vector of float)
+0:34          direct index ( temp 2-element array of 2-component vector of float)
+0:34            'a21' ( in 3-element array of 2-element array of 2-component vector of float)
+0:34            Constant:
+0:34              0 (const int)
+0:34          Constant:
+0:34            0 (const int)
+0:35      move second child to first child ( temp 2-component vector of float)
+0:35        direct index (layout( stream=0) temp 2-component vector of float)
+0:35          'g_a21' (layout( stream=0) out 2-element array of 2-component vector of float)
+0:35          Constant:
+0:35            0 (const int)
+0:35        direct index ( temp 2-component vector of float)
+0:35          direct index ( temp 2-element array of 2-component vector of float)
+0:35            'a21' ( in 3-element array of 2-element array of 2-component vector of float)
+0:35            Constant:
+0:35              0 (const int)
+0:35          Constant:
+0:35            1 (const int)
+0:37      move second child to first child ( temp 4-component vector of float)
+0:37        gl_Position: direct index for structure (layout( stream=0) gl_Position 4-component vector of float Position)
+0:37          'anon@0' (layout( stream=0) out block{layout( stream=0) gl_Position 4-component vector of float Position gl_Position, layout( stream=0) gl_PointSize float PointSize gl_PointSize, layout( stream=0) out 1-element array of float ClipDistance gl_ClipDistance, layout( stream=0) out 1-element array of float CullDistance gl_CullDistance})
+0:37          Constant:
+0:37            0 (const uint)
+0:37        Constant:
+0:37          0.000000
+0:37          0.000000
+0:37          0.000000
+0:37          0.000000
+0:39      EmitVertex ( global void)
+0:40      EmitVertex ( global void)
+0:41      EmitVertex ( global void)
+0:?   Linker Objects
+0:?     'gs_in0' ( in 3-element array of block{ in 4-component vector of float a20})
+0:?     'a21' ( in 3-element array of 2-element array of 2-component vector of float)
+0:?     'gs_out0' (layout( stream=0) out block{layout( stream=0) out 4-component vector of float a20})
+0:?     'g_a21' (layout( stream=0) out 2-element array of 2-component vector of float)
+0:?     'gs_in1' ( in 3-element array of block{layout( location=0) in 64-element array of 4-component vector of float a0})
+0:?     'o0' (layout( location=0 stream=0) out 64-element array of 4-component vector of float)
+0:?     'anon@0' (layout( stream=0) out block{layout( stream=0) gl_Position 4-component vector of float Position gl_Position, layout( stream=0) gl_PointSize float PointSize gl_PointSize, layout( stream=0) out 1-element array of float ClipDistance gl_ClipDistance, layout( stream=0) out 1-element array of float CullDistance gl_CullDistance})
+Shader version: 460
+0:? Sequence
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        'o' ( out 4-component vector of float)
+0:76        b1: direct index for structure ( in 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp 4-component vector of float)
+0:77        'o' ( out 4-component vector of float)
+0:77        b2: direct index for structure ( in 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp 4-component vector of float)
+0:78        'o' ( out 4-component vector of float)
+0:78        b3: direct index for structure ( in 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp 4-component vector of float)
+0:79        'o' ( out 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp 4-component vector of float)
+0:80        'o' ( out 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp 4-component vector of float)
+0:81        'o' ( out 4-component vector of float)
+0:81        b5: direct index for structure ( in 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp 4-component vector of float)
+0:82        'o' ( out 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp 4-component vector of float)
+0:83        'o' ( out 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp 4-component vector of float)
+0:84        'o' ( out 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp 4-component vector of float)
+0:85        'o' ( out 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp 4-component vector of float)
+0:86        'o' ( out 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp 4-component vector of float)
+0:87        'o' ( out 4-component vector of float)
+0:87        Construct vec4 ( temp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp 4-component vector of float)
+0:88        'o' ( out 4-component vector of float)
+0:88        vector swizzle ( temp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp 4-component vector of float)
+0:89        'o' ( out 4-component vector of float)
+0:89        Construct vec4 ( temp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in float)
+0:89            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp 4-component vector of float)
+0:90        'o' ( out 4-component vector of float)
+0:90        vector swizzle ( temp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp 4-component vector of float)
+0:91        'o' ( out 4-component vector of float)
+0:91        Construct vec4 ( temp 4-component vector of float)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp 4-component vector of float)
+0:92        'o' ( out 4-component vector of float)
+0:92        Construct vec4 ( temp 4-component vector of float)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp float)
+0:92            add ( temp float)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp float)
+0:92              b12: direct index for structure ( in 6-element array of float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp 4-component vector of float)
+0:93        'o' ( out 4-component vector of float)
+0:93        Construct vec4 ( temp 4-component vector of float)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp 4-component vector of float)
+0:95            'o' ( out 4-component vector of float)
+0:95            vector swizzle ( temp 4-component vector of float)
+0:95              matrix-times-vector ( temp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp 4-component vector of float)
+0:96            'o' ( out 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp 4-component vector of float)
+0:97            'o' ( out 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp 4-component vector of float)
+0:99        'o' ( out 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major shared) uniform int)
+0:99            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp 4-component vector of float)
+0:100        'o' ( out 4-component vector of float)
+0:100        indirect index ( temp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major shared) uniform int)
+0:100            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp 4-component vector of float)
+0:101        'o' ( out 4-component vector of float)
+0:101        vector swizzle ( temp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp 4-component vector of float)
+0:102        'o' ( out 4-component vector of float)
+0:102        a20: direct index for structure ( in 4-component vector of float)
+0:102          'anon@8' ( in block{ in 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp 4-component vector of float)
+0:103        'o' ( out 4-component vector of float)
+0:103        Construct vec4 ( temp 4-component vector of float)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'g_a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'g_a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of float)
+0:?     'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:?     'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:?     'b16' ( flat in uint)
+0:?     'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in 2-component vector of float)
+0:?     'anon@8' ( in block{ in 4-component vector of float a20})
+0:?     'g_a21' ( smooth in 2-element array of 2-component vector of float)
+0:?     'o' ( out 4-component vector of float)
+

--- a/Test/baseResults/link.missingCrossStageIO.0.vert.out
+++ b/Test/baseResults/link.missingCrossStageIO.0.vert.out
@@ -1,0 +1,791 @@
+link.missingCrossStageIO.0.vert
+Shader version: 460
+0:? Sequence
+0:3  Function Definition: main( ( global void)
+0:3    Function Parameters: 
+0:?   Linker Objects
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+link.missingCrossStageIO.0.frag
+Shader version: 460
+0:? Sequence
+0:71  Function Definition: uncalled( ( global uint)
+0:71    Function Parameters: 
+0:72    Sequence
+0:72      Branch: Return with expression
+0:72        'b16' ( flat in uint)
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        'o' ( out 4-component vector of float)
+0:76        b1: direct index for structure ( in 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp 4-component vector of float)
+0:77        'o' ( out 4-component vector of float)
+0:77        b2: direct index for structure ( in 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp 4-component vector of float)
+0:78        'o' ( out 4-component vector of float)
+0:78        b3: direct index for structure ( in 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp 4-component vector of float)
+0:79        'o' ( out 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp 4-component vector of float)
+0:80        'o' ( out 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp 4-component vector of float)
+0:81        'o' ( out 4-component vector of float)
+0:81        b5: direct index for structure ( in 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp 4-component vector of float)
+0:82        'o' ( out 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp 4-component vector of float)
+0:83        'o' ( out 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp 4-component vector of float)
+0:84        'o' ( out 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp 4-component vector of float)
+0:85        'o' ( out 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp 4-component vector of float)
+0:86        'o' ( out 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp 4-component vector of float)
+0:87        'o' ( out 4-component vector of float)
+0:87        Construct vec4 ( temp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp 4-component vector of float)
+0:88        'o' ( out 4-component vector of float)
+0:88        vector swizzle ( temp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp 4-component vector of float)
+0:89        'o' ( out 4-component vector of float)
+0:89        Construct vec4 ( temp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in float)
+0:89            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp 4-component vector of float)
+0:90        'o' ( out 4-component vector of float)
+0:90        vector swizzle ( temp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp 4-component vector of float)
+0:91        'o' ( out 4-component vector of float)
+0:91        Construct vec4 ( temp 4-component vector of float)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp 4-component vector of float)
+0:92        'o' ( out 4-component vector of float)
+0:92        Construct vec4 ( temp 4-component vector of float)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp float)
+0:92            add ( temp float)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp float)
+0:92              b12: direct index for structure ( in 6-element array of float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp 4-component vector of float)
+0:93        'o' ( out 4-component vector of float)
+0:93        Construct vec4 ( temp 4-component vector of float)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp 4-component vector of float)
+0:95            'o' ( out 4-component vector of float)
+0:95            vector swizzle ( temp 4-component vector of float)
+0:95              matrix-times-vector ( temp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp 4-component vector of float)
+0:96            'o' ( out 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp 4-component vector of float)
+0:97            'o' ( out 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp 4-component vector of float)
+0:99        'o' ( out 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major shared) uniform int)
+0:99            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp 4-component vector of float)
+0:100        'o' ( out 4-component vector of float)
+0:100        indirect index ( temp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major shared) uniform int)
+0:100            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp 4-component vector of float)
+0:101        'o' ( out 4-component vector of float)
+0:101        vector swizzle ( temp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp 4-component vector of float)
+0:102        'o' ( out 4-component vector of float)
+0:102        a20: direct index for structure ( in 4-component vector of float)
+0:102          'anon@8' ( in block{ in 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp 4-component vector of float)
+0:103        'o' ( out 4-component vector of float)
+0:103        Construct vec4 ( temp 4-component vector of float)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of float)
+0:?     'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:?     'anon@4' (layout( location=29) in block{ in unsized 10-element array of float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:?     'b16' ( flat in uint)
+0:?     'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in 2-component vector of float)
+0:?     'anon@8' ( in block{ in 4-component vector of float a20})
+0:?     'a21' ( smooth in 2-element array of 2-component vector of float)
+0:?     'o' ( out 4-component vector of float)
+
+
+Linked vertex stage:
+
+
+Linked fragment stage:
+
+ERROR: 0:76: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=0) in { in vec4 b0,  in vec4 b1,  in vec4 b2,  in vec4 b3} BBlock0
+ERROR: 0:77: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=0) in { in vec4 b0,  in vec4 b1,  in vec4 b2,  in vec4 b3} BBlock0
+ERROR: 0:78: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=0) in { in vec4 b0,  in vec4 b1,  in vec4 b2,  in vec4 b3} BBlock0
+ERROR: 0:79: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=4) smooth in vec4 b4[2]
+ERROR: 0:80: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=4) smooth in vec4 b4[2]
+ERROR: 0:81: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=6) in { in vec4 b5} BBlock1
+ERROR: 0:82: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:83: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:84: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:85: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:86: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:87: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=12) smooth in float b7[4]
+ERROR: 0:87: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=12) smooth in float b7[4]
+ERROR: 0:87: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=12) smooth in float b7[4]
+ERROR: 0:87: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=12) smooth in float b7[4]
+ERROR: 0:88: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:89: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:90: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:91: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:91: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:91: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:91: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:93: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=29) in { in float b13[10]} BBlock4
+ERROR: 0:93: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=29) in { in float b13[10]} BBlock4
+ERROR: 0:93: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=29) in { in float b13[10]} BBlock4
+ERROR: 0:93: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=29) in { in float b13[10]} BBlock4
+ERROR: 0:99: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=46) smooth in vec4 b20[4]
+ERROR: 0:100: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=50) in { in vec4 b21[10]} BBlock7
+ERROR: 0:101: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=60) smooth in vec2 b22
+ERROR: 0:102: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in { in vec4 a20} Block0
+ERROR: 0:103: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     smooth in vec2 a21[2]
+ERROR: 0:103: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     smooth in vec2 a21[2]
+
+Shader version: 460
+0:? Sequence
+0:3  Function Definition: main( ( global void)
+0:3    Function Parameters: 
+0:?   Linker Objects
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+Shader version: 460
+0:? Sequence
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp 4-component vector of float)
+0:76        'o' ( out 4-component vector of float)
+0:76        b1: direct index for structure ( in 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp 4-component vector of float)
+0:77        'o' ( out 4-component vector of float)
+0:77        b2: direct index for structure ( in 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp 4-component vector of float)
+0:78        'o' ( out 4-component vector of float)
+0:78        b3: direct index for structure ( in 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp 4-component vector of float)
+0:79        'o' ( out 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp 4-component vector of float)
+0:80        'o' ( out 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp 4-component vector of float)
+0:81        'o' ( out 4-component vector of float)
+0:81        b5: direct index for structure ( in 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp 4-component vector of float)
+0:82        'o' ( out 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp 4-component vector of float)
+0:83        'o' ( out 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp 4-component vector of float)
+0:84        'o' ( out 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp 4-component vector of float)
+0:85        'o' ( out 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp 4-component vector of float)
+0:86        'o' ( out 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp 4-component vector of float)
+0:87        'o' ( out 4-component vector of float)
+0:87        Construct vec4 ( temp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp 4-component vector of float)
+0:88        'o' ( out 4-component vector of float)
+0:88        vector swizzle ( temp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp 4-component vector of float)
+0:89        'o' ( out 4-component vector of float)
+0:89        Construct vec4 ( temp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in float)
+0:89            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp 4-component vector of float)
+0:90        'o' ( out 4-component vector of float)
+0:90        vector swizzle ( temp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp 4-component vector of float)
+0:91        'o' ( out 4-component vector of float)
+0:91        Construct vec4 ( temp 4-component vector of float)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of float)
+0:91              'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp 4-component vector of float)
+0:92        'o' ( out 4-component vector of float)
+0:92        Construct vec4 ( temp 4-component vector of float)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp float)
+0:92            b12: direct index for structure ( in 6-element array of float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp float)
+0:92            add ( temp float)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp float)
+0:92                b12: direct index for structure ( in 6-element array of float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp float)
+0:92              b12: direct index for structure ( in 6-element array of float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp 4-component vector of float)
+0:93        'o' ( out 4-component vector of float)
+0:93        Construct vec4 ( temp 4-component vector of float)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp float)
+0:93            b13: direct index for structure ( in 10-element array of float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp 4-component vector of float)
+0:95            'o' ( out 4-component vector of float)
+0:95            vector swizzle ( temp 4-component vector of float)
+0:95              matrix-times-vector ( temp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp 4-component vector of float)
+0:96            'o' ( out 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp 4-component vector of float)
+0:97            'o' ( out 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp 4-component vector of float)
+0:99        'o' ( out 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major shared) uniform int)
+0:99            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp 4-component vector of float)
+0:100        'o' ( out 4-component vector of float)
+0:100        indirect index ( temp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major shared) uniform int)
+0:100            'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp 4-component vector of float)
+0:101        'o' ( out 4-component vector of float)
+0:101        vector swizzle ( temp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp 4-component vector of float)
+0:102        'o' ( out 4-component vector of float)
+0:102        a20: direct index for structure ( in 4-component vector of float)
+0:102          'anon@8' ( in block{ in 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp 4-component vector of float)
+0:103        'o' ( out 4-component vector of float)
+0:103        Construct vec4 ( temp 4-component vector of float)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in 4-component vector of float b0,  in 4-component vector of float b1,  in 4-component vector of float b2,  in 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of float)
+0:?     'anon@2' ( in block{layout( location=21) in 2-component vector of float b8, layout( location=22) in float b9, layout( location=16) in 3-component vector of float b10, layout( location=17) in 4-element array of float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of float b12})
+0:?     'anon@4' (layout( location=29) in block{ in 10-element array of float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in 2X2 matrix of float)
+0:?     'b16' ( flat in uint)
+0:?     'anon@6' ( in block{layout( location=45) in 4-component vector of float b17, layout( location=43) in 4-component vector of float b18, layout( location=44) in 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major shared) uniform block{layout( column_major shared) uniform int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in 2-component vector of float)
+0:?     'anon@8' ( in block{ in 4-component vector of float a20})
+0:?     'a21' ( smooth in 2-element array of 2-component vector of float)
+0:?     'o' ( out 4-component vector of float)
+

--- a/Test/baseResults/link.vk.crossStageIO.0.vert.out
+++ b/Test/baseResults/link.vk.crossStageIO.0.vert.out
@@ -1,0 +1,1960 @@
+link.vk.crossStageIO.0.vert
+Shader version: 460
+0:? Sequence
+0:66  Function Definition: main( ( global void)
+0:66    Function Parameters: 
+0:67    Sequence
+0:67      Test condition and select ( temp void)
+0:67        Condition
+0:67        Constant:
+0:67          false (const bool)
+0:67        true case
+0:68        Sequence
+0:68          move second child to first child ( temp highp 4-component vector of float)
+0:68            'a0' (layout( location=40) smooth out highp 4-component vector of float)
+0:68            Constant:
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:70      move second child to first child ( temp highp 4-component vector of float)
+0:70        a1: direct index for structure ( out highp 4-component vector of float)
+0:70          'anon@0' (layout( location=1) out block{ out highp 4-component vector of float a1})
+0:70          Constant:
+0:70            0 (const uint)
+0:70        Constant:
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:71      move second child to first child ( temp highp 4-component vector of float)
+0:71        a2: direct index for structure (layout( location=3) out highp 4-component vector of float)
+0:71          'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:71          Constant:
+0:71            0 (const uint)
+0:71        Constant:
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:72      move second child to first child ( temp highp 4-component vector of float)
+0:72        a3: direct index for structure (layout( location=2) out highp 4-component vector of float)
+0:72          'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:72          Constant:
+0:72            1 (const uint)
+0:72        Constant:
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:73      move second child to first child ( temp highp 4-component vector of float)
+0:73        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:73          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:73          Constant:
+0:73            0 (const int)
+0:73        Constant:
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:74      move second child to first child ( temp highp 4-component vector of float)
+0:74        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:74          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:74          Constant:
+0:74            1 (const int)
+0:74        Constant:
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:75      move second child to first child ( temp highp 4-component vector of float)
+0:75        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:75          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:75          Constant:
+0:75            2 (const int)
+0:75        Constant:
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        a5: direct index for structure (layout( location=4) out highp 4-component vector of float)
+0:76          'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        Constant:
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:77      move second child to first child ( temp highp 4-component vector of float)
+0:77        direct index (layout( location=8) temp highp 4-component vector of float)
+0:77          a6: direct index for structure (layout( location=8) out 2-element array of highp 4-component vector of float)
+0:77            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:77            Constant:
+0:77              1 (const uint)
+0:77          Constant:
+0:77            0 (const int)
+0:77        Constant:
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:78      move second child to first child ( temp highp 4-component vector of float)
+0:78        direct index (layout( location=8) temp highp 4-component vector of float)
+0:78          a6: direct index for structure (layout( location=8) out 2-element array of highp 4-component vector of float)
+0:78            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:78            Constant:
+0:78              1 (const uint)
+0:78          Constant:
+0:78            1 (const int)
+0:78        Constant:
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:79      move second child to first child ( temp highp 4-component vector of float)
+0:79        direct index (layout( location=10) temp highp 4-component vector of float)
+0:79          a7: direct index for structure (layout( location=10) out 2-element array of highp 4-component vector of float)
+0:79            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:79            Constant:
+0:79              2 (const uint)
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:80      move second child to first child ( temp highp 4-component vector of float)
+0:80        direct index (layout( location=10) temp highp 4-component vector of float)
+0:80          a7: direct index for structure (layout( location=10) out 2-element array of highp 4-component vector of float)
+0:80            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:80            Constant:
+0:80              2 (const uint)
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:81      move second child to first child ( temp highp float)
+0:81        a8: direct index for structure (layout( location=12) out highp float)
+0:81          'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:81          Constant:
+0:81            0 (const uint)
+0:81        Constant:
+0:81          0.000000
+0:82      move second child to first child ( temp highp float)
+0:82        direct index ( temp highp float)
+0:82          direct index (layout( location=15) temp highp 2-component vector of float)
+0:82            a9: direct index for structure (layout( location=15) out 2-element array of highp 2-component vector of float)
+0:82              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:82              Constant:
+0:82                1 (const uint)
+0:82            Constant:
+0:82              0 (const int)
+0:82          Constant:
+0:82            0 (const int)
+0:82        Constant:
+0:82          0.000000
+0:83      move second child to first child ( temp highp float)
+0:83        direct index ( temp highp float)
+0:83          direct index (layout( location=15) temp highp 2-component vector of float)
+0:83            a9: direct index for structure (layout( location=15) out 2-element array of highp 2-component vector of float)
+0:83              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:83              Constant:
+0:83                1 (const uint)
+0:83            Constant:
+0:83              1 (const int)
+0:83          Constant:
+0:83            1 (const int)
+0:83        Constant:
+0:83          0.000000
+0:84      move second child to first child ( temp highp 4-component vector of float)
+0:84        direct index (layout( location=17) temp highp 4-component vector of float)
+0:84          a10: direct index for structure (layout( location=17) out 2-element array of highp 4-component vector of float)
+0:84            'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:84            Constant:
+0:84              2 (const uint)
+0:84          Constant:
+0:84            0 (const int)
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:85      move second child to first child ( temp highp 4-component vector of float)
+0:85        direct index (layout( location=17) temp highp 4-component vector of float)
+0:85          a10: direct index for structure (layout( location=17) out 2-element array of highp 4-component vector of float)
+0:85            'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:85            Constant:
+0:85              2 (const uint)
+0:85          Constant:
+0:85            1 (const int)
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:86      move second child to first child ( temp highp float)
+0:86        direct index ( temp highp float)
+0:86          a: direct index for structure ( global 3-element array of highp float)
+0:86            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:86              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:86                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:86                Constant:
+0:86                  3 (const uint)
+0:86              Constant:
+0:86                0 (const int)
+0:86            Constant:
+0:86              0 (const int)
+0:86          Constant:
+0:86            0 (const int)
+0:86        Constant:
+0:86          0.000000
+0:87      move second child to first child ( temp highp float)
+0:87        direct index ( temp highp float)
+0:87          a: direct index for structure ( global 3-element array of highp float)
+0:87            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:87              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:87                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:87                Constant:
+0:87                  3 (const uint)
+0:87              Constant:
+0:87                0 (const int)
+0:87            Constant:
+0:87              0 (const int)
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          0.000000
+0:88      move second child to first child ( temp highp float)
+0:88        direct index ( temp highp float)
+0:88          a: direct index for structure ( global 3-element array of highp float)
+0:88            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:88              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:88                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:88                Constant:
+0:88                  3 (const uint)
+0:88              Constant:
+0:88                0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88          Constant:
+0:88            2 (const int)
+0:88        Constant:
+0:88          0.000000
+0:89      move second child to first child ( temp highp float)
+0:89        b: direct index for structure ( global highp float)
+0:89          direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:89            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:89              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:89              Constant:
+0:89                3 (const uint)
+0:89            Constant:
+0:89              0 (const int)
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          0.000000
+0:90      move second child to first child ( temp highp float)
+0:90        direct index ( temp highp float)
+0:90          a: direct index for structure ( global 3-element array of highp float)
+0:90            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:90              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:90                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:90                Constant:
+0:90                  3 (const uint)
+0:90              Constant:
+0:90                1 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:90          Constant:
+0:90            0 (const int)
+0:90        Constant:
+0:90          0.000000
+0:91      move second child to first child ( temp highp float)
+0:91        direct index ( temp highp float)
+0:91          a: direct index for structure ( global 3-element array of highp float)
+0:91            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:91              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:91                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:91                Constant:
+0:91                  3 (const uint)
+0:91              Constant:
+0:91                1 (const int)
+0:91            Constant:
+0:91              0 (const int)
+0:91          Constant:
+0:91            1 (const int)
+0:91        Constant:
+0:91          0.000000
+0:92      move second child to first child ( temp highp float)
+0:92        direct index ( temp highp float)
+0:92          a: direct index for structure ( global 3-element array of highp float)
+0:92            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:92              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:92                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:92                Constant:
+0:92                  3 (const uint)
+0:92              Constant:
+0:92                1 (const int)
+0:92            Constant:
+0:92              0 (const int)
+0:92          Constant:
+0:92            2 (const int)
+0:92        Constant:
+0:92          0.000000
+0:93      move second child to first child ( temp highp float)
+0:93        b: direct index for structure ( global highp float)
+0:93          direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:93            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:93              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:93              Constant:
+0:93                3 (const uint)
+0:93            Constant:
+0:93              1 (const int)
+0:93          Constant:
+0:93            1 (const int)
+0:93        Constant:
+0:93          0.000000
+0:94      move second child to first child ( temp highp float)
+0:94        direct index (layout( location=27) smooth temp highp float)
+0:94          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:94          Constant:
+0:94            0 (const int)
+0:94        Constant:
+0:94          0.000000
+0:95      move second child to first child ( temp highp float)
+0:95        direct index (layout( location=27) smooth temp highp float)
+0:95          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:95          Constant:
+0:95            1 (const int)
+0:95        Constant:
+0:95          0.000000
+0:96      move second child to first child ( temp highp float)
+0:96        direct index (layout( location=27) smooth temp highp float)
+0:96          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:96          Constant:
+0:96            2 (const int)
+0:96        Constant:
+0:96          0.000000
+0:97      move second child to first child ( temp highp float)
+0:97        direct index ( temp highp float)
+0:97          a13: direct index for structure ( global highp 2-component vector of float)
+0:97            's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:97            Constant:
+0:97              0 (const int)
+0:97          Constant:
+0:97            1 (const int)
+0:97        Constant:
+0:97          0.000000
+0:98      move second child to first child ( temp highp float)
+0:98        direct index ( temp highp float)
+0:98          a: direct index for structure ( global 3-element array of highp float)
+0:98            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:98              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:98              Constant:
+0:98                1 (const int)
+0:98            Constant:
+0:98              0 (const int)
+0:98          Constant:
+0:98            0 (const int)
+0:98        Constant:
+0:98          0.000000
+0:99      move second child to first child ( temp highp float)
+0:99        direct index ( temp highp float)
+0:99          a: direct index for structure ( global 3-element array of highp float)
+0:99            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:99              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:99              Constant:
+0:99                1 (const int)
+0:99            Constant:
+0:99              0 (const int)
+0:99          Constant:
+0:99            1 (const int)
+0:99        Constant:
+0:99          0.000000
+0:100      move second child to first child ( temp highp float)
+0:100        direct index ( temp highp float)
+0:100          a: direct index for structure ( global 3-element array of highp float)
+0:100            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:100              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:100              Constant:
+0:100                1 (const int)
+0:100            Constant:
+0:100              0 (const int)
+0:100          Constant:
+0:100            2 (const int)
+0:100        Constant:
+0:100          0.000000
+0:101      move second child to first child ( temp highp float)
+0:101        b: direct index for structure ( global highp float)
+0:101          a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:101            's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:101            Constant:
+0:101              1 (const int)
+0:101          Constant:
+0:101            1 (const int)
+0:101        Constant:
+0:101          0.000000
+0:102      move second child to first child ( temp highp 4X4 matrix of float)
+0:102        a15: direct index for structure ( global highp 4X4 matrix of float)
+0:102          's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:102          Constant:
+0:102            2 (const int)
+0:102        Constant:
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:104      move second child to first child ( temp highp 4-component vector of float)
+0:104        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:104          'a17' (layout( location=46) smooth out 4-element array of highp 4-component vector of float)
+0:104          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:104            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:104            Constant:
+0:104              0 (const int)
+0:104        Constant:
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:105      move second child to first child ( temp highp 4-component vector of float)
+0:105        direct index ( temp highp 4-component vector of float)
+0:105          a18: direct index for structure ( out 10-element array of highp 4-component vector of float)
+0:105            'anon@4' (layout( location=50) out block{ out 10-element array of highp 4-component vector of float a18})
+0:105            Constant:
+0:105              0 (const uint)
+0:105          Constant:
+0:105            5 (const int)
+0:105        Constant:
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:106      move second child to first child ( temp highp 2-component vector of float)
+0:106        a19: direct index for structure (layout( location=60) out highp 2-component vector of float)
+0:106          'anon@5' ( out block{layout( location=60) out highp 2-component vector of float a19})
+0:106          Constant:
+0:106            0 (const uint)
+0:106        Constant:
+0:106          0.000000
+0:106          0.000000
+0:107      move second child to first child ( temp highp 4-component vector of float)
+0:107        a20: direct index for structure ( out highp 4-component vector of float)
+0:107          'anon@6' ( out block{ out highp 4-component vector of float a20})
+0:107          Constant:
+0:107            0 (const uint)
+0:107        Constant:
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:108      move second child to first child ( temp highp 2-component vector of float)
+0:108        direct index ( smooth temp highp 2-component vector of float)
+0:108          'a21' ( smooth out 2-element array of highp 2-component vector of float)
+0:108          Constant:
+0:108            0 (const int)
+0:108        Constant:
+0:108          0.000000
+0:108          0.000000
+0:109      move second child to first child ( temp highp 2-component vector of float)
+0:109        direct index ( smooth temp highp 2-component vector of float)
+0:109          'a21' ( smooth out 2-element array of highp 2-component vector of float)
+0:109          Constant:
+0:109            1 (const int)
+0:109        Constant:
+0:109          0.000000
+0:109          0.000000
+0:?   Linker Objects
+0:?     'a0' (layout( location=40) smooth out highp 4-component vector of float)
+0:?     'anon@0' (layout( location=1) out block{ out highp 4-component vector of float a1})
+0:?     'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:?     'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:?     'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:?     'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:?     'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:?     's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:?     'a16' (layout( location=39) smooth out highp float)
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'a17' (layout( location=46) smooth out 4-element array of highp 4-component vector of float)
+0:?     'anon@4' (layout( location=50) out block{ out 10-element array of highp 4-component vector of float a18})
+0:?     'anon@5' ( out block{layout( location=60) out highp 2-component vector of float a19})
+0:?     'anon@6' ( out block{ out highp 4-component vector of float a20})
+0:?     'a21' ( smooth out 2-element array of highp 2-component vector of float)
+
+link.vk.crossStageIO.0.frag
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:71  Function Definition: uncalled( ( global highp uint)
+0:71    Function Parameters: 
+0:72    Sequence
+0:72      Branch: Return with expression
+0:72        'b16' ( flat in highp uint)
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        'o' ( out highp 4-component vector of float)
+0:76        b1: direct index for structure ( in highp 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp highp 4-component vector of float)
+0:77        'o' ( out highp 4-component vector of float)
+0:77        b2: direct index for structure ( in highp 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp highp 4-component vector of float)
+0:78        'o' ( out highp 4-component vector of float)
+0:78        b3: direct index for structure ( in highp 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp highp 4-component vector of float)
+0:79        'o' ( out highp 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp highp 4-component vector of float)
+0:80        'o' ( out highp 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp highp 4-component vector of float)
+0:81        'o' ( out highp 4-component vector of float)
+0:81        b5: direct index for structure ( in highp 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp highp 4-component vector of float)
+0:82        'o' ( out highp 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp highp 4-component vector of float)
+0:83        'o' ( out highp 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp highp 4-component vector of float)
+0:84        'o' ( out highp 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp highp 4-component vector of float)
+0:85        'o' ( out highp 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp highp 4-component vector of float)
+0:86        'o' ( out highp 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp highp 4-component vector of float)
+0:87        'o' ( out highp 4-component vector of float)
+0:87        Construct vec4 ( temp highp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp highp 4-component vector of float)
+0:88        'o' ( out highp 4-component vector of float)
+0:88        vector swizzle ( temp highp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in highp 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp highp 4-component vector of float)
+0:89        'o' ( out highp 4-component vector of float)
+0:89        Construct vec4 ( temp highp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in highp float)
+0:89            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp highp 4-component vector of float)
+0:90        'o' ( out highp 4-component vector of float)
+0:90        vector swizzle ( temp highp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in highp 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp highp 4-component vector of float)
+0:91        'o' ( out highp 4-component vector of float)
+0:91        Construct vec4 ( temp highp 4-component vector of float)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp highp 4-component vector of float)
+0:92        'o' ( out highp 4-component vector of float)
+0:92        Construct vec4 ( temp highp 4-component vector of float)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp highp float)
+0:92            add ( temp highp float)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp highp float)
+0:92              b12: direct index for structure ( in 6-element array of highp float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp highp 4-component vector of float)
+0:93        'o' ( out highp 4-component vector of float)
+0:93        Construct vec4 ( temp highp 4-component vector of float)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp highp 4-component vector of float)
+0:95            'o' ( out highp 4-component vector of float)
+0:95            vector swizzle ( temp highp 4-component vector of float)
+0:95              matrix-times-vector ( temp highp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp highp 4-component vector of float)
+0:96            'o' ( out highp 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in highp 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp highp 4-component vector of float)
+0:97            'o' ( out highp 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in highp 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp highp 4-component vector of float)
+0:99        'o' ( out highp 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:99            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp highp 4-component vector of float)
+0:100        'o' ( out highp 4-component vector of float)
+0:100        indirect index ( temp highp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of highp 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:100            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp highp 4-component vector of float)
+0:101        'o' ( out highp 4-component vector of float)
+0:101        vector swizzle ( temp highp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp highp 4-component vector of float)
+0:102        'o' ( out highp 4-component vector of float)
+0:102        a20: direct index for structure ( in highp 4-component vector of float)
+0:102          'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp highp 4-component vector of float)
+0:103        'o' ( out highp 4-component vector of float)
+0:103        Construct vec4 ( temp highp 4-component vector of float)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:?     'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:?     'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in highp 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:?     'b16' ( flat in highp uint)
+0:?     'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:?     'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:?     'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:?     'o' ( out highp 4-component vector of float)
+
+
+Linked vertex stage:
+
+
+Linked fragment stage:
+
+
+Shader version: 460
+0:? Sequence
+0:66  Function Definition: main( ( global void)
+0:66    Function Parameters: 
+0:67    Sequence
+0:67      Test condition and select ( temp void)
+0:67        Condition
+0:67        Constant:
+0:67          false (const bool)
+0:67        true case
+0:68        Sequence
+0:68          move second child to first child ( temp highp 4-component vector of float)
+0:68            'a0' (layout( location=40) smooth out highp 4-component vector of float)
+0:68            Constant:
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:70      move second child to first child ( temp highp 4-component vector of float)
+0:70        a1: direct index for structure ( out highp 4-component vector of float)
+0:70          'anon@0' (layout( location=1) out block{ out highp 4-component vector of float a1})
+0:70          Constant:
+0:70            0 (const uint)
+0:70        Constant:
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:71      move second child to first child ( temp highp 4-component vector of float)
+0:71        a2: direct index for structure (layout( location=3) out highp 4-component vector of float)
+0:71          'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:71          Constant:
+0:71            0 (const uint)
+0:71        Constant:
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:72      move second child to first child ( temp highp 4-component vector of float)
+0:72        a3: direct index for structure (layout( location=2) out highp 4-component vector of float)
+0:72          'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:72          Constant:
+0:72            1 (const uint)
+0:72        Constant:
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:73      move second child to first child ( temp highp 4-component vector of float)
+0:73        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:73          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:73          Constant:
+0:73            0 (const int)
+0:73        Constant:
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:74      move second child to first child ( temp highp 4-component vector of float)
+0:74        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:74          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:74          Constant:
+0:74            1 (const int)
+0:74        Constant:
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:75      move second child to first child ( temp highp 4-component vector of float)
+0:75        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:75          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:75          Constant:
+0:75            2 (const int)
+0:75        Constant:
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        a5: direct index for structure (layout( location=4) out highp 4-component vector of float)
+0:76          'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        Constant:
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:77      move second child to first child ( temp highp 4-component vector of float)
+0:77        direct index (layout( location=8) temp highp 4-component vector of float)
+0:77          a6: direct index for structure (layout( location=8) out 2-element array of highp 4-component vector of float)
+0:77            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:77            Constant:
+0:77              1 (const uint)
+0:77          Constant:
+0:77            0 (const int)
+0:77        Constant:
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:78      move second child to first child ( temp highp 4-component vector of float)
+0:78        direct index (layout( location=8) temp highp 4-component vector of float)
+0:78          a6: direct index for structure (layout( location=8) out 2-element array of highp 4-component vector of float)
+0:78            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:78            Constant:
+0:78              1 (const uint)
+0:78          Constant:
+0:78            1 (const int)
+0:78        Constant:
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:79      move second child to first child ( temp highp 4-component vector of float)
+0:79        direct index (layout( location=10) temp highp 4-component vector of float)
+0:79          a7: direct index for structure (layout( location=10) out 2-element array of highp 4-component vector of float)
+0:79            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:79            Constant:
+0:79              2 (const uint)
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:80      move second child to first child ( temp highp 4-component vector of float)
+0:80        direct index (layout( location=10) temp highp 4-component vector of float)
+0:80          a7: direct index for structure (layout( location=10) out 2-element array of highp 4-component vector of float)
+0:80            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:80            Constant:
+0:80              2 (const uint)
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:81      move second child to first child ( temp highp float)
+0:81        a8: direct index for structure (layout( location=12) out highp float)
+0:81          'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:81          Constant:
+0:81            0 (const uint)
+0:81        Constant:
+0:81          0.000000
+0:82      move second child to first child ( temp highp float)
+0:82        direct index ( temp highp float)
+0:82          direct index (layout( location=15) temp highp 2-component vector of float)
+0:82            a9: direct index for structure (layout( location=15) out 2-element array of highp 2-component vector of float)
+0:82              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:82              Constant:
+0:82                1 (const uint)
+0:82            Constant:
+0:82              0 (const int)
+0:82          Constant:
+0:82            0 (const int)
+0:82        Constant:
+0:82          0.000000
+0:83      move second child to first child ( temp highp float)
+0:83        direct index ( temp highp float)
+0:83          direct index (layout( location=15) temp highp 2-component vector of float)
+0:83            a9: direct index for structure (layout( location=15) out 2-element array of highp 2-component vector of float)
+0:83              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:83              Constant:
+0:83                1 (const uint)
+0:83            Constant:
+0:83              1 (const int)
+0:83          Constant:
+0:83            1 (const int)
+0:83        Constant:
+0:83          0.000000
+0:84      move second child to first child ( temp highp 4-component vector of float)
+0:84        direct index (layout( location=17) temp highp 4-component vector of float)
+0:84          a10: direct index for structure (layout( location=17) out 2-element array of highp 4-component vector of float)
+0:84            'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:84            Constant:
+0:84              2 (const uint)
+0:84          Constant:
+0:84            0 (const int)
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:85      move second child to first child ( temp highp 4-component vector of float)
+0:85        direct index (layout( location=17) temp highp 4-component vector of float)
+0:85          a10: direct index for structure (layout( location=17) out 2-element array of highp 4-component vector of float)
+0:85            'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:85            Constant:
+0:85              2 (const uint)
+0:85          Constant:
+0:85            1 (const int)
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:86      move second child to first child ( temp highp float)
+0:86        direct index ( temp highp float)
+0:86          a: direct index for structure ( global 3-element array of highp float)
+0:86            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:86              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:86                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:86                Constant:
+0:86                  3 (const uint)
+0:86              Constant:
+0:86                0 (const int)
+0:86            Constant:
+0:86              0 (const int)
+0:86          Constant:
+0:86            0 (const int)
+0:86        Constant:
+0:86          0.000000
+0:87      move second child to first child ( temp highp float)
+0:87        direct index ( temp highp float)
+0:87          a: direct index for structure ( global 3-element array of highp float)
+0:87            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:87              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:87                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:87                Constant:
+0:87                  3 (const uint)
+0:87              Constant:
+0:87                0 (const int)
+0:87            Constant:
+0:87              0 (const int)
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          0.000000
+0:88      move second child to first child ( temp highp float)
+0:88        direct index ( temp highp float)
+0:88          a: direct index for structure ( global 3-element array of highp float)
+0:88            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:88              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:88                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:88                Constant:
+0:88                  3 (const uint)
+0:88              Constant:
+0:88                0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88          Constant:
+0:88            2 (const int)
+0:88        Constant:
+0:88          0.000000
+0:89      move second child to first child ( temp highp float)
+0:89        b: direct index for structure ( global highp float)
+0:89          direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:89            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:89              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:89              Constant:
+0:89                3 (const uint)
+0:89            Constant:
+0:89              0 (const int)
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          0.000000
+0:90      move second child to first child ( temp highp float)
+0:90        direct index ( temp highp float)
+0:90          a: direct index for structure ( global 3-element array of highp float)
+0:90            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:90              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:90                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:90                Constant:
+0:90                  3 (const uint)
+0:90              Constant:
+0:90                1 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:90          Constant:
+0:90            0 (const int)
+0:90        Constant:
+0:90          0.000000
+0:91      move second child to first child ( temp highp float)
+0:91        direct index ( temp highp float)
+0:91          a: direct index for structure ( global 3-element array of highp float)
+0:91            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:91              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:91                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:91                Constant:
+0:91                  3 (const uint)
+0:91              Constant:
+0:91                1 (const int)
+0:91            Constant:
+0:91              0 (const int)
+0:91          Constant:
+0:91            1 (const int)
+0:91        Constant:
+0:91          0.000000
+0:92      move second child to first child ( temp highp float)
+0:92        direct index ( temp highp float)
+0:92          a: direct index for structure ( global 3-element array of highp float)
+0:92            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:92              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:92                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:92                Constant:
+0:92                  3 (const uint)
+0:92              Constant:
+0:92                1 (const int)
+0:92            Constant:
+0:92              0 (const int)
+0:92          Constant:
+0:92            2 (const int)
+0:92        Constant:
+0:92          0.000000
+0:93      move second child to first child ( temp highp float)
+0:93        b: direct index for structure ( global highp float)
+0:93          direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:93            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:93              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:93              Constant:
+0:93                3 (const uint)
+0:93            Constant:
+0:93              1 (const int)
+0:93          Constant:
+0:93            1 (const int)
+0:93        Constant:
+0:93          0.000000
+0:94      move second child to first child ( temp highp float)
+0:94        direct index (layout( location=27) smooth temp highp float)
+0:94          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:94          Constant:
+0:94            0 (const int)
+0:94        Constant:
+0:94          0.000000
+0:95      move second child to first child ( temp highp float)
+0:95        direct index (layout( location=27) smooth temp highp float)
+0:95          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:95          Constant:
+0:95            1 (const int)
+0:95        Constant:
+0:95          0.000000
+0:96      move second child to first child ( temp highp float)
+0:96        direct index (layout( location=27) smooth temp highp float)
+0:96          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:96          Constant:
+0:96            2 (const int)
+0:96        Constant:
+0:96          0.000000
+0:97      move second child to first child ( temp highp float)
+0:97        direct index ( temp highp float)
+0:97          a13: direct index for structure ( global highp 2-component vector of float)
+0:97            's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:97            Constant:
+0:97              0 (const int)
+0:97          Constant:
+0:97            1 (const int)
+0:97        Constant:
+0:97          0.000000
+0:98      move second child to first child ( temp highp float)
+0:98        direct index ( temp highp float)
+0:98          a: direct index for structure ( global 3-element array of highp float)
+0:98            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:98              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:98              Constant:
+0:98                1 (const int)
+0:98            Constant:
+0:98              0 (const int)
+0:98          Constant:
+0:98            0 (const int)
+0:98        Constant:
+0:98          0.000000
+0:99      move second child to first child ( temp highp float)
+0:99        direct index ( temp highp float)
+0:99          a: direct index for structure ( global 3-element array of highp float)
+0:99            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:99              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:99              Constant:
+0:99                1 (const int)
+0:99            Constant:
+0:99              0 (const int)
+0:99          Constant:
+0:99            1 (const int)
+0:99        Constant:
+0:99          0.000000
+0:100      move second child to first child ( temp highp float)
+0:100        direct index ( temp highp float)
+0:100          a: direct index for structure ( global 3-element array of highp float)
+0:100            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:100              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:100              Constant:
+0:100                1 (const int)
+0:100            Constant:
+0:100              0 (const int)
+0:100          Constant:
+0:100            2 (const int)
+0:100        Constant:
+0:100          0.000000
+0:101      move second child to first child ( temp highp float)
+0:101        b: direct index for structure ( global highp float)
+0:101          a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:101            's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:101            Constant:
+0:101              1 (const int)
+0:101          Constant:
+0:101            1 (const int)
+0:101        Constant:
+0:101          0.000000
+0:102      move second child to first child ( temp highp 4X4 matrix of float)
+0:102        a15: direct index for structure ( global highp 4X4 matrix of float)
+0:102          's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:102          Constant:
+0:102            2 (const int)
+0:102        Constant:
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:104      move second child to first child ( temp highp 4-component vector of float)
+0:104        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:104          'a17' (layout( location=46) smooth out 4-element array of highp 4-component vector of float)
+0:104          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:104            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:104            Constant:
+0:104              0 (const int)
+0:104        Constant:
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:105      move second child to first child ( temp highp 4-component vector of float)
+0:105        direct index ( temp highp 4-component vector of float)
+0:105          a18: direct index for structure ( out 10-element array of highp 4-component vector of float)
+0:105            'anon@4' (layout( location=50) out block{ out 10-element array of highp 4-component vector of float a18})
+0:105            Constant:
+0:105              0 (const uint)
+0:105          Constant:
+0:105            5 (const int)
+0:105        Constant:
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:106      move second child to first child ( temp highp 2-component vector of float)
+0:106        a19: direct index for structure (layout( location=60) out highp 2-component vector of float)
+0:106          'anon@5' ( out block{layout( location=60) out highp 2-component vector of float a19})
+0:106          Constant:
+0:106            0 (const uint)
+0:106        Constant:
+0:106          0.000000
+0:106          0.000000
+0:107      move second child to first child ( temp highp 4-component vector of float)
+0:107        a20: direct index for structure ( out highp 4-component vector of float)
+0:107          'anon@6' ( out block{ out highp 4-component vector of float a20})
+0:107          Constant:
+0:107            0 (const uint)
+0:107        Constant:
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:108      move second child to first child ( temp highp 2-component vector of float)
+0:108        direct index ( smooth temp highp 2-component vector of float)
+0:108          'a21' ( smooth out 2-element array of highp 2-component vector of float)
+0:108          Constant:
+0:108            0 (const int)
+0:108        Constant:
+0:108          0.000000
+0:108          0.000000
+0:109      move second child to first child ( temp highp 2-component vector of float)
+0:109        direct index ( smooth temp highp 2-component vector of float)
+0:109          'a21' ( smooth out 2-element array of highp 2-component vector of float)
+0:109          Constant:
+0:109            1 (const int)
+0:109        Constant:
+0:109          0.000000
+0:109          0.000000
+0:?   Linker Objects
+0:?     'a0' (layout( location=40) smooth out highp 4-component vector of float)
+0:?     'anon@0' (layout( location=1) out block{ out highp 4-component vector of float a1})
+0:?     'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:?     'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:?     'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:?     'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:?     'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:?     's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:?     'a16' (layout( location=39) smooth out highp float)
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'a17' (layout( location=46) smooth out 4-element array of highp 4-component vector of float)
+0:?     'anon@4' (layout( location=50) out block{ out 10-element array of highp 4-component vector of float a18})
+0:?     'anon@5' ( out block{layout( location=60) out highp 2-component vector of float a19})
+0:?     'anon@6' ( out block{ out highp 4-component vector of float a20})
+0:?     'a21' ( smooth out 2-element array of highp 2-component vector of float)
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        'o' ( out highp 4-component vector of float)
+0:76        b1: direct index for structure ( in highp 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp highp 4-component vector of float)
+0:77        'o' ( out highp 4-component vector of float)
+0:77        b2: direct index for structure ( in highp 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp highp 4-component vector of float)
+0:78        'o' ( out highp 4-component vector of float)
+0:78        b3: direct index for structure ( in highp 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp highp 4-component vector of float)
+0:79        'o' ( out highp 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp highp 4-component vector of float)
+0:80        'o' ( out highp 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp highp 4-component vector of float)
+0:81        'o' ( out highp 4-component vector of float)
+0:81        b5: direct index for structure ( in highp 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp highp 4-component vector of float)
+0:82        'o' ( out highp 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp highp 4-component vector of float)
+0:83        'o' ( out highp 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp highp 4-component vector of float)
+0:84        'o' ( out highp 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp highp 4-component vector of float)
+0:85        'o' ( out highp 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp highp 4-component vector of float)
+0:86        'o' ( out highp 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp highp 4-component vector of float)
+0:87        'o' ( out highp 4-component vector of float)
+0:87        Construct vec4 ( temp highp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp highp 4-component vector of float)
+0:88        'o' ( out highp 4-component vector of float)
+0:88        vector swizzle ( temp highp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in highp 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp highp 4-component vector of float)
+0:89        'o' ( out highp 4-component vector of float)
+0:89        Construct vec4 ( temp highp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in highp float)
+0:89            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp highp 4-component vector of float)
+0:90        'o' ( out highp 4-component vector of float)
+0:90        vector swizzle ( temp highp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in highp 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp highp 4-component vector of float)
+0:91        'o' ( out highp 4-component vector of float)
+0:91        Construct vec4 ( temp highp 4-component vector of float)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp highp 4-component vector of float)
+0:92        'o' ( out highp 4-component vector of float)
+0:92        Construct vec4 ( temp highp 4-component vector of float)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp highp float)
+0:92            add ( temp highp float)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp highp float)
+0:92              b12: direct index for structure ( in 6-element array of highp float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp highp 4-component vector of float)
+0:93        'o' ( out highp 4-component vector of float)
+0:93        Construct vec4 ( temp highp 4-component vector of float)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp highp 4-component vector of float)
+0:95            'o' ( out highp 4-component vector of float)
+0:95            vector swizzle ( temp highp 4-component vector of float)
+0:95              matrix-times-vector ( temp highp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp highp 4-component vector of float)
+0:96            'o' ( out highp 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in highp 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp highp 4-component vector of float)
+0:97            'o' ( out highp 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in highp 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp highp 4-component vector of float)
+0:99        'o' ( out highp 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:99            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp highp 4-component vector of float)
+0:100        'o' ( out highp 4-component vector of float)
+0:100        indirect index ( temp highp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of highp 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:100            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp highp 4-component vector of float)
+0:101        'o' ( out highp 4-component vector of float)
+0:101        vector swizzle ( temp highp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp highp 4-component vector of float)
+0:102        'o' ( out highp 4-component vector of float)
+0:102        a20: direct index for structure ( in highp 4-component vector of float)
+0:102          'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp highp 4-component vector of float)
+0:103        'o' ( out highp 4-component vector of float)
+0:103        Construct vec4 ( temp highp 4-component vector of float)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:?     'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:?     'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in highp 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:?     'b16' ( flat in highp uint)
+0:?     'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:?     'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:?     'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:?     'o' ( out highp 4-component vector of float)
+
+Validation failed
+// Module Version 10000
+// Generated by (magic number): 8000b
+// Id's are bound by 128
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Vertex 4  "main" 13 18 26 34 43 56 75 82 98 110 115 121 124 127
+                              Source GLSL 460
+                              Name 4  "main"
+                              Name 13  "a0"
+                              Name 16  "ABlock0"
+                              MemberName 16(ABlock0) 0  "a1"
+                              Name 18  ""
+                              Name 24  "ABlock1"
+                              MemberName 24(ABlock1) 0  "a2"
+                              MemberName 24(ABlock1) 1  "a3"
+                              Name 26  ""
+                              Name 34  "a4"
+                              Name 41  "ABlock2"
+                              MemberName 41(ABlock2) 0  "a5"
+                              MemberName 41(ABlock2) 1  "a6"
+                              MemberName 41(ABlock2) 2  "a7"
+                              Name 43  ""
+                              Name 52  "S"
+                              MemberName 52(S) 0  "a"
+                              MemberName 52(S) 1  "b"
+                              Name 54  "ABlock3"
+                              MemberName 54(ABlock3) 0  "a8"
+                              MemberName 54(ABlock3) 1  "a9"
+                              MemberName 54(ABlock3) 2  "a10"
+                              MemberName 54(ABlock3) 3  "a11"
+                              Name 56  ""
+                              Name 75  "a12"
+                              Name 80  "AStruct1"
+                              MemberName 80(AStruct1) 0  "a13"
+                              MemberName 80(AStruct1) 1  "a14"
+                              MemberName 80(AStruct1) 2  "a15"
+                              Name 82  "s0"
+                              Name 98  "a17"
+                              Name 99  "UBO0"
+                              MemberName 99(UBO0) 0  "i"
+                              Name 101  "ubo0"
+                              Name 108  "ABlock4"
+                              MemberName 108(ABlock4) 0  "a18"
+                              Name 110  ""
+                              Name 113  "ABlock5"
+                              MemberName 113(ABlock5) 0  "a19"
+                              Name 115  ""
+                              Name 119  "Block0"
+                              MemberName 119(Block0) 0  "a20"
+                              Name 121  ""
+                              Name 124  "a21"
+                              Name 127  "a16"
+                              Decorate 13(a0) Location 40
+                              Decorate 16(ABlock0) Block
+                              Decorate 18 Location 1
+                              Decorate 24(ABlock1) Block
+                              MemberDecorate 24(ABlock1) 0 Location 3
+                              MemberDecorate 24(ABlock1) 1 Location 2
+                              Decorate 26 Location 0
+                              Decorate 34(a4) Location 5
+                              Decorate 41(ABlock2) Block
+                              MemberDecorate 41(ABlock2) 0 Location 4
+                              MemberDecorate 41(ABlock2) 1 Location 8
+                              MemberDecorate 41(ABlock2) 2 Location 10
+                              Decorate 43 Location 2
+                              Decorate 54(ABlock3) Block
+                              MemberDecorate 54(ABlock3) 0 Location 12
+                              MemberDecorate 54(ABlock3) 1 Location 15
+                              MemberDecorate 54(ABlock3) 2 Location 17
+                              MemberDecorate 54(ABlock3) 3 Location 19
+                              Decorate 56 Location 7
+                              Decorate 75(a12) Location 27
+                              Decorate 82(s0) Location 30
+                              Decorate 98(a17) Location 46
+                              Decorate 99(UBO0) Block
+                              MemberDecorate 99(UBO0) 0 Offset 0
+                              Decorate 101(ubo0) Binding 0
+                              Decorate 101(ubo0) DescriptorSet 0
+                              Decorate 108(ABlock4) Block
+                              Decorate 110 Location 50
+                              Decorate 113(ABlock5) Block
+                              MemberDecorate 113(ABlock5) 0 Location 60
+                              Decorate 115 Location 20
+                              Decorate 119(Block0) Block
+                              Decorate 121 Location 21
+                              Decorate 124(a21) Location 22
+                              Decorate 127(a16) Location 39
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeBool
+               7:     6(bool) ConstantFalse
+              10:             TypeFloat 32
+              11:             TypeVector 10(float) 4
+              12:             TypePointer Output 11(fvec4)
+          13(a0):     12(ptr) Variable Output
+              14:   10(float) Constant 1065353216
+              15:   11(fvec4) ConstantComposite 14 14 14 14
+     16(ABlock0):             TypeStruct 11(fvec4)
+              17:             TypePointer Output 16(ABlock0)
+              18:     17(ptr) Variable Output
+              19:             TypeInt 32 1
+              20:     19(int) Constant 0
+              21:   10(float) Constant 0
+              22:   11(fvec4) ConstantComposite 21 21 21 21
+     24(ABlock1):             TypeStruct 11(fvec4) 11(fvec4)
+              25:             TypePointer Output 24(ABlock1)
+              26:     25(ptr) Variable Output
+              28:     19(int) Constant 1
+              30:             TypeInt 32 0
+              31:     30(int) Constant 3
+              32:             TypeArray 11(fvec4) 31
+              33:             TypePointer Output 32
+          34(a4):     33(ptr) Variable Output
+              37:     19(int) Constant 2
+              39:     30(int) Constant 2
+              40:             TypeArray 11(fvec4) 39
+     41(ABlock2):             TypeStruct 11(fvec4) 40 40
+              42:             TypePointer Output 41(ABlock2)
+              43:     42(ptr) Variable Output
+              49:             TypeVector 10(float) 2
+              50:             TypeArray 49(fvec2) 39
+              51:             TypeArray 10(float) 31
+           52(S):             TypeStruct 51 10(float)
+              53:             TypeArray 52(S) 39
+     54(ABlock3):             TypeStruct 10(float) 50 40 53
+              55:             TypePointer Output 54(ABlock3)
+              56:     55(ptr) Variable Output
+              57:             TypePointer Output 10(float)
+              59:     30(int) Constant 0
+              61:     30(int) Constant 1
+              65:     19(int) Constant 3
+              74:             TypePointer Output 51
+         75(a12):     74(ptr) Variable Output
+              79:             TypeMatrix 11(fvec4) 4
+    80(AStruct1):             TypeStruct 49(fvec2) 52(S) 79
+              81:             TypePointer Output 80(AStruct1)
+          82(s0):     81(ptr) Variable Output
+              88:   11(fvec4) ConstantComposite 14 21 21 21
+              89:   11(fvec4) ConstantComposite 21 14 21 21
+              90:   11(fvec4) ConstantComposite 21 21 14 21
+              91:   11(fvec4) ConstantComposite 21 21 21 14
+              92:          79 ConstantComposite 88 89 90 91
+              93:             TypePointer Output 79
+              95:     30(int) Constant 4
+              96:             TypeArray 11(fvec4) 95
+              97:             TypePointer Output 96
+         98(a17):     97(ptr) Variable Output
+        99(UBO0):             TypeStruct 19(int)
+             100:             TypePointer Uniform 99(UBO0)
+       101(ubo0):    100(ptr) Variable Uniform
+             102:             TypePointer Uniform 19(int)
+             106:     30(int) Constant 10
+             107:             TypeArray 11(fvec4) 106
+    108(ABlock4):             TypeStruct 107
+             109:             TypePointer Output 108(ABlock4)
+             110:    109(ptr) Variable Output
+             111:     19(int) Constant 5
+    113(ABlock5):             TypeStruct 49(fvec2)
+             114:             TypePointer Output 113(ABlock5)
+             115:    114(ptr) Variable Output
+             116:   49(fvec2) ConstantComposite 21 21
+             117:             TypePointer Output 49(fvec2)
+     119(Block0):             TypeStruct 11(fvec4)
+             120:             TypePointer Output 119(Block0)
+             121:    120(ptr) Variable Output
+             123:             TypePointer Output 50
+        124(a21):    123(ptr) Variable Output
+        127(a16):     57(ptr) Variable Output
+         4(main):           2 Function None 3
+               5:             Label
+                              SelectionMerge 9 None
+                              BranchConditional 7 8 9
+               8:               Label
+                                Store 13(a0) 15
+                                Branch 9
+               9:             Label
+              23:     12(ptr) AccessChain 18 20
+                              Store 23 22
+              27:     12(ptr) AccessChain 26 20
+                              Store 27 22
+              29:     12(ptr) AccessChain 26 28
+                              Store 29 22
+              35:     12(ptr) AccessChain 34(a4) 20
+                              Store 35 22
+              36:     12(ptr) AccessChain 34(a4) 28
+                              Store 36 22
+              38:     12(ptr) AccessChain 34(a4) 37
+                              Store 38 22
+              44:     12(ptr) AccessChain 43 20
+                              Store 44 22
+              45:     12(ptr) AccessChain 43 28 20
+                              Store 45 22
+              46:     12(ptr) AccessChain 43 28 28
+                              Store 46 22
+              47:     12(ptr) AccessChain 43 37 20
+                              Store 47 22
+              48:     12(ptr) AccessChain 43 37 28
+                              Store 48 22
+              58:     57(ptr) AccessChain 56 20
+                              Store 58 21
+              60:     57(ptr) AccessChain 56 28 20 59
+                              Store 60 21
+              62:     57(ptr) AccessChain 56 28 28 61
+                              Store 62 21
+              63:     12(ptr) AccessChain 56 37 20
+                              Store 63 22
+              64:     12(ptr) AccessChain 56 37 28
+                              Store 64 22
+              66:     57(ptr) AccessChain 56 65 20 20 20
+                              Store 66 21
+              67:     57(ptr) AccessChain 56 65 20 20 28
+                              Store 67 21
+              68:     57(ptr) AccessChain 56 65 20 20 37
+                              Store 68 21
+              69:     57(ptr) AccessChain 56 65 20 28
+                              Store 69 21
+              70:     57(ptr) AccessChain 56 65 28 20 20
+                              Store 70 21
+              71:     57(ptr) AccessChain 56 65 28 20 28
+                              Store 71 21
+              72:     57(ptr) AccessChain 56 65 28 20 37
+                              Store 72 21
+              73:     57(ptr) AccessChain 56 65 28 28
+                              Store 73 21
+              76:     57(ptr) AccessChain 75(a12) 20
+                              Store 76 21
+              77:     57(ptr) AccessChain 75(a12) 28
+                              Store 77 21
+              78:     57(ptr) AccessChain 75(a12) 37
+                              Store 78 21
+              83:     57(ptr) AccessChain 82(s0) 20 61
+                              Store 83 21
+              84:     57(ptr) AccessChain 82(s0) 28 20 20
+                              Store 84 21
+              85:     57(ptr) AccessChain 82(s0) 28 20 28
+                              Store 85 21
+              86:     57(ptr) AccessChain 82(s0) 28 20 37
+                              Store 86 21
+              87:     57(ptr) AccessChain 82(s0) 28 28
+                              Store 87 21
+              94:     93(ptr) AccessChain 82(s0) 37
+                              Store 94 92
+             103:    102(ptr) AccessChain 101(ubo0) 20
+             104:     19(int) Load 103
+             105:     12(ptr) AccessChain 98(a17) 104
+                              Store 105 15
+             112:     12(ptr) AccessChain 110 20 111
+                              Store 112 15
+             118:    117(ptr) AccessChain 115 20
+                              Store 118 116
+             122:     12(ptr) AccessChain 121 20
+                              Store 122 15
+             125:    117(ptr) AccessChain 124(a21) 20
+                              Store 125 116
+             126:    117(ptr) AccessChain 124(a21) 28
+                              Store 126 116
+                              Return
+                              FunctionEnd

--- a/Test/baseResults/link.vk.crossStageIO.1.vert.out
+++ b/Test/baseResults/link.vk.crossStageIO.1.vert.out
@@ -1,0 +1,2157 @@
+link.vk.crossStageIO.1.vert
+Shader version: 460
+0:? Sequence
+0:66  Function Definition: main( ( global void)
+0:66    Function Parameters: 
+0:67    Sequence
+0:67      Test condition and select ( temp void)
+0:67        Condition
+0:67        Constant:
+0:67          false (const bool)
+0:67        true case
+0:68        Sequence
+0:68          move second child to first child ( temp highp 4-component vector of float)
+0:68            'a0' (layout( location=40) smooth out highp 4-component vector of float)
+0:68            Constant:
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:70      move second child to first child ( temp highp 4-component vector of float)
+0:70        a1: direct index for structure ( out highp 4-component vector of float)
+0:70          'anon@0' (layout( location=1) out block{ out highp 4-component vector of float a1})
+0:70          Constant:
+0:70            0 (const uint)
+0:70        Constant:
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:71      move second child to first child ( temp highp 4-component vector of float)
+0:71        a2: direct index for structure (layout( location=3) out highp 4-component vector of float)
+0:71          'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:71          Constant:
+0:71            0 (const uint)
+0:71        Constant:
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:72      move second child to first child ( temp highp 4-component vector of float)
+0:72        a3: direct index for structure (layout( location=2) out highp 4-component vector of float)
+0:72          'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:72          Constant:
+0:72            1 (const uint)
+0:72        Constant:
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:73      move second child to first child ( temp highp 4-component vector of float)
+0:73        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:73          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:73          Constant:
+0:73            0 (const int)
+0:73        Constant:
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:74      move second child to first child ( temp highp 4-component vector of float)
+0:74        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:74          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:74          Constant:
+0:74            1 (const int)
+0:74        Constant:
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:75      move second child to first child ( temp highp 4-component vector of float)
+0:75        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:75          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:75          Constant:
+0:75            2 (const int)
+0:75        Constant:
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        a5: direct index for structure (layout( location=4) out highp 4-component vector of float)
+0:76          'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        Constant:
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:77      move second child to first child ( temp highp 4-component vector of float)
+0:77        direct index (layout( location=8) temp highp 4-component vector of float)
+0:77          a6: direct index for structure (layout( location=8) out 2-element array of highp 4-component vector of float)
+0:77            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:77            Constant:
+0:77              1 (const uint)
+0:77          Constant:
+0:77            0 (const int)
+0:77        Constant:
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:78      move second child to first child ( temp highp 4-component vector of float)
+0:78        direct index (layout( location=8) temp highp 4-component vector of float)
+0:78          a6: direct index for structure (layout( location=8) out 2-element array of highp 4-component vector of float)
+0:78            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:78            Constant:
+0:78              1 (const uint)
+0:78          Constant:
+0:78            1 (const int)
+0:78        Constant:
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:79      move second child to first child ( temp highp 4-component vector of float)
+0:79        direct index (layout( location=10) temp highp 4-component vector of float)
+0:79          a7: direct index for structure (layout( location=10) out 2-element array of highp 4-component vector of float)
+0:79            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:79            Constant:
+0:79              2 (const uint)
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:80      move second child to first child ( temp highp 4-component vector of float)
+0:80        direct index (layout( location=10) temp highp 4-component vector of float)
+0:80          a7: direct index for structure (layout( location=10) out 2-element array of highp 4-component vector of float)
+0:80            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:80            Constant:
+0:80              2 (const uint)
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:81      move second child to first child ( temp highp float)
+0:81        a8: direct index for structure (layout( location=12) out highp float)
+0:81          'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:81          Constant:
+0:81            0 (const uint)
+0:81        Constant:
+0:81          0.000000
+0:82      move second child to first child ( temp highp float)
+0:82        direct index ( temp highp float)
+0:82          direct index (layout( location=15) temp highp 2-component vector of float)
+0:82            a9: direct index for structure (layout( location=15) out 2-element array of highp 2-component vector of float)
+0:82              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:82              Constant:
+0:82                1 (const uint)
+0:82            Constant:
+0:82              0 (const int)
+0:82          Constant:
+0:82            0 (const int)
+0:82        Constant:
+0:82          0.000000
+0:83      move second child to first child ( temp highp float)
+0:83        direct index ( temp highp float)
+0:83          direct index (layout( location=15) temp highp 2-component vector of float)
+0:83            a9: direct index for structure (layout( location=15) out 2-element array of highp 2-component vector of float)
+0:83              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:83              Constant:
+0:83                1 (const uint)
+0:83            Constant:
+0:83              1 (const int)
+0:83          Constant:
+0:83            1 (const int)
+0:83        Constant:
+0:83          0.000000
+0:84      move second child to first child ( temp highp 4-component vector of float)
+0:84        direct index (layout( location=17) temp highp 4-component vector of float)
+0:84          a10: direct index for structure (layout( location=17) out 2-element array of highp 4-component vector of float)
+0:84            'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:84            Constant:
+0:84              2 (const uint)
+0:84          Constant:
+0:84            0 (const int)
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:85      move second child to first child ( temp highp 4-component vector of float)
+0:85        direct index (layout( location=17) temp highp 4-component vector of float)
+0:85          a10: direct index for structure (layout( location=17) out 2-element array of highp 4-component vector of float)
+0:85            'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:85            Constant:
+0:85              2 (const uint)
+0:85          Constant:
+0:85            1 (const int)
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:86      move second child to first child ( temp highp float)
+0:86        direct index ( temp highp float)
+0:86          a: direct index for structure ( global 3-element array of highp float)
+0:86            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:86              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:86                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:86                Constant:
+0:86                  3 (const uint)
+0:86              Constant:
+0:86                0 (const int)
+0:86            Constant:
+0:86              0 (const int)
+0:86          Constant:
+0:86            0 (const int)
+0:86        Constant:
+0:86          0.000000
+0:87      move second child to first child ( temp highp float)
+0:87        direct index ( temp highp float)
+0:87          a: direct index for structure ( global 3-element array of highp float)
+0:87            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:87              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:87                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:87                Constant:
+0:87                  3 (const uint)
+0:87              Constant:
+0:87                0 (const int)
+0:87            Constant:
+0:87              0 (const int)
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          0.000000
+0:88      move second child to first child ( temp highp float)
+0:88        direct index ( temp highp float)
+0:88          a: direct index for structure ( global 3-element array of highp float)
+0:88            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:88              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:88                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:88                Constant:
+0:88                  3 (const uint)
+0:88              Constant:
+0:88                0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88          Constant:
+0:88            2 (const int)
+0:88        Constant:
+0:88          0.000000
+0:89      move second child to first child ( temp highp float)
+0:89        b: direct index for structure ( global highp float)
+0:89          direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:89            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:89              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:89              Constant:
+0:89                3 (const uint)
+0:89            Constant:
+0:89              0 (const int)
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          0.000000
+0:90      move second child to first child ( temp highp float)
+0:90        direct index ( temp highp float)
+0:90          a: direct index for structure ( global 3-element array of highp float)
+0:90            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:90              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:90                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:90                Constant:
+0:90                  3 (const uint)
+0:90              Constant:
+0:90                1 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:90          Constant:
+0:90            0 (const int)
+0:90        Constant:
+0:90          0.000000
+0:91      move second child to first child ( temp highp float)
+0:91        direct index ( temp highp float)
+0:91          a: direct index for structure ( global 3-element array of highp float)
+0:91            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:91              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:91                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:91                Constant:
+0:91                  3 (const uint)
+0:91              Constant:
+0:91                1 (const int)
+0:91            Constant:
+0:91              0 (const int)
+0:91          Constant:
+0:91            1 (const int)
+0:91        Constant:
+0:91          0.000000
+0:92      move second child to first child ( temp highp float)
+0:92        direct index ( temp highp float)
+0:92          a: direct index for structure ( global 3-element array of highp float)
+0:92            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:92              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:92                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:92                Constant:
+0:92                  3 (const uint)
+0:92              Constant:
+0:92                1 (const int)
+0:92            Constant:
+0:92              0 (const int)
+0:92          Constant:
+0:92            2 (const int)
+0:92        Constant:
+0:92          0.000000
+0:93      move second child to first child ( temp highp float)
+0:93        b: direct index for structure ( global highp float)
+0:93          direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:93            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:93              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:93              Constant:
+0:93                3 (const uint)
+0:93            Constant:
+0:93              1 (const int)
+0:93          Constant:
+0:93            1 (const int)
+0:93        Constant:
+0:93          0.000000
+0:94      move second child to first child ( temp highp float)
+0:94        direct index (layout( location=27) smooth temp highp float)
+0:94          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:94          Constant:
+0:94            0 (const int)
+0:94        Constant:
+0:94          0.000000
+0:95      move second child to first child ( temp highp float)
+0:95        direct index (layout( location=27) smooth temp highp float)
+0:95          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:95          Constant:
+0:95            1 (const int)
+0:95        Constant:
+0:95          0.000000
+0:96      move second child to first child ( temp highp float)
+0:96        direct index (layout( location=27) smooth temp highp float)
+0:96          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:96          Constant:
+0:96            2 (const int)
+0:96        Constant:
+0:96          0.000000
+0:97      move second child to first child ( temp highp float)
+0:97        direct index ( temp highp float)
+0:97          a13: direct index for structure ( global highp 2-component vector of float)
+0:97            's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:97            Constant:
+0:97              0 (const int)
+0:97          Constant:
+0:97            1 (const int)
+0:97        Constant:
+0:97          0.000000
+0:98      move second child to first child ( temp highp float)
+0:98        direct index ( temp highp float)
+0:98          a: direct index for structure ( global 3-element array of highp float)
+0:98            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:98              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:98              Constant:
+0:98                1 (const int)
+0:98            Constant:
+0:98              0 (const int)
+0:98          Constant:
+0:98            0 (const int)
+0:98        Constant:
+0:98          0.000000
+0:99      move second child to first child ( temp highp float)
+0:99        direct index ( temp highp float)
+0:99          a: direct index for structure ( global 3-element array of highp float)
+0:99            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:99              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:99              Constant:
+0:99                1 (const int)
+0:99            Constant:
+0:99              0 (const int)
+0:99          Constant:
+0:99            1 (const int)
+0:99        Constant:
+0:99          0.000000
+0:100      move second child to first child ( temp highp float)
+0:100        direct index ( temp highp float)
+0:100          a: direct index for structure ( global 3-element array of highp float)
+0:100            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:100              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:100              Constant:
+0:100                1 (const int)
+0:100            Constant:
+0:100              0 (const int)
+0:100          Constant:
+0:100            2 (const int)
+0:100        Constant:
+0:100          0.000000
+0:101      move second child to first child ( temp highp float)
+0:101        b: direct index for structure ( global highp float)
+0:101          a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:101            's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:101            Constant:
+0:101              1 (const int)
+0:101          Constant:
+0:101            1 (const int)
+0:101        Constant:
+0:101          0.000000
+0:102      move second child to first child ( temp highp 4X4 matrix of float)
+0:102        a15: direct index for structure ( global highp 4X4 matrix of float)
+0:102          's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:102          Constant:
+0:102            2 (const int)
+0:102        Constant:
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:104      move second child to first child ( temp highp 4-component vector of float)
+0:104        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:104          'a17' (layout( location=46) smooth out 4-element array of highp 4-component vector of float)
+0:104          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:104            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:104            Constant:
+0:104              0 (const int)
+0:104        Constant:
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:105      move second child to first child ( temp highp 4-component vector of float)
+0:105        direct index ( temp highp 4-component vector of float)
+0:105          a18: direct index for structure ( out 10-element array of highp 4-component vector of float)
+0:105            'anon@4' (layout( location=50) out block{ out 10-element array of highp 4-component vector of float a18})
+0:105            Constant:
+0:105              0 (const uint)
+0:105          Constant:
+0:105            5 (const int)
+0:105        Constant:
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:106      move second child to first child ( temp highp 2-component vector of float)
+0:106        a19: direct index for structure (layout( location=60) out highp 2-component vector of float)
+0:106          'anon@5' ( out block{layout( location=60) out highp 2-component vector of float a19})
+0:106          Constant:
+0:106            0 (const uint)
+0:106        Constant:
+0:106          0.000000
+0:106          0.000000
+0:107      move second child to first child ( temp highp 4-component vector of float)
+0:107        a20: direct index for structure ( out highp 4-component vector of float)
+0:107          'anon@6' ( out block{ out highp 4-component vector of float a20})
+0:107          Constant:
+0:107            0 (const uint)
+0:107        Constant:
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:108      move second child to first child ( temp highp 2-component vector of float)
+0:108        direct index ( smooth temp highp 2-component vector of float)
+0:108          'a21' ( smooth out 2-element array of highp 2-component vector of float)
+0:108          Constant:
+0:108            0 (const int)
+0:108        Constant:
+0:108          0.000000
+0:108          0.000000
+0:109      move second child to first child ( temp highp 2-component vector of float)
+0:109        direct index ( smooth temp highp 2-component vector of float)
+0:109          'a21' ( smooth out 2-element array of highp 2-component vector of float)
+0:109          Constant:
+0:109            1 (const int)
+0:109        Constant:
+0:109          0.000000
+0:109          0.000000
+0:?   Linker Objects
+0:?     'a0' (layout( location=40) smooth out highp 4-component vector of float)
+0:?     'anon@0' (layout( location=1) out block{ out highp 4-component vector of float a1})
+0:?     'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:?     'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:?     'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:?     'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:?     'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:?     's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:?     'a16' (layout( location=39) smooth out highp float)
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'a17' (layout( location=46) smooth out 4-element array of highp 4-component vector of float)
+0:?     'anon@4' (layout( location=50) out block{ out 10-element array of highp 4-component vector of float a18})
+0:?     'anon@5' ( out block{layout( location=60) out highp 2-component vector of float a19})
+0:?     'anon@6' ( out block{ out highp 4-component vector of float a20})
+0:?     'a21' ( smooth out 2-element array of highp 2-component vector of float)
+
+link.vk.crossStageIO.1.geom
+Shader version: 460
+invocations = -1
+max_vertices = 3
+input primitive = triangles
+output primitive = triangle_strip
+0:? Sequence
+0:28  Function Definition: main( ( global void)
+0:28    Function Parameters: 
+0:29    Sequence
+0:29      Sequence
+0:29        Sequence
+0:29          move second child to first child ( temp highp int)
+0:29            'i' ( temp highp int)
+0:29            Constant:
+0:29              0 (const int)
+0:29        Loop with condition tested first
+0:29          Loop Condition
+0:29          Compare Less Than ( temp bool)
+0:29            'i' ( temp highp int)
+0:29            Constant:
+0:29              32 (const int)
+0:29          Loop Body
+0:30          Sequence
+0:30            move second child to first child ( temp highp 4-component vector of float)
+0:30              indirect index (layout( location=0 stream=0) temp highp 4-component vector of float)
+0:30                'o0' (layout( location=0 stream=0) out 64-element array of highp 4-component vector of float)
+0:30                'i' ( temp highp int)
+0:30              indirect index (layout( location=0) temp highp 4-component vector of float)
+0:30                a0: direct index for structure (layout( location=0) in 64-element array of highp 4-component vector of float)
+0:30                  direct index ( temp block{layout( location=0) in 64-element array of highp 4-component vector of float a0})
+0:30                    'gs_in1' ( in 3-element array of block{layout( location=0) in 64-element array of highp 4-component vector of float a0})
+0:30                    Constant:
+0:30                      0 (const int)
+0:30                  Constant:
+0:30                    0 (const int)
+0:30                'i' ( temp highp int)
+0:29          Loop Terminal Expression
+0:29          Pre-Increment ( temp highp int)
+0:29            'i' ( temp highp int)
+0:33      move second child to first child ( temp highp 4-component vector of float)
+0:33        a20: direct index for structure (layout( stream=0) out highp 4-component vector of float)
+0:33          'gs_out0' (layout( stream=0) out block{layout( stream=0) out highp 4-component vector of float a20})
+0:33          Constant:
+0:33            0 (const int)
+0:33        a20: direct index for structure ( in highp 4-component vector of float)
+0:33          direct index ( temp block{ in highp 4-component vector of float a20})
+0:33            'gs_in0' ( in 3-element array of block{ in highp 4-component vector of float a20})
+0:33            Constant:
+0:33              0 (const int)
+0:33          Constant:
+0:33            0 (const int)
+0:34      move second child to first child ( temp highp 2-component vector of float)
+0:34        direct index (layout( stream=0) temp highp 2-component vector of float)
+0:34          'g_a21' (layout( stream=0) out 2-element array of highp 2-component vector of float)
+0:34          Constant:
+0:34            0 (const int)
+0:34        direct index ( temp highp 2-component vector of float)
+0:34          direct index ( temp 2-element array of highp 2-component vector of float)
+0:34            'a21' ( in 3-element array of 2-element array of highp 2-component vector of float)
+0:34            Constant:
+0:34              0 (const int)
+0:34          Constant:
+0:34            0 (const int)
+0:35      move second child to first child ( temp highp 2-component vector of float)
+0:35        direct index (layout( stream=0) temp highp 2-component vector of float)
+0:35          'g_a21' (layout( stream=0) out 2-element array of highp 2-component vector of float)
+0:35          Constant:
+0:35            0 (const int)
+0:35        direct index ( temp highp 2-component vector of float)
+0:35          direct index ( temp 2-element array of highp 2-component vector of float)
+0:35            'a21' ( in 3-element array of 2-element array of highp 2-component vector of float)
+0:35            Constant:
+0:35              0 (const int)
+0:35          Constant:
+0:35            1 (const int)
+0:37      move second child to first child ( temp 4-component vector of float)
+0:37        gl_Position: direct index for structure (layout( stream=0) gl_Position 4-component vector of float Position)
+0:37          'anon@0' (layout( stream=0) out block{layout( stream=0) gl_Position 4-component vector of float Position gl_Position, layout( stream=0) gl_PointSize float PointSize gl_PointSize, layout( stream=0) out unsized 1-element array of float ClipDistance gl_ClipDistance, layout( stream=0) out unsized 1-element array of float CullDistance gl_CullDistance})
+0:37          Constant:
+0:37            0 (const uint)
+0:37        Constant:
+0:37          0.000000
+0:37          0.000000
+0:37          0.000000
+0:37          0.000000
+0:39      EmitVertex ( global void)
+0:40      EmitVertex ( global void)
+0:41      EmitVertex ( global void)
+0:?   Linker Objects
+0:?     'gs_in0' ( in 3-element array of block{ in highp 4-component vector of float a20})
+0:?     'a21' ( in 3-element array of 2-element array of highp 2-component vector of float)
+0:?     'gs_out0' (layout( stream=0) out block{layout( stream=0) out highp 4-component vector of float a20})
+0:?     'g_a21' (layout( stream=0) out 2-element array of highp 2-component vector of float)
+0:?     'gs_in1' ( in 3-element array of block{layout( location=0) in 64-element array of highp 4-component vector of float a0})
+0:?     'o0' (layout( location=0 stream=0) out 64-element array of highp 4-component vector of float)
+0:?     'anon@0' (layout( stream=0) out block{layout( stream=0) gl_Position 4-component vector of float Position gl_Position, layout( stream=0) gl_PointSize float PointSize gl_PointSize, layout( stream=0) out unsized 1-element array of float ClipDistance gl_ClipDistance, layout( stream=0) out unsized 1-element array of float CullDistance gl_CullDistance})
+
+link.vk.crossStageIO.1.frag
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:71  Function Definition: uncalled( ( global highp uint)
+0:71    Function Parameters: 
+0:72    Sequence
+0:72      Branch: Return with expression
+0:72        'b16' ( flat in highp uint)
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        'o' ( out highp 4-component vector of float)
+0:76        b1: direct index for structure ( in highp 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp highp 4-component vector of float)
+0:77        'o' ( out highp 4-component vector of float)
+0:77        b2: direct index for structure ( in highp 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp highp 4-component vector of float)
+0:78        'o' ( out highp 4-component vector of float)
+0:78        b3: direct index for structure ( in highp 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp highp 4-component vector of float)
+0:79        'o' ( out highp 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp highp 4-component vector of float)
+0:80        'o' ( out highp 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp highp 4-component vector of float)
+0:81        'o' ( out highp 4-component vector of float)
+0:81        b5: direct index for structure ( in highp 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp highp 4-component vector of float)
+0:82        'o' ( out highp 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp highp 4-component vector of float)
+0:83        'o' ( out highp 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp highp 4-component vector of float)
+0:84        'o' ( out highp 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp highp 4-component vector of float)
+0:85        'o' ( out highp 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp highp 4-component vector of float)
+0:86        'o' ( out highp 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp highp 4-component vector of float)
+0:87        'o' ( out highp 4-component vector of float)
+0:87        Construct vec4 ( temp highp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp highp 4-component vector of float)
+0:88        'o' ( out highp 4-component vector of float)
+0:88        vector swizzle ( temp highp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in highp 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp highp 4-component vector of float)
+0:89        'o' ( out highp 4-component vector of float)
+0:89        Construct vec4 ( temp highp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in highp float)
+0:89            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp highp 4-component vector of float)
+0:90        'o' ( out highp 4-component vector of float)
+0:90        vector swizzle ( temp highp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in highp 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp highp 4-component vector of float)
+0:91        'o' ( out highp 4-component vector of float)
+0:91        Construct vec4 ( temp highp 4-component vector of float)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp highp 4-component vector of float)
+0:92        'o' ( out highp 4-component vector of float)
+0:92        Construct vec4 ( temp highp 4-component vector of float)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp highp float)
+0:92            add ( temp highp float)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp highp float)
+0:92              b12: direct index for structure ( in 6-element array of highp float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp highp 4-component vector of float)
+0:93        'o' ( out highp 4-component vector of float)
+0:93        Construct vec4 ( temp highp 4-component vector of float)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp highp 4-component vector of float)
+0:95            'o' ( out highp 4-component vector of float)
+0:95            vector swizzle ( temp highp 4-component vector of float)
+0:95              matrix-times-vector ( temp highp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp highp 4-component vector of float)
+0:96            'o' ( out highp 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in highp 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp highp 4-component vector of float)
+0:97            'o' ( out highp 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in highp 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp highp 4-component vector of float)
+0:99        'o' ( out highp 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:99            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp highp 4-component vector of float)
+0:100        'o' ( out highp 4-component vector of float)
+0:100        indirect index ( temp highp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of highp 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:100            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp highp 4-component vector of float)
+0:101        'o' ( out highp 4-component vector of float)
+0:101        vector swizzle ( temp highp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp highp 4-component vector of float)
+0:102        'o' ( out highp 4-component vector of float)
+0:102        a20: direct index for structure ( in highp 4-component vector of float)
+0:102          'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp highp 4-component vector of float)
+0:103        'o' ( out highp 4-component vector of float)
+0:103        Construct vec4 ( temp highp 4-component vector of float)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'g_a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'g_a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:?     'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:?     'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in highp 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:?     'b16' ( flat in highp uint)
+0:?     'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:?     'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:?     'g_a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:?     'o' ( out highp 4-component vector of float)
+
+
+Linked vertex stage:
+
+
+Linked geometry stage:
+
+
+Linked fragment stage:
+
+
+Shader version: 460
+0:? Sequence
+0:66  Function Definition: main( ( global void)
+0:66    Function Parameters: 
+0:67    Sequence
+0:67      Test condition and select ( temp void)
+0:67        Condition
+0:67        Constant:
+0:67          false (const bool)
+0:67        true case
+0:68        Sequence
+0:68          move second child to first child ( temp highp 4-component vector of float)
+0:68            'a0' (layout( location=40) smooth out highp 4-component vector of float)
+0:68            Constant:
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:68              1.000000
+0:70      move second child to first child ( temp highp 4-component vector of float)
+0:70        a1: direct index for structure ( out highp 4-component vector of float)
+0:70          'anon@0' (layout( location=1) out block{ out highp 4-component vector of float a1})
+0:70          Constant:
+0:70            0 (const uint)
+0:70        Constant:
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:70          0.000000
+0:71      move second child to first child ( temp highp 4-component vector of float)
+0:71        a2: direct index for structure (layout( location=3) out highp 4-component vector of float)
+0:71          'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:71          Constant:
+0:71            0 (const uint)
+0:71        Constant:
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:71          0.000000
+0:72      move second child to first child ( temp highp 4-component vector of float)
+0:72        a3: direct index for structure (layout( location=2) out highp 4-component vector of float)
+0:72          'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:72          Constant:
+0:72            1 (const uint)
+0:72        Constant:
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:72          0.000000
+0:73      move second child to first child ( temp highp 4-component vector of float)
+0:73        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:73          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:73          Constant:
+0:73            0 (const int)
+0:73        Constant:
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:73          0.000000
+0:74      move second child to first child ( temp highp 4-component vector of float)
+0:74        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:74          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:74          Constant:
+0:74            1 (const int)
+0:74        Constant:
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:74          0.000000
+0:75      move second child to first child ( temp highp 4-component vector of float)
+0:75        direct index (layout( location=5) smooth temp highp 4-component vector of float)
+0:75          'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:75          Constant:
+0:75            2 (const int)
+0:75        Constant:
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:75          0.000000
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        a5: direct index for structure (layout( location=4) out highp 4-component vector of float)
+0:76          'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        Constant:
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:76          0.000000
+0:77      move second child to first child ( temp highp 4-component vector of float)
+0:77        direct index (layout( location=8) temp highp 4-component vector of float)
+0:77          a6: direct index for structure (layout( location=8) out 2-element array of highp 4-component vector of float)
+0:77            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:77            Constant:
+0:77              1 (const uint)
+0:77          Constant:
+0:77            0 (const int)
+0:77        Constant:
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:77          0.000000
+0:78      move second child to first child ( temp highp 4-component vector of float)
+0:78        direct index (layout( location=8) temp highp 4-component vector of float)
+0:78          a6: direct index for structure (layout( location=8) out 2-element array of highp 4-component vector of float)
+0:78            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:78            Constant:
+0:78              1 (const uint)
+0:78          Constant:
+0:78            1 (const int)
+0:78        Constant:
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:78          0.000000
+0:79      move second child to first child ( temp highp 4-component vector of float)
+0:79        direct index (layout( location=10) temp highp 4-component vector of float)
+0:79          a7: direct index for structure (layout( location=10) out 2-element array of highp 4-component vector of float)
+0:79            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:79            Constant:
+0:79              2 (const uint)
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:79          0.000000
+0:80      move second child to first child ( temp highp 4-component vector of float)
+0:80        direct index (layout( location=10) temp highp 4-component vector of float)
+0:80          a7: direct index for structure (layout( location=10) out 2-element array of highp 4-component vector of float)
+0:80            'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:80            Constant:
+0:80              2 (const uint)
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:80          0.000000
+0:81      move second child to first child ( temp highp float)
+0:81        a8: direct index for structure (layout( location=12) out highp float)
+0:81          'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:81          Constant:
+0:81            0 (const uint)
+0:81        Constant:
+0:81          0.000000
+0:82      move second child to first child ( temp highp float)
+0:82        direct index ( temp highp float)
+0:82          direct index (layout( location=15) temp highp 2-component vector of float)
+0:82            a9: direct index for structure (layout( location=15) out 2-element array of highp 2-component vector of float)
+0:82              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:82              Constant:
+0:82                1 (const uint)
+0:82            Constant:
+0:82              0 (const int)
+0:82          Constant:
+0:82            0 (const int)
+0:82        Constant:
+0:82          0.000000
+0:83      move second child to first child ( temp highp float)
+0:83        direct index ( temp highp float)
+0:83          direct index (layout( location=15) temp highp 2-component vector of float)
+0:83            a9: direct index for structure (layout( location=15) out 2-element array of highp 2-component vector of float)
+0:83              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:83              Constant:
+0:83                1 (const uint)
+0:83            Constant:
+0:83              1 (const int)
+0:83          Constant:
+0:83            1 (const int)
+0:83        Constant:
+0:83          0.000000
+0:84      move second child to first child ( temp highp 4-component vector of float)
+0:84        direct index (layout( location=17) temp highp 4-component vector of float)
+0:84          a10: direct index for structure (layout( location=17) out 2-element array of highp 4-component vector of float)
+0:84            'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:84            Constant:
+0:84              2 (const uint)
+0:84          Constant:
+0:84            0 (const int)
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:84          0.000000
+0:85      move second child to first child ( temp highp 4-component vector of float)
+0:85        direct index (layout( location=17) temp highp 4-component vector of float)
+0:85          a10: direct index for structure (layout( location=17) out 2-element array of highp 4-component vector of float)
+0:85            'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:85            Constant:
+0:85              2 (const uint)
+0:85          Constant:
+0:85            1 (const int)
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:85          0.000000
+0:86      move second child to first child ( temp highp float)
+0:86        direct index ( temp highp float)
+0:86          a: direct index for structure ( global 3-element array of highp float)
+0:86            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:86              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:86                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:86                Constant:
+0:86                  3 (const uint)
+0:86              Constant:
+0:86                0 (const int)
+0:86            Constant:
+0:86              0 (const int)
+0:86          Constant:
+0:86            0 (const int)
+0:86        Constant:
+0:86          0.000000
+0:87      move second child to first child ( temp highp float)
+0:87        direct index ( temp highp float)
+0:87          a: direct index for structure ( global 3-element array of highp float)
+0:87            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:87              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:87                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:87                Constant:
+0:87                  3 (const uint)
+0:87              Constant:
+0:87                0 (const int)
+0:87            Constant:
+0:87              0 (const int)
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          0.000000
+0:88      move second child to first child ( temp highp float)
+0:88        direct index ( temp highp float)
+0:88          a: direct index for structure ( global 3-element array of highp float)
+0:88            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:88              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:88                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:88                Constant:
+0:88                  3 (const uint)
+0:88              Constant:
+0:88                0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88          Constant:
+0:88            2 (const int)
+0:88        Constant:
+0:88          0.000000
+0:89      move second child to first child ( temp highp float)
+0:89        b: direct index for structure ( global highp float)
+0:89          direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:89            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:89              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:89              Constant:
+0:89                3 (const uint)
+0:89            Constant:
+0:89              0 (const int)
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          0.000000
+0:90      move second child to first child ( temp highp float)
+0:90        direct index ( temp highp float)
+0:90          a: direct index for structure ( global 3-element array of highp float)
+0:90            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:90              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:90                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:90                Constant:
+0:90                  3 (const uint)
+0:90              Constant:
+0:90                1 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:90          Constant:
+0:90            0 (const int)
+0:90        Constant:
+0:90          0.000000
+0:91      move second child to first child ( temp highp float)
+0:91        direct index ( temp highp float)
+0:91          a: direct index for structure ( global 3-element array of highp float)
+0:91            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:91              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:91                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:91                Constant:
+0:91                  3 (const uint)
+0:91              Constant:
+0:91                1 (const int)
+0:91            Constant:
+0:91              0 (const int)
+0:91          Constant:
+0:91            1 (const int)
+0:91        Constant:
+0:91          0.000000
+0:92      move second child to first child ( temp highp float)
+0:92        direct index ( temp highp float)
+0:92          a: direct index for structure ( global 3-element array of highp float)
+0:92            direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:92              a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:92                'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:92                Constant:
+0:92                  3 (const uint)
+0:92              Constant:
+0:92                1 (const int)
+0:92            Constant:
+0:92              0 (const int)
+0:92          Constant:
+0:92            2 (const int)
+0:92        Constant:
+0:92          0.000000
+0:93      move second child to first child ( temp highp float)
+0:93        b: direct index for structure ( global highp float)
+0:93          direct index (layout( location=19) temp structure{ global 3-element array of highp float a,  global highp float b})
+0:93            a11: direct index for structure (layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b})
+0:93              'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:93              Constant:
+0:93                3 (const uint)
+0:93            Constant:
+0:93              1 (const int)
+0:93          Constant:
+0:93            1 (const int)
+0:93        Constant:
+0:93          0.000000
+0:94      move second child to first child ( temp highp float)
+0:94        direct index (layout( location=27) smooth temp highp float)
+0:94          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:94          Constant:
+0:94            0 (const int)
+0:94        Constant:
+0:94          0.000000
+0:95      move second child to first child ( temp highp float)
+0:95        direct index (layout( location=27) smooth temp highp float)
+0:95          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:95          Constant:
+0:95            1 (const int)
+0:95        Constant:
+0:95          0.000000
+0:96      move second child to first child ( temp highp float)
+0:96        direct index (layout( location=27) smooth temp highp float)
+0:96          'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:96          Constant:
+0:96            2 (const int)
+0:96        Constant:
+0:96          0.000000
+0:97      move second child to first child ( temp highp float)
+0:97        direct index ( temp highp float)
+0:97          a13: direct index for structure ( global highp 2-component vector of float)
+0:97            's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:97            Constant:
+0:97              0 (const int)
+0:97          Constant:
+0:97            1 (const int)
+0:97        Constant:
+0:97          0.000000
+0:98      move second child to first child ( temp highp float)
+0:98        direct index ( temp highp float)
+0:98          a: direct index for structure ( global 3-element array of highp float)
+0:98            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:98              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:98              Constant:
+0:98                1 (const int)
+0:98            Constant:
+0:98              0 (const int)
+0:98          Constant:
+0:98            0 (const int)
+0:98        Constant:
+0:98          0.000000
+0:99      move second child to first child ( temp highp float)
+0:99        direct index ( temp highp float)
+0:99          a: direct index for structure ( global 3-element array of highp float)
+0:99            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:99              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:99              Constant:
+0:99                1 (const int)
+0:99            Constant:
+0:99              0 (const int)
+0:99          Constant:
+0:99            1 (const int)
+0:99        Constant:
+0:99          0.000000
+0:100      move second child to first child ( temp highp float)
+0:100        direct index ( temp highp float)
+0:100          a: direct index for structure ( global 3-element array of highp float)
+0:100            a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:100              's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:100              Constant:
+0:100                1 (const int)
+0:100            Constant:
+0:100              0 (const int)
+0:100          Constant:
+0:100            2 (const int)
+0:100        Constant:
+0:100          0.000000
+0:101      move second child to first child ( temp highp float)
+0:101        b: direct index for structure ( global highp float)
+0:101          a14: direct index for structure ( global structure{ global 3-element array of highp float a,  global highp float b})
+0:101            's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:101            Constant:
+0:101              1 (const int)
+0:101          Constant:
+0:101            1 (const int)
+0:101        Constant:
+0:101          0.000000
+0:102      move second child to first child ( temp highp 4X4 matrix of float)
+0:102        a15: direct index for structure ( global highp 4X4 matrix of float)
+0:102          's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:102          Constant:
+0:102            2 (const int)
+0:102        Constant:
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          0.000000
+0:102          1.000000
+0:104      move second child to first child ( temp highp 4-component vector of float)
+0:104        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:104          'a17' (layout( location=46) smooth out 4-element array of highp 4-component vector of float)
+0:104          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:104            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:104            Constant:
+0:104              0 (const int)
+0:104        Constant:
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:104          1.000000
+0:105      move second child to first child ( temp highp 4-component vector of float)
+0:105        direct index ( temp highp 4-component vector of float)
+0:105          a18: direct index for structure ( out 10-element array of highp 4-component vector of float)
+0:105            'anon@4' (layout( location=50) out block{ out 10-element array of highp 4-component vector of float a18})
+0:105            Constant:
+0:105              0 (const uint)
+0:105          Constant:
+0:105            5 (const int)
+0:105        Constant:
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:105          1.000000
+0:106      move second child to first child ( temp highp 2-component vector of float)
+0:106        a19: direct index for structure (layout( location=60) out highp 2-component vector of float)
+0:106          'anon@5' ( out block{layout( location=60) out highp 2-component vector of float a19})
+0:106          Constant:
+0:106            0 (const uint)
+0:106        Constant:
+0:106          0.000000
+0:106          0.000000
+0:107      move second child to first child ( temp highp 4-component vector of float)
+0:107        a20: direct index for structure ( out highp 4-component vector of float)
+0:107          'anon@6' ( out block{ out highp 4-component vector of float a20})
+0:107          Constant:
+0:107            0 (const uint)
+0:107        Constant:
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:107          1.000000
+0:108      move second child to first child ( temp highp 2-component vector of float)
+0:108        direct index ( smooth temp highp 2-component vector of float)
+0:108          'a21' ( smooth out 2-element array of highp 2-component vector of float)
+0:108          Constant:
+0:108            0 (const int)
+0:108        Constant:
+0:108          0.000000
+0:108          0.000000
+0:109      move second child to first child ( temp highp 2-component vector of float)
+0:109        direct index ( smooth temp highp 2-component vector of float)
+0:109          'a21' ( smooth out 2-element array of highp 2-component vector of float)
+0:109          Constant:
+0:109            1 (const int)
+0:109        Constant:
+0:109          0.000000
+0:109          0.000000
+0:?   Linker Objects
+0:?     'a0' (layout( location=40) smooth out highp 4-component vector of float)
+0:?     'anon@0' (layout( location=1) out block{ out highp 4-component vector of float a1})
+0:?     'anon@1' ( out block{layout( location=3) out highp 4-component vector of float a2, layout( location=2) out highp 4-component vector of float a3})
+0:?     'a4' (layout( location=5) smooth out 3-element array of highp 4-component vector of float)
+0:?     'anon@2' ( out block{layout( location=4) out highp 4-component vector of float a5, layout( location=8) out 2-element array of highp 4-component vector of float a6, layout( location=10) out 2-element array of highp 4-component vector of float a7})
+0:?     'anon@3' ( out block{layout( location=12) out highp float a8, layout( location=15) out 2-element array of highp 2-component vector of float a9, layout( location=17) out 2-element array of highp 4-component vector of float a10, layout( location=19) out 2-element array of structure{ global 3-element array of highp float a,  global highp float b} a11})
+0:?     'a12' (layout( location=27) smooth out 3-element array of highp float)
+0:?     's0' (layout( location=30) smooth out structure{ global highp 2-component vector of float a13,  global structure{ global 3-element array of highp float a,  global highp float b} a14,  global highp 4X4 matrix of float a15})
+0:?     'a16' (layout( location=39) smooth out highp float)
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'a17' (layout( location=46) smooth out 4-element array of highp 4-component vector of float)
+0:?     'anon@4' (layout( location=50) out block{ out 10-element array of highp 4-component vector of float a18})
+0:?     'anon@5' ( out block{layout( location=60) out highp 2-component vector of float a19})
+0:?     'anon@6' ( out block{ out highp 4-component vector of float a20})
+0:?     'a21' ( smooth out 2-element array of highp 2-component vector of float)
+Shader version: 460
+invocations = 1
+max_vertices = 3
+input primitive = triangles
+output primitive = triangle_strip
+0:? Sequence
+0:28  Function Definition: main( ( global void)
+0:28    Function Parameters: 
+0:29    Sequence
+0:29      Sequence
+0:29        Sequence
+0:29          move second child to first child ( temp highp int)
+0:29            'i' ( temp highp int)
+0:29            Constant:
+0:29              0 (const int)
+0:29        Loop with condition tested first
+0:29          Loop Condition
+0:29          Compare Less Than ( temp bool)
+0:29            'i' ( temp highp int)
+0:29            Constant:
+0:29              32 (const int)
+0:29          Loop Body
+0:30          Sequence
+0:30            move second child to first child ( temp highp 4-component vector of float)
+0:30              indirect index (layout( location=0 stream=0) temp highp 4-component vector of float)
+0:30                'o0' (layout( location=0 stream=0) out 64-element array of highp 4-component vector of float)
+0:30                'i' ( temp highp int)
+0:30              indirect index (layout( location=0) temp highp 4-component vector of float)
+0:30                a0: direct index for structure (layout( location=0) in 64-element array of highp 4-component vector of float)
+0:30                  direct index ( temp block{layout( location=0) in 64-element array of highp 4-component vector of float a0})
+0:30                    'gs_in1' ( in 3-element array of block{layout( location=0) in 64-element array of highp 4-component vector of float a0})
+0:30                    Constant:
+0:30                      0 (const int)
+0:30                  Constant:
+0:30                    0 (const int)
+0:30                'i' ( temp highp int)
+0:29          Loop Terminal Expression
+0:29          Pre-Increment ( temp highp int)
+0:29            'i' ( temp highp int)
+0:33      move second child to first child ( temp highp 4-component vector of float)
+0:33        a20: direct index for structure (layout( stream=0) out highp 4-component vector of float)
+0:33          'gs_out0' (layout( stream=0) out block{layout( stream=0) out highp 4-component vector of float a20})
+0:33          Constant:
+0:33            0 (const int)
+0:33        a20: direct index for structure ( in highp 4-component vector of float)
+0:33          direct index ( temp block{ in highp 4-component vector of float a20})
+0:33            'gs_in0' ( in 3-element array of block{ in highp 4-component vector of float a20})
+0:33            Constant:
+0:33              0 (const int)
+0:33          Constant:
+0:33            0 (const int)
+0:34      move second child to first child ( temp highp 2-component vector of float)
+0:34        direct index (layout( stream=0) temp highp 2-component vector of float)
+0:34          'g_a21' (layout( stream=0) out 2-element array of highp 2-component vector of float)
+0:34          Constant:
+0:34            0 (const int)
+0:34        direct index ( temp highp 2-component vector of float)
+0:34          direct index ( temp 2-element array of highp 2-component vector of float)
+0:34            'a21' ( in 3-element array of 2-element array of highp 2-component vector of float)
+0:34            Constant:
+0:34              0 (const int)
+0:34          Constant:
+0:34            0 (const int)
+0:35      move second child to first child ( temp highp 2-component vector of float)
+0:35        direct index (layout( stream=0) temp highp 2-component vector of float)
+0:35          'g_a21' (layout( stream=0) out 2-element array of highp 2-component vector of float)
+0:35          Constant:
+0:35            0 (const int)
+0:35        direct index ( temp highp 2-component vector of float)
+0:35          direct index ( temp 2-element array of highp 2-component vector of float)
+0:35            'a21' ( in 3-element array of 2-element array of highp 2-component vector of float)
+0:35            Constant:
+0:35              0 (const int)
+0:35          Constant:
+0:35            1 (const int)
+0:37      move second child to first child ( temp 4-component vector of float)
+0:37        gl_Position: direct index for structure (layout( stream=0) gl_Position 4-component vector of float Position)
+0:37          'anon@0' (layout( stream=0) out block{layout( stream=0) gl_Position 4-component vector of float Position gl_Position, layout( stream=0) gl_PointSize float PointSize gl_PointSize, layout( stream=0) out 1-element array of float ClipDistance gl_ClipDistance, layout( stream=0) out 1-element array of float CullDistance gl_CullDistance})
+0:37          Constant:
+0:37            0 (const uint)
+0:37        Constant:
+0:37          0.000000
+0:37          0.000000
+0:37          0.000000
+0:37          0.000000
+0:39      EmitVertex ( global void)
+0:40      EmitVertex ( global void)
+0:41      EmitVertex ( global void)
+0:?   Linker Objects
+0:?     'gs_in0' ( in 3-element array of block{ in highp 4-component vector of float a20})
+0:?     'a21' ( in 3-element array of 2-element array of highp 2-component vector of float)
+0:?     'gs_out0' (layout( stream=0) out block{layout( stream=0) out highp 4-component vector of float a20})
+0:?     'g_a21' (layout( stream=0) out 2-element array of highp 2-component vector of float)
+0:?     'gs_in1' ( in 3-element array of block{layout( location=0) in 64-element array of highp 4-component vector of float a0})
+0:?     'o0' (layout( location=0 stream=0) out 64-element array of highp 4-component vector of float)
+0:?     'anon@0' (layout( stream=0) out block{layout( stream=0) gl_Position 4-component vector of float Position gl_Position, layout( stream=0) gl_PointSize float PointSize gl_PointSize, layout( stream=0) out 1-element array of float ClipDistance gl_ClipDistance, layout( stream=0) out 1-element array of float CullDistance gl_CullDistance})
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        'o' ( out highp 4-component vector of float)
+0:76        b1: direct index for structure ( in highp 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp highp 4-component vector of float)
+0:77        'o' ( out highp 4-component vector of float)
+0:77        b2: direct index for structure ( in highp 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp highp 4-component vector of float)
+0:78        'o' ( out highp 4-component vector of float)
+0:78        b3: direct index for structure ( in highp 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp highp 4-component vector of float)
+0:79        'o' ( out highp 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp highp 4-component vector of float)
+0:80        'o' ( out highp 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp highp 4-component vector of float)
+0:81        'o' ( out highp 4-component vector of float)
+0:81        b5: direct index for structure ( in highp 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp highp 4-component vector of float)
+0:82        'o' ( out highp 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp highp 4-component vector of float)
+0:83        'o' ( out highp 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp highp 4-component vector of float)
+0:84        'o' ( out highp 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp highp 4-component vector of float)
+0:85        'o' ( out highp 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp highp 4-component vector of float)
+0:86        'o' ( out highp 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp highp 4-component vector of float)
+0:87        'o' ( out highp 4-component vector of float)
+0:87        Construct vec4 ( temp highp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp highp 4-component vector of float)
+0:88        'o' ( out highp 4-component vector of float)
+0:88        vector swizzle ( temp highp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in highp 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp highp 4-component vector of float)
+0:89        'o' ( out highp 4-component vector of float)
+0:89        Construct vec4 ( temp highp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in highp float)
+0:89            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp highp 4-component vector of float)
+0:90        'o' ( out highp 4-component vector of float)
+0:90        vector swizzle ( temp highp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in highp 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp highp 4-component vector of float)
+0:91        'o' ( out highp 4-component vector of float)
+0:91        Construct vec4 ( temp highp 4-component vector of float)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp highp 4-component vector of float)
+0:92        'o' ( out highp 4-component vector of float)
+0:92        Construct vec4 ( temp highp 4-component vector of float)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp highp float)
+0:92            add ( temp highp float)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp highp float)
+0:92              b12: direct index for structure ( in 6-element array of highp float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp highp 4-component vector of float)
+0:93        'o' ( out highp 4-component vector of float)
+0:93        Construct vec4 ( temp highp 4-component vector of float)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp highp 4-component vector of float)
+0:95            'o' ( out highp 4-component vector of float)
+0:95            vector swizzle ( temp highp 4-component vector of float)
+0:95              matrix-times-vector ( temp highp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp highp 4-component vector of float)
+0:96            'o' ( out highp 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in highp 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp highp 4-component vector of float)
+0:97            'o' ( out highp 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in highp 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp highp 4-component vector of float)
+0:99        'o' ( out highp 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:99            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp highp 4-component vector of float)
+0:100        'o' ( out highp 4-component vector of float)
+0:100        indirect index ( temp highp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of highp 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:100            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp highp 4-component vector of float)
+0:101        'o' ( out highp 4-component vector of float)
+0:101        vector swizzle ( temp highp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp highp 4-component vector of float)
+0:102        'o' ( out highp 4-component vector of float)
+0:102        a20: direct index for structure ( in highp 4-component vector of float)
+0:102          'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp highp 4-component vector of float)
+0:103        'o' ( out highp 4-component vector of float)
+0:103        Construct vec4 ( temp highp 4-component vector of float)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'g_a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'g_a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:?     'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:?     'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in highp 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:?     'b16' ( flat in highp uint)
+0:?     'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:?     'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:?     'g_a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:?     'o' ( out highp 4-component vector of float)
+
+Validation failed
+// Module Version 10000
+// Generated by (magic number): 8000b
+// Id's are bound by 128
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Vertex 4  "main" 13 18 26 34 43 56 75 82 98 110 115 121 124 127
+                              Source GLSL 460
+                              Name 4  "main"
+                              Name 13  "a0"
+                              Name 16  "ABlock0"
+                              MemberName 16(ABlock0) 0  "a1"
+                              Name 18  ""
+                              Name 24  "ABlock1"
+                              MemberName 24(ABlock1) 0  "a2"
+                              MemberName 24(ABlock1) 1  "a3"
+                              Name 26  ""
+                              Name 34  "a4"
+                              Name 41  "ABlock2"
+                              MemberName 41(ABlock2) 0  "a5"
+                              MemberName 41(ABlock2) 1  "a6"
+                              MemberName 41(ABlock2) 2  "a7"
+                              Name 43  ""
+                              Name 52  "S"
+                              MemberName 52(S) 0  "a"
+                              MemberName 52(S) 1  "b"
+                              Name 54  "ABlock3"
+                              MemberName 54(ABlock3) 0  "a8"
+                              MemberName 54(ABlock3) 1  "a9"
+                              MemberName 54(ABlock3) 2  "a10"
+                              MemberName 54(ABlock3) 3  "a11"
+                              Name 56  ""
+                              Name 75  "a12"
+                              Name 80  "AStruct1"
+                              MemberName 80(AStruct1) 0  "a13"
+                              MemberName 80(AStruct1) 1  "a14"
+                              MemberName 80(AStruct1) 2  "a15"
+                              Name 82  "s0"
+                              Name 98  "a17"
+                              Name 99  "UBO0"
+                              MemberName 99(UBO0) 0  "i"
+                              Name 101  "ubo0"
+                              Name 108  "ABlock4"
+                              MemberName 108(ABlock4) 0  "a18"
+                              Name 110  ""
+                              Name 113  "ABlock5"
+                              MemberName 113(ABlock5) 0  "a19"
+                              Name 115  ""
+                              Name 119  "Block0"
+                              MemberName 119(Block0) 0  "a20"
+                              Name 121  ""
+                              Name 124  "a21"
+                              Name 127  "a16"
+                              Decorate 13(a0) Location 40
+                              Decorate 16(ABlock0) Block
+                              Decorate 18 Location 1
+                              Decorate 24(ABlock1) Block
+                              MemberDecorate 24(ABlock1) 0 Location 3
+                              MemberDecorate 24(ABlock1) 1 Location 2
+                              Decorate 26 Location 0
+                              Decorate 34(a4) Location 5
+                              Decorate 41(ABlock2) Block
+                              MemberDecorate 41(ABlock2) 0 Location 4
+                              MemberDecorate 41(ABlock2) 1 Location 8
+                              MemberDecorate 41(ABlock2) 2 Location 10
+                              Decorate 43 Location 2
+                              Decorate 54(ABlock3) Block
+                              MemberDecorate 54(ABlock3) 0 Location 12
+                              MemberDecorate 54(ABlock3) 1 Location 15
+                              MemberDecorate 54(ABlock3) 2 Location 17
+                              MemberDecorate 54(ABlock3) 3 Location 19
+                              Decorate 56 Location 7
+                              Decorate 75(a12) Location 27
+                              Decorate 82(s0) Location 30
+                              Decorate 98(a17) Location 46
+                              Decorate 99(UBO0) Block
+                              MemberDecorate 99(UBO0) 0 Offset 0
+                              Decorate 101(ubo0) Binding 0
+                              Decorate 101(ubo0) DescriptorSet 0
+                              Decorate 108(ABlock4) Block
+                              Decorate 110 Location 50
+                              Decorate 113(ABlock5) Block
+                              MemberDecorate 113(ABlock5) 0 Location 60
+                              Decorate 115 Location 20
+                              Decorate 119(Block0) Block
+                              Decorate 121 Location 21
+                              Decorate 124(a21) Location 22
+                              Decorate 127(a16) Location 39
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeBool
+               7:     6(bool) ConstantFalse
+              10:             TypeFloat 32
+              11:             TypeVector 10(float) 4
+              12:             TypePointer Output 11(fvec4)
+          13(a0):     12(ptr) Variable Output
+              14:   10(float) Constant 1065353216
+              15:   11(fvec4) ConstantComposite 14 14 14 14
+     16(ABlock0):             TypeStruct 11(fvec4)
+              17:             TypePointer Output 16(ABlock0)
+              18:     17(ptr) Variable Output
+              19:             TypeInt 32 1
+              20:     19(int) Constant 0
+              21:   10(float) Constant 0
+              22:   11(fvec4) ConstantComposite 21 21 21 21
+     24(ABlock1):             TypeStruct 11(fvec4) 11(fvec4)
+              25:             TypePointer Output 24(ABlock1)
+              26:     25(ptr) Variable Output
+              28:     19(int) Constant 1
+              30:             TypeInt 32 0
+              31:     30(int) Constant 3
+              32:             TypeArray 11(fvec4) 31
+              33:             TypePointer Output 32
+          34(a4):     33(ptr) Variable Output
+              37:     19(int) Constant 2
+              39:     30(int) Constant 2
+              40:             TypeArray 11(fvec4) 39
+     41(ABlock2):             TypeStruct 11(fvec4) 40 40
+              42:             TypePointer Output 41(ABlock2)
+              43:     42(ptr) Variable Output
+              49:             TypeVector 10(float) 2
+              50:             TypeArray 49(fvec2) 39
+              51:             TypeArray 10(float) 31
+           52(S):             TypeStruct 51 10(float)
+              53:             TypeArray 52(S) 39
+     54(ABlock3):             TypeStruct 10(float) 50 40 53
+              55:             TypePointer Output 54(ABlock3)
+              56:     55(ptr) Variable Output
+              57:             TypePointer Output 10(float)
+              59:     30(int) Constant 0
+              61:     30(int) Constant 1
+              65:     19(int) Constant 3
+              74:             TypePointer Output 51
+         75(a12):     74(ptr) Variable Output
+              79:             TypeMatrix 11(fvec4) 4
+    80(AStruct1):             TypeStruct 49(fvec2) 52(S) 79
+              81:             TypePointer Output 80(AStruct1)
+          82(s0):     81(ptr) Variable Output
+              88:   11(fvec4) ConstantComposite 14 21 21 21
+              89:   11(fvec4) ConstantComposite 21 14 21 21
+              90:   11(fvec4) ConstantComposite 21 21 14 21
+              91:   11(fvec4) ConstantComposite 21 21 21 14
+              92:          79 ConstantComposite 88 89 90 91
+              93:             TypePointer Output 79
+              95:     30(int) Constant 4
+              96:             TypeArray 11(fvec4) 95
+              97:             TypePointer Output 96
+         98(a17):     97(ptr) Variable Output
+        99(UBO0):             TypeStruct 19(int)
+             100:             TypePointer Uniform 99(UBO0)
+       101(ubo0):    100(ptr) Variable Uniform
+             102:             TypePointer Uniform 19(int)
+             106:     30(int) Constant 10
+             107:             TypeArray 11(fvec4) 106
+    108(ABlock4):             TypeStruct 107
+             109:             TypePointer Output 108(ABlock4)
+             110:    109(ptr) Variable Output
+             111:     19(int) Constant 5
+    113(ABlock5):             TypeStruct 49(fvec2)
+             114:             TypePointer Output 113(ABlock5)
+             115:    114(ptr) Variable Output
+             116:   49(fvec2) ConstantComposite 21 21
+             117:             TypePointer Output 49(fvec2)
+     119(Block0):             TypeStruct 11(fvec4)
+             120:             TypePointer Output 119(Block0)
+             121:    120(ptr) Variable Output
+             123:             TypePointer Output 50
+        124(a21):    123(ptr) Variable Output
+        127(a16):     57(ptr) Variable Output
+         4(main):           2 Function None 3
+               5:             Label
+                              SelectionMerge 9 None
+                              BranchConditional 7 8 9
+               8:               Label
+                                Store 13(a0) 15
+                                Branch 9
+               9:             Label
+              23:     12(ptr) AccessChain 18 20
+                              Store 23 22
+              27:     12(ptr) AccessChain 26 20
+                              Store 27 22
+              29:     12(ptr) AccessChain 26 28
+                              Store 29 22
+              35:     12(ptr) AccessChain 34(a4) 20
+                              Store 35 22
+              36:     12(ptr) AccessChain 34(a4) 28
+                              Store 36 22
+              38:     12(ptr) AccessChain 34(a4) 37
+                              Store 38 22
+              44:     12(ptr) AccessChain 43 20
+                              Store 44 22
+              45:     12(ptr) AccessChain 43 28 20
+                              Store 45 22
+              46:     12(ptr) AccessChain 43 28 28
+                              Store 46 22
+              47:     12(ptr) AccessChain 43 37 20
+                              Store 47 22
+              48:     12(ptr) AccessChain 43 37 28
+                              Store 48 22
+              58:     57(ptr) AccessChain 56 20
+                              Store 58 21
+              60:     57(ptr) AccessChain 56 28 20 59
+                              Store 60 21
+              62:     57(ptr) AccessChain 56 28 28 61
+                              Store 62 21
+              63:     12(ptr) AccessChain 56 37 20
+                              Store 63 22
+              64:     12(ptr) AccessChain 56 37 28
+                              Store 64 22
+              66:     57(ptr) AccessChain 56 65 20 20 20
+                              Store 66 21
+              67:     57(ptr) AccessChain 56 65 20 20 28
+                              Store 67 21
+              68:     57(ptr) AccessChain 56 65 20 20 37
+                              Store 68 21
+              69:     57(ptr) AccessChain 56 65 20 28
+                              Store 69 21
+              70:     57(ptr) AccessChain 56 65 28 20 20
+                              Store 70 21
+              71:     57(ptr) AccessChain 56 65 28 20 28
+                              Store 71 21
+              72:     57(ptr) AccessChain 56 65 28 20 37
+                              Store 72 21
+              73:     57(ptr) AccessChain 56 65 28 28
+                              Store 73 21
+              76:     57(ptr) AccessChain 75(a12) 20
+                              Store 76 21
+              77:     57(ptr) AccessChain 75(a12) 28
+                              Store 77 21
+              78:     57(ptr) AccessChain 75(a12) 37
+                              Store 78 21
+              83:     57(ptr) AccessChain 82(s0) 20 61
+                              Store 83 21
+              84:     57(ptr) AccessChain 82(s0) 28 20 20
+                              Store 84 21
+              85:     57(ptr) AccessChain 82(s0) 28 20 28
+                              Store 85 21
+              86:     57(ptr) AccessChain 82(s0) 28 20 37
+                              Store 86 21
+              87:     57(ptr) AccessChain 82(s0) 28 28
+                              Store 87 21
+              94:     93(ptr) AccessChain 82(s0) 37
+                              Store 94 92
+             103:    102(ptr) AccessChain 101(ubo0) 20
+             104:     19(int) Load 103
+             105:     12(ptr) AccessChain 98(a17) 104
+                              Store 105 15
+             112:     12(ptr) AccessChain 110 20 111
+                              Store 112 15
+             118:    117(ptr) AccessChain 115 20
+                              Store 118 116
+             122:     12(ptr) AccessChain 121 20
+                              Store 122 15
+             125:    117(ptr) AccessChain 124(a21) 20
+                              Store 125 116
+             126:    117(ptr) AccessChain 124(a21) 28
+                              Store 126 116
+                              Return
+                              FunctionEnd

--- a/Test/baseResults/link.vk.missingCrossStageIO.0.vert.out
+++ b/Test/baseResults/link.vk.missingCrossStageIO.0.vert.out
@@ -1,0 +1,791 @@
+link.vk.missingCrossStageIO.0.vert
+Shader version: 460
+0:? Sequence
+0:3  Function Definition: main( ( global void)
+0:3    Function Parameters: 
+0:?   Linker Objects
+
+link.vk.missingCrossStageIO.0.frag
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:71  Function Definition: uncalled( ( global highp uint)
+0:71    Function Parameters: 
+0:72    Sequence
+0:72      Branch: Return with expression
+0:72        'b16' ( flat in highp uint)
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        'o' ( out highp 4-component vector of float)
+0:76        b1: direct index for structure ( in highp 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp highp 4-component vector of float)
+0:77        'o' ( out highp 4-component vector of float)
+0:77        b2: direct index for structure ( in highp 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp highp 4-component vector of float)
+0:78        'o' ( out highp 4-component vector of float)
+0:78        b3: direct index for structure ( in highp 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp highp 4-component vector of float)
+0:79        'o' ( out highp 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp highp 4-component vector of float)
+0:80        'o' ( out highp 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp highp 4-component vector of float)
+0:81        'o' ( out highp 4-component vector of float)
+0:81        b5: direct index for structure ( in highp 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp highp 4-component vector of float)
+0:82        'o' ( out highp 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp highp 4-component vector of float)
+0:83        'o' ( out highp 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp highp 4-component vector of float)
+0:84        'o' ( out highp 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp highp 4-component vector of float)
+0:85        'o' ( out highp 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp highp 4-component vector of float)
+0:86        'o' ( out highp 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp highp 4-component vector of float)
+0:87        'o' ( out highp 4-component vector of float)
+0:87        Construct vec4 ( temp highp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp highp 4-component vector of float)
+0:88        'o' ( out highp 4-component vector of float)
+0:88        vector swizzle ( temp highp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in highp 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp highp 4-component vector of float)
+0:89        'o' ( out highp 4-component vector of float)
+0:89        Construct vec4 ( temp highp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in highp float)
+0:89            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp highp 4-component vector of float)
+0:90        'o' ( out highp 4-component vector of float)
+0:90        vector swizzle ( temp highp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in highp 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp highp 4-component vector of float)
+0:91        'o' ( out highp 4-component vector of float)
+0:91        Construct vec4 ( temp highp 4-component vector of float)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp highp 4-component vector of float)
+0:92        'o' ( out highp 4-component vector of float)
+0:92        Construct vec4 ( temp highp 4-component vector of float)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp highp float)
+0:92            add ( temp highp float)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp highp float)
+0:92              b12: direct index for structure ( in 6-element array of highp float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp highp 4-component vector of float)
+0:93        'o' ( out highp 4-component vector of float)
+0:93        Construct vec4 ( temp highp 4-component vector of float)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in unsized 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp highp 4-component vector of float)
+0:95            'o' ( out highp 4-component vector of float)
+0:95            vector swizzle ( temp highp 4-component vector of float)
+0:95              matrix-times-vector ( temp highp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp highp 4-component vector of float)
+0:96            'o' ( out highp 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in highp 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp highp 4-component vector of float)
+0:97            'o' ( out highp 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in highp 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp highp 4-component vector of float)
+0:99        'o' ( out highp 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:99            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp highp 4-component vector of float)
+0:100        'o' ( out highp 4-component vector of float)
+0:100        indirect index ( temp highp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of highp 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:100            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp highp 4-component vector of float)
+0:101        'o' ( out highp 4-component vector of float)
+0:101        vector swizzle ( temp highp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp highp 4-component vector of float)
+0:102        'o' ( out highp 4-component vector of float)
+0:102        a20: direct index for structure ( in highp 4-component vector of float)
+0:102          'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp highp 4-component vector of float)
+0:103        'o' ( out highp 4-component vector of float)
+0:103        Construct vec4 ( temp highp 4-component vector of float)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:?     'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:?     'anon@4' (layout( location=29) in block{ in unsized 10-element array of highp float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in highp 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:?     'b16' ( flat in highp uint)
+0:?     'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:?     'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:?     'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:?     'o' ( out highp 4-component vector of float)
+
+
+Linked vertex stage:
+
+
+Linked fragment stage:
+
+ERROR: 0:76: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=0) in { in vec4 b0,  in vec4 b1,  in vec4 b2,  in vec4 b3} BBlock0
+ERROR: 0:77: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=0) in { in vec4 b0,  in vec4 b1,  in vec4 b2,  in vec4 b3} BBlock0
+ERROR: 0:78: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=0) in { in vec4 b0,  in vec4 b1,  in vec4 b2,  in vec4 b3} BBlock0
+ERROR: 0:79: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=4) smooth in vec4 b4[2]
+ERROR: 0:80: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=4) smooth in vec4 b4[2]
+ERROR: 0:81: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=6) in { in vec4 b5} BBlock1
+ERROR: 0:82: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:83: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:84: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:85: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:86: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=7) smooth in vec4 b6[5]
+ERROR: 0:87: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=12) smooth in float b7[4]
+ERROR: 0:87: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=12) smooth in float b7[4]
+ERROR: 0:87: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=12) smooth in float b7[4]
+ERROR: 0:87: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=12) smooth in float b7[4]
+ERROR: 0:88: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:89: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:90: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:91: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:91: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:91: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:91: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in {layout( location=21) in vec2 b8, layout( location=22) in float b9, layout( location=16) in vec3 b10, layout( location=17) in float b11[4]} BBlock2
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:92: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=23) in { in float b12[6]} BBlock3
+ERROR: 0:93: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=29) in { in float b13[10]} BBlock4
+ERROR: 0:93: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=29) in { in float b13[10]} BBlock4
+ERROR: 0:93: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=29) in { in float b13[10]} BBlock4
+ERROR: 0:93: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=29) in { in float b13[10]} BBlock4
+ERROR: 0:99: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=46) smooth in vec4 b20[4]
+ERROR: 0:100: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=50) in { in vec4 b21[10]} BBlock7
+ERROR: 0:101: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+    layout( location=60) smooth in vec2 b22
+ERROR: 0:102: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     in { in vec4 a20} Block0
+ERROR: 0:103: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     smooth in vec2 a21[2]
+ERROR: 0:103: Linking fragment and vertex stages: Preceding stage has no matching declaration for statically used input:
+     smooth in vec2 a21[2]
+
+Shader version: 460
+0:? Sequence
+0:3  Function Definition: main( ( global void)
+0:3    Function Parameters: 
+0:?   Linker Objects
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:75  Function Definition: main( ( global void)
+0:75    Function Parameters: 
+0:76    Sequence
+0:76      move second child to first child ( temp highp 4-component vector of float)
+0:76        'o' ( out highp 4-component vector of float)
+0:76        b1: direct index for structure ( in highp 4-component vector of float)
+0:76          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:76          Constant:
+0:76            1 (const uint)
+0:77      add second child into first child ( temp highp 4-component vector of float)
+0:77        'o' ( out highp 4-component vector of float)
+0:77        b2: direct index for structure ( in highp 4-component vector of float)
+0:77          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:77          Constant:
+0:77            2 (const uint)
+0:78      add second child into first child ( temp highp 4-component vector of float)
+0:78        'o' ( out highp 4-component vector of float)
+0:78        b3: direct index for structure ( in highp 4-component vector of float)
+0:78          'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:78          Constant:
+0:78            3 (const uint)
+0:79      add second child into first child ( temp highp 4-component vector of float)
+0:79        'o' ( out highp 4-component vector of float)
+0:79        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:79          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:79          Constant:
+0:79            0 (const int)
+0:80      add second child into first child ( temp highp 4-component vector of float)
+0:80        'o' ( out highp 4-component vector of float)
+0:80        direct index (layout( location=4) smooth temp highp 4-component vector of float)
+0:80          'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:80          Constant:
+0:80            1 (const int)
+0:81      add second child into first child ( temp highp 4-component vector of float)
+0:81        'o' ( out highp 4-component vector of float)
+0:81        b5: direct index for structure ( in highp 4-component vector of float)
+0:81          'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:81          Constant:
+0:81            0 (const uint)
+0:82      add second child into first child ( temp highp 4-component vector of float)
+0:82        'o' ( out highp 4-component vector of float)
+0:82        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:82          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:82          Constant:
+0:82            0 (const int)
+0:83      add second child into first child ( temp highp 4-component vector of float)
+0:83        'o' ( out highp 4-component vector of float)
+0:83        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:83          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:83          Constant:
+0:83            1 (const int)
+0:84      add second child into first child ( temp highp 4-component vector of float)
+0:84        'o' ( out highp 4-component vector of float)
+0:84        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:84          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:84          Constant:
+0:84            2 (const int)
+0:85      add second child into first child ( temp highp 4-component vector of float)
+0:85        'o' ( out highp 4-component vector of float)
+0:85        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:85          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:85          Constant:
+0:85            3 (const int)
+0:86      add second child into first child ( temp highp 4-component vector of float)
+0:86        'o' ( out highp 4-component vector of float)
+0:86        direct index (layout( location=7) smooth temp highp 4-component vector of float)
+0:86          'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:86          Constant:
+0:86            4 (const int)
+0:87      add second child into first child ( temp highp 4-component vector of float)
+0:87        'o' ( out highp 4-component vector of float)
+0:87        Construct vec4 ( temp highp 4-component vector of float)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              0 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              1 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              2 (const int)
+0:87          direct index (layout( location=12) smooth temp highp float)
+0:87            'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:87            Constant:
+0:87              3 (const int)
+0:88      add second child into first child ( temp highp 4-component vector of float)
+0:88        'o' ( out highp 4-component vector of float)
+0:88        vector swizzle ( temp highp 4-component vector of float)
+0:88          b8: direct index for structure (layout( location=21) in highp 2-component vector of float)
+0:88            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:88            Constant:
+0:88              0 (const uint)
+0:88          Sequence
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              0 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:88            Constant:
+0:88              1 (const int)
+0:89      add second child into first child ( temp highp 4-component vector of float)
+0:89        'o' ( out highp 4-component vector of float)
+0:89        Construct vec4 ( temp highp 4-component vector of float)
+0:89          b9: direct index for structure (layout( location=22) in highp float)
+0:89            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:89            Constant:
+0:89              1 (const uint)
+0:90      add second child into first child ( temp highp 4-component vector of float)
+0:90        'o' ( out highp 4-component vector of float)
+0:90        vector swizzle ( temp highp 4-component vector of float)
+0:90          b10: direct index for structure (layout( location=16) in highp 3-component vector of float)
+0:90            'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:90            Constant:
+0:90              2 (const uint)
+0:90          Sequence
+0:90            Constant:
+0:90              0 (const int)
+0:90            Constant:
+0:90              1 (const int)
+0:90            Constant:
+0:90              2 (const int)
+0:90            Constant:
+0:90              0 (const int)
+0:91      add second child into first child ( temp highp 4-component vector of float)
+0:91        'o' ( out highp 4-component vector of float)
+0:91        Construct vec4 ( temp highp 4-component vector of float)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              0 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              1 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              2 (const int)
+0:91          direct index (layout( location=17) temp highp float)
+0:91            b11: direct index for structure (layout( location=17) in 4-element array of highp float)
+0:91              'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:91              Constant:
+0:91                3 (const uint)
+0:91            Constant:
+0:91              3 (const int)
+0:92      add second child into first child ( temp highp 4-component vector of float)
+0:92        'o' ( out highp 4-component vector of float)
+0:92        Construct vec4 ( temp highp 4-component vector of float)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              0 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              1 (const int)
+0:92          direct index ( temp highp float)
+0:92            b12: direct index for structure ( in 6-element array of highp float)
+0:92              'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92              Constant:
+0:92                0 (const uint)
+0:92            Constant:
+0:92              2 (const int)
+0:92          add ( temp highp float)
+0:92            add ( temp highp float)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  3 (const int)
+0:92              direct index ( temp highp float)
+0:92                b12: direct index for structure ( in 6-element array of highp float)
+0:92                  'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                  Constant:
+0:92                    0 (const uint)
+0:92                Constant:
+0:92                  4 (const int)
+0:92            direct index ( temp highp float)
+0:92              b12: direct index for structure ( in 6-element array of highp float)
+0:92                'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:92                Constant:
+0:92                  0 (const uint)
+0:92              Constant:
+0:92                5 (const int)
+0:93      add second child into first child ( temp highp 4-component vector of float)
+0:93        'o' ( out highp 4-component vector of float)
+0:93        Construct vec4 ( temp highp 4-component vector of float)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              9 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              7 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              6 (const int)
+0:93          direct index ( temp highp float)
+0:93            b13: direct index for structure ( in 10-element array of highp float)
+0:93              'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:93              Constant:
+0:93                0 (const uint)
+0:93            Constant:
+0:93              0 (const int)
+0:94      Test condition and select ( temp void)
+0:94        Condition
+0:94        Constant:
+0:94          false (const bool)
+0:94        true case
+0:95        Sequence
+0:95          add second child into first child ( temp highp 4-component vector of float)
+0:95            'o' ( out highp 4-component vector of float)
+0:95            vector swizzle ( temp highp 4-component vector of float)
+0:95              matrix-times-vector ( temp highp 2-component vector of float)
+0:95                'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:95                Constant:
+0:95                  1.000000
+0:95                  1.000000
+0:95              Sequence
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  0 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:95                Constant:
+0:95                  1 (const int)
+0:96          add second child into first child ( temp highp 4-component vector of float)
+0:96            'o' ( out highp 4-component vector of float)
+0:96            b18: direct index for structure (layout( location=43) in highp 4-component vector of float)
+0:96              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:96              Constant:
+0:96                1 (const uint)
+0:97          add second child into first child ( temp highp 4-component vector of float)
+0:97            'o' ( out highp 4-component vector of float)
+0:97            b19: direct index for structure (layout( location=44) in highp 4-component vector of float)
+0:97              'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:97              Constant:
+0:97                2 (const uint)
+0:99      add second child into first child ( temp highp 4-component vector of float)
+0:99        'o' ( out highp 4-component vector of float)
+0:99        indirect index (layout( location=46) smooth temp highp 4-component vector of float)
+0:99          'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:99          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:99            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:99            Constant:
+0:99              0 (const int)
+0:100      add second child into first child ( temp highp 4-component vector of float)
+0:100        'o' ( out highp 4-component vector of float)
+0:100        indirect index ( temp highp 4-component vector of float)
+0:100          b21: direct index for structure ( in 10-element array of highp 4-component vector of float)
+0:100            'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:100            Constant:
+0:100              0 (const uint)
+0:100          i: direct index for structure (layout( column_major std140) uniform highp int)
+0:100            'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:100            Constant:
+0:100              0 (const int)
+0:101      add second child into first child ( temp highp 4-component vector of float)
+0:101        'o' ( out highp 4-component vector of float)
+0:101        vector swizzle ( temp highp 4-component vector of float)
+0:101          'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:101          Sequence
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              0 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:101            Constant:
+0:101              1 (const int)
+0:102      add second child into first child ( temp highp 4-component vector of float)
+0:102        'o' ( out highp 4-component vector of float)
+0:102        a20: direct index for structure ( in highp 4-component vector of float)
+0:102          'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:102          Constant:
+0:102            0 (const uint)
+0:103      add second child into first child ( temp highp 4-component vector of float)
+0:103        'o' ( out highp 4-component vector of float)
+0:103        Construct vec4 ( temp highp 4-component vector of float)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              0 (const int)
+0:103          direct index ( smooth temp highp 2-component vector of float)
+0:103            'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:103            Constant:
+0:103              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( location=0) in block{ in highp 4-component vector of float b0,  in highp 4-component vector of float b1,  in highp 4-component vector of float b2,  in highp 4-component vector of float b3})
+0:?     'b4' (layout( location=4) smooth in 2-element array of highp 4-component vector of float)
+0:?     'anon@1' (layout( location=6) in block{ in highp 4-component vector of float b5})
+0:?     'b6' (layout( location=7) smooth in 5-element array of highp 4-component vector of float)
+0:?     'b7' (layout( location=12) smooth in 4-element array of highp float)
+0:?     'anon@2' ( in block{layout( location=21) in highp 2-component vector of float b8, layout( location=22) in highp float b9, layout( location=16) in highp 3-component vector of float b10, layout( location=17) in 4-element array of highp float b11})
+0:?     'anon@3' (layout( location=23) in block{ in 6-element array of highp float b12})
+0:?     'anon@4' (layout( location=29) in block{ in 10-element array of highp float b13})
+0:?     'anon@5' (layout( location=39) in block{ flat in highp 2-component vector of int b14})
+0:?     'b15' (layout( location=40) smooth in highp 2X2 matrix of float)
+0:?     'b16' ( flat in highp uint)
+0:?     'anon@6' ( in block{layout( location=45) in highp 4-component vector of float b17, layout( location=43) in highp 4-component vector of float b18, layout( location=44) in highp 4-component vector of float b19})
+0:?     'ubo0' (layout( binding=0 column_major std140) uniform block{layout( column_major std140) uniform highp int i})
+0:?     'b20' (layout( location=46) smooth in 4-element array of highp 4-component vector of float)
+0:?     'anon@7' (layout( location=50) in block{ in 10-element array of highp 4-component vector of float b21})
+0:?     'b22' (layout( location=60) smooth in highp 2-component vector of float)
+0:?     'anon@8' ( in block{ in highp 4-component vector of float a20})
+0:?     'a21' ( smooth in 2-element array of highp 2-component vector of float)
+0:?     'o' ( out highp 4-component vector of float)
+
+Validation failed
+SPIR-V is not generated for failed compile or link

--- a/Test/baseResults/validation_fails.txt
+++ b/Test/baseResults/validation_fails.txt
@@ -42,8 +42,11 @@ Test/baseResults/hlsl.struct.split.assign.frag.out
 Test/baseResults/hlsl.texture.struct.frag.out
 Test/baseResults/hlsl.tristream-append.geom.out
 Test/baseResults/iomap.mismatchedBufferTypes.vert.out
+Test/baseResults/link.vk.crossStageIO.0.vert.out
+Test/baseResults/link.vk.crossStageIO.1.vert.out
 Test/baseResults/link.vk.differentPC.0.0.frag.out
 Test/baseResults/link.vk.differentPC.1.0.frag.out
+Test/baseResults/link.vk.missingCrossStageIO.0.vert.out
 Test/baseResults/link.vk.pcNamingInvalid.0.0.vert.out
 Test/baseResults/spv.130.frag.out
 Test/baseResults/spv.140.frag.out

--- a/Test/link.crossStageIO.0.frag
+++ b/Test/link.crossStageIO.0.frag
@@ -1,0 +1,104 @@
+#version 460
+
+layout(location = 0) in BBlock0 {
+    vec4 b0;
+    vec4 b1;
+    vec4 b2;
+    vec4 b3;
+};
+
+layout(location = 4) in vec4 b4[2];
+
+layout(location = 6) in BBlock1 {
+    vec4 b5;
+};
+
+layout(location = 7) in vec4 b6[5];
+
+layout(location = 12) in float b7[4];
+
+layout(location = 21) in BBlock2 {
+    vec2 b8;
+    float b9;
+    layout(location = 16) vec3 b10;
+    float b11[4];
+};
+
+layout(location = 23) in BBlock3 {
+    float b12[6];
+};
+
+layout(location = 29) in BBlock4 {
+    float b13[]; // implicitly sized to 10
+};
+
+layout(location = 39) in BBlock5 {
+    flat ivec2 b14;
+};
+
+layout(location = 40) in mat2 b15;
+
+in flat uint b16;
+
+layout(location = 45) in BBlock6 {
+    vec4 b17;
+    layout(location = 43) vec4 b18;
+    vec4 b19;
+};
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) in vec4 b20[4];
+
+layout(location = 50) in BBlock7 {
+    vec4 b21[10];
+};
+
+layout(location = 60) in vec2 b22;
+
+// automatically mapped by name
+in Block0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+in vec2 a21[2];
+
+out vec4 o;
+
+uint uncalled() {
+    return b16;
+}
+
+void main() {
+    o = b1;
+    o += b2;
+    o += b3;
+    o += b4[0];
+    o += b4[1];
+    o += b5;
+    o += b6[0];
+    o += b6[1];
+    o += b6[2];
+    o += b6[3];
+    o += b6[4];
+    o += vec4(b7[0], b7[1], b7[2], b7[3]);
+    o += b8.xxyy;
+    o += vec4(b9);
+    o += b10.xyzx;
+    o += vec4(b11[0], b11[1], b11[2], b11[3]);
+    o += vec4(b12[0], b12[1], b12[2], b12[3] + b12[4] + b12[5]);
+    o += vec4(b13[9], b13[7], b13[6], b13[0]);
+    if (false) {
+        o += (b15 * vec2(1.0)).xxyy;
+        o += b18;
+        o += b19;
+    }
+    o += b20[ubo0.i];
+    o += b21[ubo0.i];
+    o += b22.xxyy;
+    o += a20;
+    o += vec4(a21[0], a21[1]);
+}

--- a/Test/link.crossStageIO.0.vert
+++ b/Test/link.crossStageIO.0.vert
@@ -1,0 +1,110 @@
+#version 460
+
+layout(location = 40) out vec4 a0;
+
+layout(location = 1) out ABlock0 {
+    vec4 a1;
+};
+
+out ABlock1 {
+    layout(location = 3) vec4 a2;
+    layout(location = 2) vec4 a3;
+};
+
+layout(location = 5) out vec4 a4[3];
+
+layout(location = 4) out ABlock2 {
+    vec4 a5;
+    layout(location = 8) vec4 a6[2];
+    vec4 a7[2];
+};
+
+struct S {
+    float a[3];
+    float b;
+};
+
+layout(location = 12) out ABlock3 {
+    float a8;
+    layout(location = 15) vec2 a9[2];
+    vec4 a10[2];
+    layout(location = 19) S a11[2]; // consumes 8 locations
+};
+
+layout(location = 27) out float a12[3];
+
+layout(location = 30) out struct AStruct1 {
+    vec2 a13;
+    S a14; // consumes 4 locations
+    mat4 a15;
+} s0;
+
+layout(location = 39) out float a16;
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) out vec4 a17[4];
+
+layout(location = 50) out ABlock4 {
+    vec4 a18[10];
+};
+
+layout(location = 59) out ABlock5 {
+    layout(location = 60) vec2 a19;
+};
+
+// automatically mapped by name
+out Block0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+out vec2 a21[2];
+
+void main() {
+    if (false) {
+        a0 = vec4(1.0);
+    }
+    a1 = vec4(0.0);
+    a2 = vec4(0.0);
+    a3 = vec4(0.0);
+    a4[0] = vec4(0.0);
+    a4[1] = vec4(0.0);
+    a4[2] = vec4(0.0);
+    a5 = vec4(0.0);
+    a6[0] = vec4(0.0);
+    a6[1] = vec4(0.0);
+    a7[0] = vec4(0.0);
+    a7[1] = vec4(0.0);
+    a8 = 0.0;
+    a9[0].x = 0.0;
+    a9[1].y = 0.0;
+    a10[0] = vec4(0.0);
+    a10[1] = vec4(0.0);
+    a11[0].a[0] = 0.0;
+    a11[0].a[1] = 0.0;
+    a11[0].a[2] = 0.0;
+    a11[0].b = 0.0;
+    a11[1].a[0] = 0.0;
+    a11[1].a[1] = 0.0;
+    a11[1].a[2] = 0.0;
+    a11[1].b = 0.0;
+    a12[0] = 0.0;
+    a12[1] = 0.0;
+    a12[2] = 0.0;
+    s0.a13.y = 0.0;
+    s0.a14.a[0] = 0.0;
+    s0.a14.a[1] = 0.0;
+    s0.a14.a[2] = 0.0;
+    s0.a14.b = 0.0;
+    s0.a15 = mat4(1.0);
+    // a16 intentionally not written to
+    a17[ubo0.i] = vec4(1.0);
+    a18[5] = vec4(1.0);
+    a19 = vec2(0.0);
+    a20 = vec4(1.0);
+    a21[0] = vec2(0.0);
+    a21[1] = vec2(0.0);
+}

--- a/Test/link.crossStageIO.1.frag
+++ b/Test/link.crossStageIO.1.frag
@@ -1,0 +1,104 @@
+#version 460
+
+layout(location = 0) in BBlock0 {
+    vec4 b0;
+    vec4 b1;
+    vec4 b2;
+    vec4 b3;
+};
+
+layout(location = 4) in vec4 b4[2];
+
+layout(location = 6) in BBlock1 {
+    vec4 b5;
+};
+
+layout(location = 7) in vec4 b6[5];
+
+layout(location = 12) in float b7[4];
+
+layout(location = 21) in BBlock2 {
+    vec2 b8;
+    float b9;
+    layout(location = 16) vec3 b10;
+    float b11[4];
+};
+
+layout(location = 23) in BBlock3 {
+    float b12[6];
+};
+
+layout(location = 29) in BBlock4 {
+    float b13[]; // implicitly sized to 10
+};
+
+layout(location = 39) in BBlock5 {
+    flat ivec2 b14;
+};
+
+layout(location = 40) in mat2 b15;
+
+in flat uint b16;
+
+layout(location = 45) in BBlock6 {
+    vec4 b17;
+    layout(location = 43) vec4 b18;
+    vec4 b19;
+};
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) in vec4 b20[4];
+
+layout(location = 50) in BBlock7 {
+    vec4 b21[10];
+};
+
+layout(location = 60) in vec2 b22;
+
+// automatically mapped by name
+in GBlock0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+in vec2 g_a21[2];
+
+out vec4 o;
+
+uint uncalled() {
+    return b16;
+}
+
+void main() {
+    o = b1;
+    o += b2;
+    o += b3;
+    o += b4[0];
+    o += b4[1];
+    o += b5;
+    o += b6[0];
+    o += b6[1];
+    o += b6[2];
+    o += b6[3];
+    o += b6[4];
+    o += vec4(b7[0], b7[1], b7[2], b7[3]);
+    o += b8.xxyy;
+    o += vec4(b9);
+    o += b10.xyzx;
+    o += vec4(b11[0], b11[1], b11[2], b11[3]);
+    o += vec4(b12[0], b12[1], b12[2], b12[3] + b12[4] + b12[5]);
+    o += vec4(b13[9], b13[7], b13[6], b13[0]);
+    if (false) {
+        o += (b15 * vec2(1.0)).xxyy;
+        o += b18;
+        o += b19;
+    }
+    o += b20[ubo0.i];
+    o += b21[ubo0.i];
+    o += b22.xxyy;
+    o += a20;
+    o += vec4(g_a21[0], g_a21[1]);
+}

--- a/Test/link.crossStageIO.1.geom
+++ b/Test/link.crossStageIO.1.geom
@@ -1,0 +1,42 @@
+#version 460
+
+layout(triangles) in;
+layout(triangle_strip, max_vertices=3) out;
+
+// automatically mapped by name
+in Block0 {
+    vec4 a20;
+} gs_in0[3];
+
+// automatically mapped by name
+in vec2 a21[3][2];
+
+// automatically mapped by name
+out GBlock0 {
+    vec4 a20;
+} gs_out0;
+
+// automatically mapped by name
+out vec2 g_a21[2];
+
+in GBlock1 {
+    layout(location = 0) in vec4 a0[64];
+} gs_in1[3];
+
+layout(location = 0) out vec4 o0[64];
+
+void main() {
+    for (int i = 0; i < 32; ++i) {
+        o0[i] = gs_in1[0].a0[i];
+    }
+
+    gs_out0.a20 = gs_in0[0].a20;
+    g_a21[0] = a21[0][0];
+    g_a21[0] = a21[0][1];
+
+    gl_Position = vec4(0);
+
+    EmitVertex();
+    EmitVertex();
+    EmitVertex();
+}

--- a/Test/link.crossStageIO.1.vert
+++ b/Test/link.crossStageIO.1.vert
@@ -1,0 +1,110 @@
+#version 460
+
+layout(location = 40) out vec4 a0;
+
+layout(location = 1) out ABlock0 {
+    vec4 a1;
+};
+
+out ABlock1 {
+    layout(location = 3) vec4 a2;
+    layout(location = 2) vec4 a3;
+};
+
+layout(location = 5) out vec4 a4[3];
+
+layout(location = 4) out ABlock2 {
+    vec4 a5;
+    layout(location = 8) vec4 a6[2];
+    vec4 a7[2];
+};
+
+struct S {
+    float a[3];
+    float b;
+};
+
+layout(location = 12) out ABlock3 {
+    float a8;
+    layout(location = 15) vec2 a9[2];
+    vec4 a10[2];
+    layout(location = 19) S a11[2]; // consumes 8 locations
+};
+
+layout(location = 27) out float a12[3];
+
+layout(location = 30) out struct AStruct1 {
+    vec2 a13;
+    S a14; // consumes 4 locations
+    mat4 a15;
+} s0;
+
+layout(location = 39) out float a16;
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) out vec4 a17[4];
+
+layout(location = 50) out ABlock4 {
+    vec4 a18[10];
+};
+
+layout(location = 59) out ABlock5 {
+    layout(location = 60) vec2 a19;
+};
+
+// automatically mapped by name
+out Block0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+out vec2 a21[2];
+
+void main() {
+    if (false) {
+        a0 = vec4(1.0);
+    }
+    a1 = vec4(0.0);
+    a2 = vec4(0.0);
+    a3 = vec4(0.0);
+    a4[0] = vec4(0.0);
+    a4[1] = vec4(0.0);
+    a4[2] = vec4(0.0);
+    a5 = vec4(0.0);
+    a6[0] = vec4(0.0);
+    a6[1] = vec4(0.0);
+    a7[0] = vec4(0.0);
+    a7[1] = vec4(0.0);
+    a8 = 0.0;
+    a9[0].x = 0.0;
+    a9[1].y = 0.0;
+    a10[0] = vec4(0.0);
+    a10[1] = vec4(0.0);
+    a11[0].a[0] = 0.0;
+    a11[0].a[1] = 0.0;
+    a11[0].a[2] = 0.0;
+    a11[0].b = 0.0;
+    a11[1].a[0] = 0.0;
+    a11[1].a[1] = 0.0;
+    a11[1].a[2] = 0.0;
+    a11[1].b = 0.0;
+    a12[0] = 0.0;
+    a12[1] = 0.0;
+    a12[2] = 0.0;
+    s0.a13.y = 0.0;
+    s0.a14.a[0] = 0.0;
+    s0.a14.a[1] = 0.0;
+    s0.a14.a[2] = 0.0;
+    s0.a14.b = 0.0;
+    s0.a15 = mat4(1.0);
+    // a16 intentionally not written to
+    a17[ubo0.i] = vec4(1.0);
+    a18[5] = vec4(1.0);
+    a19 = vec2(0.0);
+    a20 = vec4(1.0);
+    a21[0] = vec2(0.0);
+    a21[1] = vec2(0.0);
+}

--- a/Test/link.missingCrossStageIO.0.frag
+++ b/Test/link.missingCrossStageIO.0.frag
@@ -1,0 +1,104 @@
+#version 460
+
+layout(location = 0) in BBlock0 {
+    vec4 b0;
+    vec4 b1;
+    vec4 b2;
+    vec4 b3;
+};
+
+layout(location = 4) in vec4 b4[2];
+
+layout(location = 6) in BBlock1 {
+    vec4 b5;
+};
+
+layout(location = 7) in vec4 b6[5];
+
+layout(location = 12) in float b7[4];
+
+layout(location = 21) in BBlock2 {
+    vec2 b8;
+    float b9;
+    layout(location = 16) vec3 b10;
+    float b11[4];
+};
+
+layout(location = 23) in BBlock3 {
+    float b12[6];
+};
+
+layout(location = 29) in BBlock4 {
+    float b13[]; // implicitly sized to 10
+};
+
+layout(location = 39) in BBlock5 {
+    flat ivec2 b14;
+};
+
+layout(location = 40) in mat2 b15;
+
+in flat uint b16;
+
+layout(location = 45) in BBlock6 {
+    vec4 b17;
+    layout(location = 43) vec4 b18;
+    vec4 b19;
+};
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) in vec4 b20[4];
+
+layout(location = 50) in BBlock7 {
+    vec4 b21[10];
+};
+
+layout(location = 60) in vec2 b22;
+
+// automatically mapped by name
+in Block0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+in vec2 a21[2];
+
+out vec4 o;
+
+uint uncalled() {
+    return b16;
+}
+
+void main() {
+    o = b1;
+    o += b2;
+    o += b3;
+    o += b4[0];
+    o += b4[1];
+    o += b5;
+    o += b6[0];
+    o += b6[1];
+    o += b6[2];
+    o += b6[3];
+    o += b6[4];
+    o += vec4(b7[0], b7[1], b7[2], b7[3]);
+    o += b8.xxyy;
+    o += vec4(b9);
+    o += b10.xyzx;
+    o += vec4(b11[0], b11[1], b11[2], b11[3]);
+    o += vec4(b12[0], b12[1], b12[2], b12[3] + b12[4] + b12[5]);
+    o += vec4(b13[9], b13[7], b13[6], b13[0]);
+    if (false) {
+        o += (b15 * vec2(1.0)).xxyy;
+        o += b18;
+        o += b19;
+    }
+    o += b20[ubo0.i];
+    o += b21[ubo0.i];
+    o += b22.xxyy;
+    o += a20;
+    o += vec4(a21[0], a21[1]);
+}

--- a/Test/link.missingCrossStageIO.0.vert
+++ b/Test/link.missingCrossStageIO.0.vert
@@ -1,0 +1,4 @@
+#version 460
+
+void main() {
+}

--- a/Test/link.vk.crossStageIO.0.frag
+++ b/Test/link.vk.crossStageIO.0.frag
@@ -1,0 +1,104 @@
+#version 460
+
+layout(location = 0) in BBlock0 {
+    vec4 b0;
+    vec4 b1;
+    vec4 b2;
+    vec4 b3;
+};
+
+layout(location = 4) in vec4 b4[2];
+
+layout(location = 6) in BBlock1 {
+    vec4 b5;
+};
+
+layout(location = 7) in vec4 b6[5];
+
+layout(location = 12) in float b7[4];
+
+layout(location = 21) in BBlock2 {
+    vec2 b8;
+    float b9;
+    layout(location = 16) vec3 b10;
+    float b11[4];
+};
+
+layout(location = 23) in BBlock3 {
+    float b12[6];
+};
+
+layout(location = 29) in BBlock4 {
+    float b13[]; // implicitly sized to 10
+};
+
+layout(location = 39) in BBlock5 {
+    flat ivec2 b14;
+};
+
+layout(location = 40) in mat2 b15;
+
+in flat uint b16;
+
+layout(location = 45) in BBlock6 {
+    vec4 b17;
+    layout(location = 43) vec4 b18;
+    vec4 b19;
+};
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) in vec4 b20[4];
+
+layout(location = 50) in BBlock7 {
+    vec4 b21[10];
+};
+
+layout(location = 60) in vec2 b22;
+
+// automatically mapped by name
+in Block0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+in vec2 a21[2];
+
+out vec4 o;
+
+uint uncalled() {
+    return b16;
+}
+
+void main() {
+    o = b1;
+    o += b2;
+    o += b3;
+    o += b4[0];
+    o += b4[1];
+    o += b5;
+    o += b6[0];
+    o += b6[1];
+    o += b6[2];
+    o += b6[3];
+    o += b6[4];
+    o += vec4(b7[0], b7[1], b7[2], b7[3]);
+    o += b8.xxyy;
+    o += vec4(b9);
+    o += b10.xyzx;
+    o += vec4(b11[0], b11[1], b11[2], b11[3]);
+    o += vec4(b12[0], b12[1], b12[2], b12[3] + b12[4] + b12[5]);
+    o += vec4(b13[9], b13[7], b13[6], b13[0]);
+    if (false) {
+        o += (b15 * vec2(1.0)).xxyy;
+        o += b18;
+        o += b19;
+    }
+    o += b20[ubo0.i];
+    o += b21[ubo0.i];
+    o += b22.xxyy;
+    o += a20;
+    o += vec4(a21[0], a21[1]);
+}

--- a/Test/link.vk.crossStageIO.0.vert
+++ b/Test/link.vk.crossStageIO.0.vert
@@ -1,0 +1,110 @@
+#version 460
+
+layout(location = 40) out vec4 a0;
+
+layout(location = 1) out ABlock0 {
+    vec4 a1;
+};
+
+out ABlock1 {
+    layout(location = 3) vec4 a2;
+    layout(location = 2) vec4 a3;
+};
+
+layout(location = 5) out vec4 a4[3];
+
+layout(location = 4) out ABlock2 {
+    vec4 a5;
+    layout(location = 8) vec4 a6[2];
+    vec4 a7[2];
+};
+
+struct S {
+    float a[3];
+    float b;
+};
+
+layout(location = 12) out ABlock3 {
+    float a8;
+    layout(location = 15) vec2 a9[2];
+    vec4 a10[2];
+    layout(location = 19) S a11[2]; // consumes 8 locations
+};
+
+layout(location = 27) out float a12[3];
+
+layout(location = 30) out struct AStruct1 {
+    vec2 a13;
+    S a14; // consumes 4 locations
+    mat4 a15;
+} s0;
+
+layout(location = 39) out float a16;
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) out vec4 a17[4];
+
+layout(location = 50) out ABlock4 {
+    vec4 a18[10];
+};
+
+layout(location = 59) out ABlock5 {
+    layout(location = 60) vec2 a19;
+};
+
+// automatically mapped by name
+out Block0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+out vec2 a21[2];
+
+void main() {
+    if (false) {
+        a0 = vec4(1.0);
+    }
+    a1 = vec4(0.0);
+    a2 = vec4(0.0);
+    a3 = vec4(0.0);
+    a4[0] = vec4(0.0);
+    a4[1] = vec4(0.0);
+    a4[2] = vec4(0.0);
+    a5 = vec4(0.0);
+    a6[0] = vec4(0.0);
+    a6[1] = vec4(0.0);
+    a7[0] = vec4(0.0);
+    a7[1] = vec4(0.0);
+    a8 = 0.0;
+    a9[0].x = 0.0;
+    a9[1].y = 0.0;
+    a10[0] = vec4(0.0);
+    a10[1] = vec4(0.0);
+    a11[0].a[0] = 0.0;
+    a11[0].a[1] = 0.0;
+    a11[0].a[2] = 0.0;
+    a11[0].b = 0.0;
+    a11[1].a[0] = 0.0;
+    a11[1].a[1] = 0.0;
+    a11[1].a[2] = 0.0;
+    a11[1].b = 0.0;
+    a12[0] = 0.0;
+    a12[1] = 0.0;
+    a12[2] = 0.0;
+    s0.a13.y = 0.0;
+    s0.a14.a[0] = 0.0;
+    s0.a14.a[1] = 0.0;
+    s0.a14.a[2] = 0.0;
+    s0.a14.b = 0.0;
+    s0.a15 = mat4(1.0);
+    // a16 intentionally not written to
+    a17[ubo0.i] = vec4(1.0);
+    a18[5] = vec4(1.0);
+    a19 = vec2(0.0);
+    a20 = vec4(1.0);
+    a21[0] = vec2(0.0);
+    a21[1] = vec2(0.0);
+}

--- a/Test/link.vk.crossStageIO.1.frag
+++ b/Test/link.vk.crossStageIO.1.frag
@@ -1,0 +1,104 @@
+#version 460
+
+layout(location = 0) in BBlock0 {
+    vec4 b0;
+    vec4 b1;
+    vec4 b2;
+    vec4 b3;
+};
+
+layout(location = 4) in vec4 b4[2];
+
+layout(location = 6) in BBlock1 {
+    vec4 b5;
+};
+
+layout(location = 7) in vec4 b6[5];
+
+layout(location = 12) in float b7[4];
+
+layout(location = 21) in BBlock2 {
+    vec2 b8;
+    float b9;
+    layout(location = 16) vec3 b10;
+    float b11[4];
+};
+
+layout(location = 23) in BBlock3 {
+    float b12[6];
+};
+
+layout(location = 29) in BBlock4 {
+    float b13[]; // implicitly sized to 10
+};
+
+layout(location = 39) in BBlock5 {
+    flat ivec2 b14;
+};
+
+layout(location = 40) in mat2 b15;
+
+in flat uint b16;
+
+layout(location = 45) in BBlock6 {
+    vec4 b17;
+    layout(location = 43) vec4 b18;
+    vec4 b19;
+};
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) in vec4 b20[4];
+
+layout(location = 50) in BBlock7 {
+    vec4 b21[10];
+};
+
+layout(location = 60) in vec2 b22;
+
+// automatically mapped by name
+in GBlock0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+in vec2 g_a21[2];
+
+out vec4 o;
+
+uint uncalled() {
+    return b16;
+}
+
+void main() {
+    o = b1;
+    o += b2;
+    o += b3;
+    o += b4[0];
+    o += b4[1];
+    o += b5;
+    o += b6[0];
+    o += b6[1];
+    o += b6[2];
+    o += b6[3];
+    o += b6[4];
+    o += vec4(b7[0], b7[1], b7[2], b7[3]);
+    o += b8.xxyy;
+    o += vec4(b9);
+    o += b10.xyzx;
+    o += vec4(b11[0], b11[1], b11[2], b11[3]);
+    o += vec4(b12[0], b12[1], b12[2], b12[3] + b12[4] + b12[5]);
+    o += vec4(b13[9], b13[7], b13[6], b13[0]);
+    if (false) {
+        o += (b15 * vec2(1.0)).xxyy;
+        o += b18;
+        o += b19;
+    }
+    o += b20[ubo0.i];
+    o += b21[ubo0.i];
+    o += b22.xxyy;
+    o += a20;
+    o += vec4(g_a21[0], g_a21[1]);
+}

--- a/Test/link.vk.crossStageIO.1.geom
+++ b/Test/link.vk.crossStageIO.1.geom
@@ -1,0 +1,42 @@
+#version 460
+
+layout(triangles) in;
+layout(triangle_strip, max_vertices=3) out;
+
+// automatically mapped by name
+in Block0 {
+    vec4 a20;
+} gs_in0[3];
+
+// automatically mapped by name
+in vec2 a21[3][2];
+
+// automatically mapped by name
+out GBlock0 {
+    vec4 a20;
+} gs_out0;
+
+// automatically mapped by name
+out vec2 g_a21[2];
+
+in GBlock1 {
+    layout(location = 0) in vec4 a0[64];
+} gs_in1[3];
+
+layout(location = 0) out vec4 o0[64];
+
+void main() {
+    for (int i = 0; i < 32; ++i) {
+        o0[i] = gs_in1[0].a0[i];
+    }
+
+    gs_out0.a20 = gs_in0[0].a20;
+    g_a21[0] = a21[0][0];
+    g_a21[0] = a21[0][1];
+
+    gl_Position = vec4(0);
+
+    EmitVertex();
+    EmitVertex();
+    EmitVertex();
+}

--- a/Test/link.vk.crossStageIO.1.vert
+++ b/Test/link.vk.crossStageIO.1.vert
@@ -1,0 +1,110 @@
+#version 460
+
+layout(location = 40) out vec4 a0;
+
+layout(location = 1) out ABlock0 {
+    vec4 a1;
+};
+
+out ABlock1 {
+    layout(location = 3) vec4 a2;
+    layout(location = 2) vec4 a3;
+};
+
+layout(location = 5) out vec4 a4[3];
+
+layout(location = 4) out ABlock2 {
+    vec4 a5;
+    layout(location = 8) vec4 a6[2];
+    vec4 a7[2];
+};
+
+struct S {
+    float a[3];
+    float b;
+};
+
+layout(location = 12) out ABlock3 {
+    float a8;
+    layout(location = 15) vec2 a9[2];
+    vec4 a10[2];
+    layout(location = 19) S a11[2]; // consumes 8 locations
+};
+
+layout(location = 27) out float a12[3];
+
+layout(location = 30) out struct AStruct1 {
+    vec2 a13;
+    S a14; // consumes 4 locations
+    mat4 a15;
+} s0;
+
+layout(location = 39) out float a16;
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) out vec4 a17[4];
+
+layout(location = 50) out ABlock4 {
+    vec4 a18[10];
+};
+
+layout(location = 59) out ABlock5 {
+    layout(location = 60) vec2 a19;
+};
+
+// automatically mapped by name
+out Block0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+out vec2 a21[2];
+
+void main() {
+    if (false) {
+        a0 = vec4(1.0);
+    }
+    a1 = vec4(0.0);
+    a2 = vec4(0.0);
+    a3 = vec4(0.0);
+    a4[0] = vec4(0.0);
+    a4[1] = vec4(0.0);
+    a4[2] = vec4(0.0);
+    a5 = vec4(0.0);
+    a6[0] = vec4(0.0);
+    a6[1] = vec4(0.0);
+    a7[0] = vec4(0.0);
+    a7[1] = vec4(0.0);
+    a8 = 0.0;
+    a9[0].x = 0.0;
+    a9[1].y = 0.0;
+    a10[0] = vec4(0.0);
+    a10[1] = vec4(0.0);
+    a11[0].a[0] = 0.0;
+    a11[0].a[1] = 0.0;
+    a11[0].a[2] = 0.0;
+    a11[0].b = 0.0;
+    a11[1].a[0] = 0.0;
+    a11[1].a[1] = 0.0;
+    a11[1].a[2] = 0.0;
+    a11[1].b = 0.0;
+    a12[0] = 0.0;
+    a12[1] = 0.0;
+    a12[2] = 0.0;
+    s0.a13.y = 0.0;
+    s0.a14.a[0] = 0.0;
+    s0.a14.a[1] = 0.0;
+    s0.a14.a[2] = 0.0;
+    s0.a14.b = 0.0;
+    s0.a15 = mat4(1.0);
+    // a16 intentionally not written to
+    a17[ubo0.i] = vec4(1.0);
+    a18[5] = vec4(1.0);
+    a19 = vec2(0.0);
+    a20 = vec4(1.0);
+    a21[0] = vec2(0.0);
+    a21[1] = vec2(0.0);
+}

--- a/Test/link.vk.missingCrossStageIO.0.frag
+++ b/Test/link.vk.missingCrossStageIO.0.frag
@@ -1,0 +1,104 @@
+#version 460
+
+layout(location = 0) in BBlock0 {
+    vec4 b0;
+    vec4 b1;
+    vec4 b2;
+    vec4 b3;
+};
+
+layout(location = 4) in vec4 b4[2];
+
+layout(location = 6) in BBlock1 {
+    vec4 b5;
+};
+
+layout(location = 7) in vec4 b6[5];
+
+layout(location = 12) in float b7[4];
+
+layout(location = 21) in BBlock2 {
+    vec2 b8;
+    float b9;
+    layout(location = 16) vec3 b10;
+    float b11[4];
+};
+
+layout(location = 23) in BBlock3 {
+    float b12[6];
+};
+
+layout(location = 29) in BBlock4 {
+    float b13[]; // implicitly sized to 10
+};
+
+layout(location = 39) in BBlock5 {
+    flat ivec2 b14;
+};
+
+layout(location = 40) in mat2 b15;
+
+in flat uint b16;
+
+layout(location = 45) in BBlock6 {
+    vec4 b17;
+    layout(location = 43) vec4 b18;
+    vec4 b19;
+};
+
+layout(binding = 0) uniform UBO0 {
+    int i;
+} ubo0;
+
+layout(location = 46) in vec4 b20[4];
+
+layout(location = 50) in BBlock7 {
+    vec4 b21[10];
+};
+
+layout(location = 60) in vec2 b22;
+
+// automatically mapped by name
+in Block0 {
+    vec4 a20;
+};
+
+// automatically mapped by name
+in vec2 a21[2];
+
+out vec4 o;
+
+uint uncalled() {
+    return b16;
+}
+
+void main() {
+    o = b1;
+    o += b2;
+    o += b3;
+    o += b4[0];
+    o += b4[1];
+    o += b5;
+    o += b6[0];
+    o += b6[1];
+    o += b6[2];
+    o += b6[3];
+    o += b6[4];
+    o += vec4(b7[0], b7[1], b7[2], b7[3]);
+    o += b8.xxyy;
+    o += vec4(b9);
+    o += b10.xyzx;
+    o += vec4(b11[0], b11[1], b11[2], b11[3]);
+    o += vec4(b12[0], b12[1], b12[2], b12[3] + b12[4] + b12[5]);
+    o += vec4(b13[9], b13[7], b13[6], b13[0]);
+    if (false) {
+        o += (b15 * vec2(1.0)).xxyy;
+        o += b18;
+        o += b19;
+    }
+    o += b20[ubo0.i];
+    o += b21[ubo0.i];
+    o += b22.xxyy;
+    o += a20;
+    o += vec4(a21[0], a21[1]);
+}

--- a/Test/link.vk.missingCrossStageIO.0.vert
+++ b/Test/link.vk.missingCrossStageIO.0.vert
@@ -1,0 +1,4 @@
+#version 460
+
+void main() {
+}

--- a/glslang/Include/glslang_c_shader_types.h
+++ b/glslang/Include/glslang_c_shader_types.h
@@ -178,6 +178,7 @@ typedef enum {
     GLSLANG_MSG_ABSOLUTE_PATH               = (1 << 16),
     GLSLANG_MSG_DISPLAY_ERROR_COLUMN        = (1 << 17),
     GLSLANG_MSG_LINK_TIME_OPTIMIZATION_BIT  = (1 << 18),
+    GLSLANG_MSG_VALIDATE_CROSS_STAGE_IO_BIT = (1 << 19),
     LAST_ELEMENT_MARKER(GLSLANG_MSG_COUNT),
 } glslang_messages_t;
 

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -2135,8 +2135,8 @@ bool TProgram::crossStageCheck(EShMessages messages) {
 
     // compare cross stage symbols for each stage boundary
     for (unsigned int i = 1; i < activeStages.size(); ++i) {
-        activeStages[i - 1]->checkStageIO(*infoSink, *activeStages[i]);
-        error |= (activeStages[i - 1]->getNumErrors() != 0);
+        activeStages[i - 1]->checkStageIO(*infoSink, *activeStages[i], messages);
+        error |= (activeStages[i - 1]->getNumErrors() != 0 || activeStages[i]->getNumErrors() != 0);
     }
 
     // if requested, optimize cross stage IO

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -1054,7 +1054,7 @@ public:
     void mergeGlobalUniformBlocks(TInfoSink& infoSink, TIntermediate& unit, bool mergeExistingOnly);
     void mergeUniformObjects(TInfoSink& infoSink, TIntermediate& unit);
     void mergeImplicitArraySizes(TInfoSink& infoSink, TIntermediate& unit);
-    void checkStageIO(TInfoSink&, TIntermediate&);
+    void checkStageIO(TInfoSink&, TIntermediate&, EShMessages);
     void optimizeStageIO(TInfoSink&, TIntermediate&);
 
     bool buildConvertOp(TBasicType dst, TBasicType src, TOperator& convertOp) const;
@@ -1125,8 +1125,14 @@ public:
 
 protected:
     TIntermSymbol* addSymbol(long long Id, const TString&, const TString&, const TType&, const TConstUnionArray&, TIntermTyped* subtree, const TSourceLoc&);
-    void error(TInfoSink& infoSink, const char*, EShLanguage unitStage = EShLangCount);
-    void warn(TInfoSink& infoSink, const char*, EShLanguage unitStage = EShLangCount);
+    void error(TInfoSink& infoSink, const TSourceLoc* loc, EShMessages messages, const char*, EShLanguage unitStage = EShLangCount);
+    void error(TInfoSink& infoSink, const char* message, EShLanguage unitStage = EShLangCount) {
+        error(infoSink, nullptr, EShMsgDefault, message, unitStage);
+    }
+    void warn(TInfoSink& infoSink, const TSourceLoc* loc, EShMessages, const char*, EShLanguage unitStage = EShLangCount);
+    void warn(TInfoSink& infoSink, const char* message, EShLanguage unitStage = EShLangCount) {
+        warn(infoSink, nullptr, EShMsgDefault, message, unitStage);
+    }
     void mergeCallGraphs(TInfoSink&, TIntermediate&);
     void mergeModes(TInfoSink&, TIntermediate&);
     void mergeTrees(TInfoSink&, TIntermediate&);

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -273,6 +273,7 @@ enum EShMessages : unsigned {
     EShMsgAbsolutePath         = (1 << 16), // Output Absolute path for messages
     EShMsgDisplayErrorColumn   = (1 << 17), // Display error message column aswell as line
     EShMsgLinkTimeOptimization = (1 << 18), // perform cross-stage optimizations during linking
+    EShMsgValidateCrossStageIO = (1 << 19), // validate shader inputs have matching outputs in previous stage
     LAST_ELEMENT_MARKER(EShMsgCount),
 };
 

--- a/gtests/Link.FromFile.Vk.cpp
+++ b/gtests/Link.FromFile.Vk.cpp
@@ -122,6 +122,9 @@ INSTANTIATE_TEST_SUITE_P(
         {"link.vk.multiBlocksValid.0.0.vert", "link.vk.multiBlocksValid.0.1.vert"},
         {"link.vk.multiBlocksValid.1.0.geom", "link.vk.multiBlocksValid.1.1.geom"},
         {"link.vk.inconsistentGLPerVertex.0.vert", "link.vk.inconsistentGLPerVertex.0.geom"},
+        {"link.vk.crossStageIO.0.vert", "link.vk.crossStageIO.0.frag"},
+        {"link.vk.crossStageIO.1.vert", "link.vk.crossStageIO.1.geom", "link.vk.crossStageIO.1.frag"},
+        {"link.vk.missingCrossStageIO.0.vert", "link.vk.missingCrossStageIO.0.frag"},
     }))
 );
 // clang-format on

--- a/gtests/Link.FromFile.cpp
+++ b/gtests/Link.FromFile.cpp
@@ -114,6 +114,9 @@ INSTANTIATE_TEST_SUITE_P(
         {"link.tesselation.vert", "link.tesselation.frag"},
         {"link.tesselation.tese", "link.tesselation.tesc"},
         {"link.redeclareBuiltin.vert", "link.redeclareBuiltin.geom"},
+        {"link.crossStageIO.0.vert", "link.crossStageIO.0.frag"},
+        {"link.crossStageIO.1.vert", "link.crossStageIO.1.geom", "link.crossStageIO.1.frag"},
+        {"link.missingCrossStageIO.0.vert", "link.missingCrossStageIO.0.frag"},
     }))
 );
 // clang-format on

--- a/gtests/TestFixture.cpp
+++ b/gtests/TestFixture.cpp
@@ -116,7 +116,7 @@ EShMessages DeriveOptions(Source source, Semantics semantics, Target target)
             break;
     }
 
-    result = static_cast<EShMessages>(result | EShMsgHlslLegalization);
+    result = static_cast<EShMessages>(result | EShMsgHlslLegalization | EShMsgValidateCrossStageIO);
 
     return result;
 }


### PR DESCRIPTION
glslang does not currently have logic to detect when cross-stage IO statically accessed in one stage is missing in the previous stage, and there is a longstanding TODO comment in the existing TIntermediate::checkStageIO() function suggesting that such functionality should be implemented. To that end, this PR implements the proposed cross-stage link time IO validation and introduces a new EShMessages flag to optionally enable it. If the user does not explicitly opt in to this functionality by supplying the new flag, the behavior of linking remains unchanged from how it worked prior to this PR.

When enabled, the new cross-stage IO validation functionality aims to validate that statically read cross-stage input locations have corresponding output declarations in the previous stage. It also aims to ensure that as many unusual but valid usage patterns that are known to exist in real-world applications' shaders (for example, input declarations that don't have matching outputs in the previous stage but that are also never read, or that are only read in branches that can statically be determined to not be live) can be linked without any errors. At a high level, this implementation adopts a philosophy that it's always more important for valid usage to be allowed than for invalid usage to be disallowed (though of course considerable effort is still made to detect as much invalid usage as is practical to detect).

It is worth noting that though the TODO in the existing code may make this problem appear straightforward at first glance, a sufficiently robust implementation of this functionality capable of handling all valid usage patterns permitted by the GLSL specification (particularly certain usage patterns commonly encountered in complex, real-world applications) can be deceptively complicated to get right, and the amount of test coverage needed to adequately validate its functionality is substantial. Versions of the implementation in this PR have existed in Nintendo's fork of glslang for approximately 5 years and have evolved and improved over the course of that time to be able to successfully validate and link complex shader corpora from numerous real-world applications. Despite this, and the fact that this PR does include fairly comprehensive test coverage, in order to minimize risk to real-world applications this PR's functionality is conservatively gated behind a new EShMsgValidateCrossStageIO flag (and corresponding --validate-io option in the standalone executable).

The bulk of the code changes in this PR are concentrated at the end of the existing TIntermediate::checkStageIO() function (where the aforementioned TODO existed previously).

At a high level, each pair of logically adjacent stages in a program is traversed in a liveness-aware manner to compare outputs declared in each earlier stage against inputs actually read/accessed in each corresponding later stage. Live inputs are matched to outputs using several methods, and any live inputs remaining at the end of this process that haven't been matched to any output produce linker errors. To elaborate:

First, all outputs declared in the earlier stage along with all inputs that are statically accessed in the later stage are collected into temporary sequences of symbols. Per the GLSL specification, inputs are only required to have matching outputs if they are statically used, so code paths that can be statically determined to not be live are ignored in the traversal of the later stage (but obviously not in the traversal of outputs in the earlier stage).

The sequence of output symbols in the earlier stage is then iterated (and output blocks parsed accordingly) in order to populate a set of all explicitly declared output locations, including locations comprising arrayed and/or block IO that spans ranges of multiple consecutive locations. Outputs without explicit locations (i.e., whose locations will be assigned later during IO mapping) will be matched by name later, so they are ignored during this step.

Next, the sequence of live inputs in the later stage is iterated: inputs with explicit locations are checked to determine whether their location(s) exist(s) in the set of declared outputs in the earlier stage, and inputs without explicit locations are checked against outputs in the earlier stage to try to find an output with a matching name and type. Inputs matched to outputs by either of these means are removed from the temporary sequence of live inputs.

Then, remaining non-block live input variables are matched against output block member names, and likewise removed from the temporary sequence of input symbols.

Finally, remaining live block inputs are checked for matching loose (non-block) outputs in the previous stage. Liveness of block members is not (yet) tracked at a per-member granularity (though this could be implemented in the future), so any member of an input block that matches any output in the previous stage causes all other members of that block to be considered matched. This can be overly permissive in certain cases, but redesigning common liveness traversal functionality to track per-member liveness would be well out of scope for this PR. As in the earlier steps, inputs successfully matched to outputs at this point are removed from the temporary input symbol sequence.

Any statically used input variables remaining in the temporary input symbol sequence after the above process is complete don't have matching outputs in the earlier stage. In this case, linking is considered to have failed and an appropriate link error is reported for each such input. This approach ensures that all instances of inputs without corresponding outputs are reported to the user rather than only the first one.

Due to the high-level architecture of linking in glslang these kinds of link errors will always be produced by the later stage, so this PR also necessarily modifies TProgram::crossStageCheck() to check for errors in both stages (as opposed to only the earlier stage as it was doing previously) when determining whether linking should be considered to have failed.

During internal development and real world use of this functionality it was determined that glslang's existing link-time error reporting logic would need to be improved for these kinds of errors to be able to provide users with enough information to be meaningfully helpful. As a result, this PR introduces new overloads of TIntermediate::error() and TIntermediate::warn() which include source locations (in this case, of the actual static accesses to live input variables and not merely the variable declarations). Other link error/warning messages could be improved in the future to leverage these new functions to include appropriate source location information, but this kind of change is obviously out of scope for this PR and is therefore left to the maintainers and/or original authors of those messages.

This cross-stage IO validation implementation has a few known limitations that mean it doesn't necessarily detect all possible invalid usage patterns, but it intentionally prioritizes never giving false errors for valid usage. These limitations include:

The GLSL specification permits (and arguably encourages) the compiler to generate link-time warnings (but never errors) for cases where the compiler can statically determine that an output in one stage is declared but never written to but whose corresponding input is statically read from in the next stage. Due to limitations in TLiveTraverser this is currently not implemented, but the high-level structure of the cross-stage IO validation functionality has been designed with future support for such functionality in mind. A new TODO comment has been added in the appropriate part of TIntermediate::checkStageIO() in order to encourage further work on this.

As mentioned earlier, liveness of blocks is not currently tracked on an individual block member variable basis. This means all members of an input block are treated as having matching outputs if any one or more members match any output. Similarly, all indices of arrayed inputs are treated as having matching outputs if any one (or more) index matches any output. This means that the validation implementation is overly permissive in certain circumstances, and missing output declarations may not be reported in all cases where they ideally would be. Future improvements to TIOTraverser could address this limitation by collecting additional context about block member and array index access during traversal.

The GL_NV_geometry_shader_passthrough extension is not fully supported. When linking geometry shaders that use this extension, cross-stage IO validation of the geometry stage (but not of any other stages) is skipped and a warning to that effect is emitted. This limitation is only relevant in cases where:

- the user explicitly explicitly opts in to cross-stage IO validation, and
- the GL_NV_geometry_shader_passthrough extension is used

It's possible to implement support for this extension in the future, but it would likely require substantial refactoring of TIntermediate::checkStageIO() which would be out of scope for this PR.

Finally, (as in other parts of glslang) liveness-aware traversal is performed using TLiveTraverser, which currently only considers code to be statically not accessed when it is part of an if/else branch that can be statically determined to not be accessed, or inside a function that can be statically determined to never be called. This liveness-aware traversal logic could be improved in the future to handle return, discard, goto, and other types of control flow. One such enhancement to add support for liveness-aware traversal of switch/case statements has already been implemented as part of https://github.com/KhronosGroup/glslang/pull/3908. Future improvements to the accuracy of TLiveTraverser's liveness-aware traversal will have the positive side effect of continuing to improve the quality of cross-stage IO validation "for free".

If in the future all of these limitations are addressed, it may become viable to enable link time cross-stage IO validation by default.

This PR adds multiple positive and negative tests under both OpenGL and Vulkan semantics to exercise the newly implemented cross-stage IO validation functionality.

The first test (crossStageIO.0) consists of a vertex shader and a fragment shader with variously mismatching but valid combinations block and non-block IO between stages, with a goal of ensuring that as many valid usage patterns as are practical to test do not produce errors.

The second test (crossStageIO.1) is similar to the first (crossStageIO.0) but also includes a geometry shader to ensure that the IO semantics unique to that stage are handled properly.

The last test (missingCrossStageIO.0) is a negative test similar to the first test, except none of the inputs in the later stage have corresponding outputs in the earlier stage. It aims to ensure that appropriate errors are reported for various cases in which they are required by the GLSL specification.

In addition to adding these new tests, the common framework code for link-time tests has been updated to unconditionally opt into cross-stage IO validation for all existing tests, and (as expected) this has not resulted in any changes to the outputs of any tests that already existed.