### PR TITLE
cmake: Remove BUILD_SHARED_LIBS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ include(CMakePackageConfigHelpers)
 # Needed for cmake_dependent_option macro
 include(CMakeDependentOption)
 
-option(BUILD_SHARED_LIBS "Build Shared Libraries")
 option(BUILD_EXTERNAL "Build external dependencies in /External" ON)
 option(BUILD_WERROR "Enable warnings as errors (default is OFF)" OFF)
 


### PR DESCRIPTION
BUILD_SHARED_LIBS is a built in CMake variable. Because the code simply declares the varriable (ie, doesn't change the default value), it was redundant and caused confusion for users unfamiliar with CMake & its built in's.

CMake documentation for the curious:
https://github.com/KhronosGroup/glslang/compare/main...charles-lunarg:glslang:remove_built_in_cmake_option?expand=1