### PR TITLE
Fix logic in CMakeFiles for tests on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,16 +338,16 @@ if(GLSLANG_TESTS)
         set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
     endif()
 
-    # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
-    if(WIN32 AND BUILD_SHARED_LIBS AND CMAKE_VERSION VERSION_LESS "3.27")
-        message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
-    else()
-        add_test(NAME glslang-testsuite
-            COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
+    if(WIN32 AND BUILD_SHARED_LIBS)
+        # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
+        if(CMAKE_VERSION VERSION_LESS "3.27")
+            message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
+        else()
+            add_test(NAME glslang-testsuite
+                COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
 
-        # Prepend paths to shared libraries.
-        if (BUILD_SHARED_LIBS)
+            # Prepend paths to shared libraries.
             set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslang-standalone>,\;>")
             set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:spirv-remap>,\;>")
         endif()

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -98,15 +98,15 @@ if(GLSLANG_TESTS)
 
         target_link_libraries(glslangtests PRIVATE ${LIBRARIES} gmock)
 
-        # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
-        if(WIN32 AND BUILD_SHARED_LIBS AND CMAKE_VERSION VERSION_LESS "3.27")
-            message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
-        else()
-            add_test(NAME glslang-gtests
-                     COMMAND glslangtests --test-root "${GLSLANG_TEST_DIRECTORY}")
+        if(WIN32 AND BUILD_SHARED_LIBS)
+            # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
+            if(CMAKE_VERSION VERSION_LESS "3.27")
+                message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
+            else()
+                add_test(NAME glslang-gtests
+                        COMMAND glslangtests --test-root "${GLSLANG_TEST_DIRECTORY}")
 
-            # Prepend paths to shared libraries.
-            if (BUILD_SHARED_LIBS)
+                # Prepend paths to shared libraries.
                 set_tests_properties(glslang-gtests PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslangtests>,\;>")
             endif()
         endif()


### PR DESCRIPTION
The logic in the condition to include tests on Windows in CMakeFiles was wrong: if one of `WIN32`, `BUILD_SHARED_LIBS` or `CMAKE_VERSION VERSION_LESS "3.27"` was false (eg having CMake version 3.25 on Linux with enabled shared libs) would try to add the test and to execute `$<TARGET_RUNTIME_DLL_DIRS:spirv-remap>` which was introduced only in CMake 3.27.

This PR fixes this (and I also removed a spurious `if (BUILD_SHARED_LIBS)`).

The problem was introduced by commit b3a6aa7b03c51ba976e4f4e96b1e31f77f43f312 and the CI didn't spot it because `BUILD_SHARED_LIBS` is set to `OFF` by default and the presence of the (not so spurious in this buggy case)  line `if (BUILD_SHARED_LIBS)`.