### PR TITLE
Fix continuous deployment

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -43,10 +43,6 @@ jobs:
         steps:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6 # v3.31.6
-            - name: Install Ubuntu Package Dependencies
-              run: |
-                  sudo apt-get -qq update
-                  sudo apt-get install -y clang-6.0
             - run: ./update_glslang_sources.py
             - name: Build
               env:


### PR DESCRIPTION
Remove package that was required when CI was ported from Travis but is no longer required.