### PR TITLE
HlslParseContext should respect global uniform block name override by intermediate

### DIFF
--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -10284,4 +10284,14 @@ void HlslParseContext::finish()
     TParseContextBase::finish();
 }
 
+
+const char* HlslParseContext::getGlobalUniformBlockName() const
+{
+    const char* name = intermediate.getGlobalUniformBlockName();
+    if (std::string(name) == "")
+        return "$Global";
+    else
+        return name;
+}
+
 } // end namespace glslang

--- a/glslang/HLSL/hlslParseHelper.h
+++ b/glslang/HLSL/hlslParseHelper.h
@@ -57,7 +57,7 @@ public:
 
     void setLimits(const TBuiltInResource&) override;
     bool parseShaderStrings(TPpContext&, TInputScanner& input, bool versionWillBeError = false) override;
-    virtual const char* getGlobalUniformBlockName() const override { return "$Global"; }
+    virtual const char* getGlobalUniformBlockName() const override;
     virtual void setUniformBlockDefaults(TType& block) const override
     {
         block.getQualifier().layoutPacking = globalUniformDefaults.layoutPacking;


### PR DESCRIPTION
HlslParseContext should respect global uniform block name override by intermediate.
Currently global uniform block name resolved by hlsl parse context is always "$Global" (not even "$Globals" for compatibility with DXC). While the TShader accepts override name for the global block and even TParseContext respects it, it wouldn't work with hlsl. With this change, HlslParseContext would also respect the name override.