### PR TITLE
Fix crash on unnamed function parameters under relaxed rules

### DIFF
--- a/Test/baseResults/validation_fails.txt
+++ b/Test/baseResults/validation_fails.txt
@@ -77,3 +77,4 @@ Test/baseResults/spv.separate.frag.out
 Test/baseResults/spv.sparseTextureClamp.frag.out
 Test/baseResults/spv.sparseTexture.frag.out
 Test/baseResults/vk.relaxed.errorcheck.vert.out
+Test/baseResults/vk.relaxed.syntaxerror.vert.out

--- a/Test/baseResults/vk.relaxed.syntaxerror.vert.out
+++ b/Test/baseResults/vk.relaxed.syntaxerror.vert.out
@@ -1,0 +1,94 @@
+vk.relaxed.syntaxerror.vert
+Shader version: 460
+0:? Sequence
+0:5  Function Definition: main( ( global void)
+0:5    Function Parameters: 
+0:6    Sequence
+0:6      move second child to first child ( temp highp 4-component vector of float)
+0:6        'io' (layout( location=0) smooth out highp 4-component vector of float)
+0:6        Constant:
+0:6          0.000000
+0:6          0.000000
+0:6          0.000000
+0:6          0.000000
+0:?   Linker Objects
+0:?     'io' (layout( location=0) smooth out highp 4-component vector of float)
+0:?     'gl_VertexIndex' ( in int VertexIndex)
+0:?     'gl_InstanceIndex' ( in int InstanceIndex)
+
+vk.relaxed.syntaxerror.frag
+ERROR: 0:20: '' :  syntax error, unexpected SAMPLER, expecting RIGHT_PAREN
+ERROR: 1 compilation errors.  No code generated.
+
+
+Shader version: 460
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:16  Function Definition: main( ( global void)
+0:16    Function Parameters: 
+0:17    Sequence
+0:17      move second child to first child ( temp highp 4-component vector of float)
+0:17        'o' ( out highp 4-component vector of float)
+0:17        add ( temp highp 4-component vector of float)
+0:17          'io' (layout( location=0) smooth in highp 4-component vector of float)
+0:17          Function Call: foo(struct-OpaqueInStruct-s211;s21; ( global highp 4-component vector of float)
+0:17            uniformStruct: direct index for structure ( uniform structure{ global highp int /*smp*/})
+0:17              'anon@0' (layout( column_major std140) uniform block{ uniform structure{ global highp int /*smp*/} uniformStruct})
+0:17              Constant:
+0:17                0 (const uint)
+0:17            'uniformStruct.smp' ( uniform highp sampler2D)
+0:?   Linker Objects
+0:?     'io' (layout( location=0) smooth in highp 4-component vector of float)
+0:?     'o' ( out highp 4-component vector of float)
+0:?     'uniformStruct.smp' ( uniform highp sampler2D)
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform structure{ global highp int /*smp*/} uniformStruct})
+
+
+Linked vertex stage:
+
+
+Linked fragment stage:
+
+ERROR: Linking fragment stage: No function definition (body) found: 
+    foo(struct-OpaqueInStruct-s211;s21;
+
+Shader version: 460
+0:? Sequence
+0:5  Function Definition: main( ( global void)
+0:5    Function Parameters: 
+0:6    Sequence
+0:6      move second child to first child ( temp highp 4-component vector of float)
+0:6        'io' (layout( location=0) smooth out highp 4-component vector of float)
+0:6        Constant:
+0:6          0.000000
+0:6          0.000000
+0:6          0.000000
+0:6          0.000000
+0:?   Linker Objects
+0:?     'io' (layout( location=0) smooth out highp 4-component vector of float)
+0:?     'gl_VertexIndex' ( in int VertexIndex)
+0:?     'gl_InstanceIndex' ( in int InstanceIndex)
+Shader version: 460
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:16  Function Definition: main( ( global void)
+0:16    Function Parameters: 
+0:17    Sequence
+0:17      move second child to first child ( temp highp 4-component vector of float)
+0:17        'o' ( out highp 4-component vector of float)
+0:17        add ( temp highp 4-component vector of float)
+0:17          'io' (layout( location=0) smooth in highp 4-component vector of float)
+0:17          Function Call: foo(struct-OpaqueInStruct-s211;s21; ( global highp 4-component vector of float)
+0:17            uniformStruct: direct index for structure ( uniform structure{ global highp int /*smp*/})
+0:17              'anon@0' (layout( column_major std140) uniform block{ uniform structure{ global highp int /*smp*/} uniformStruct})
+0:17              Constant:
+0:17                0 (const uint)
+0:17            'uniformStruct.smp' ( uniform highp sampler2D)
+0:?   Linker Objects
+0:?     'io' (layout( location=0) smooth in highp 4-component vector of float)
+0:?     'o' ( out highp 4-component vector of float)
+0:?     'uniformStruct.smp' ( uniform highp sampler2D)
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform structure{ global highp int /*smp*/} uniformStruct})
+
+Validation failed
+SPIR-V is not generated for failed compile or link

--- a/Test/vk.relaxed.syntaxerror.frag
+++ b/Test/vk.relaxed.syntaxerror.frag
@@ -1,0 +1,23 @@
+#version 460
+
+layout (location = 0) in vec4 io;
+
+out vec4 o;
+
+struct OpaqueInStruct
+{
+	sampler2D smp;
+};
+
+uniform OpaqueInStruct uniformStruct;
+
+vec4 foo(OpaqueInStruct);
+
+void main() {
+    o = io + foo(uniformStruct);
+}
+
+vec4 foo(OpaqueInStruct sampler) { // unnamed variable and invalid SAMPLER token
+    return a + vec4(test);
+}
+

--- a/Test/vk.relaxed.syntaxerror.vert
+++ b/Test/vk.relaxed.syntaxerror.vert
@@ -1,0 +1,7 @@
+#version 460
+
+layout (location = 0) out vec4 io;
+
+void main() {
+    io = vec4(0.0);
+}

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -1797,6 +1797,7 @@ public:
         return *typeName;
     }
 
+    virtual bool hasFieldName() const { return (fieldName != nullptr); }
     virtual const TString& getFieldName() const
     {
         assert(fieldName);

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -7964,12 +7964,15 @@ static void ForEachOpaque(const TType& type, const TString& path, Function callb
                  ++flatIndex)
             {
                 TString subscriptPath = path;
-                for (size_t dimIndex = 0; dimIndex < indices.size(); ++dimIndex)
+                if (path != "")
                 {
-                    int index = indices[dimIndex];
-                    subscriptPath.append("[");
-                    subscriptPath.append(String(index));
-                    subscriptPath.append("]");
+                    for (size_t dimIndex = 0; dimIndex < indices.size(); ++dimIndex)
+                    {
+                        int index = indices[dimIndex];
+                        subscriptPath.append("[");
+                        subscriptPath.append(String(index));
+                        subscriptPath.append("]");
+                    }
                 }
 
                 recursion(type, subscriptPath, true, recursion);
@@ -7991,8 +7994,11 @@ static void ForEachOpaque(const TType& type, const TString& path, Function callb
             for (const TTypeLoc& typeLoc : types)
             {
                 TString nextPath = path;
-                nextPath.append(".");
-                nextPath.append(typeLoc.type->getFieldName());
+                if (path != "")
+                {
+                    nextPath.append(".");
+                    nextPath.append(typeLoc.type->getFieldName());
+                }
 
                 recursion(*(typeLoc.type), nextPath, false, recursion);
             }
@@ -8050,9 +8056,13 @@ void TParseContext::vkRelaxedRemapFunctionParameter(TFunction* function, TParame
     if (!param.type->isStruct() || !param.type->containsOpaque())
         return;
 
-    ForEachOpaque(*param.type, (param.name ? *param.name : param.type->getFieldName()),
+    TString fieldName = param.name
+        ? *param.name
+        : param.type->hasFieldName() ? param.type->getFieldName() : "";
+
+    ForEachOpaque(*param.type, fieldName,
                   [function, param, newParams](const TType& type, const TString& path) {
-                      TString* memberName = NewPoolTString(path.c_str());
+                      TString* memberName = path != "" ? NewPoolTString(path.c_str()) : nullptr;
 
                       TType* memberType = new TType();
                       memberType->shallowCopy(type);

--- a/gtests/VkRelaxed.FromFile.cpp
+++ b/gtests/VkRelaxed.FromFile.cpp
@@ -297,6 +297,7 @@ INSTANTIATE_TEST_SUITE_P(
         {{"vk.relaxed.stagelink.vert", "vk.relaxed.stagelink.frag"}, {}},
         {{"vk.relaxed.errorcheck.vert", "vk.relaxed.errorcheck.frag"}, {}},
         {{"vk.relaxed.changeSet.vert", "vk.relaxed.changeSet.frag" }, { {"0"}, {"1"} } },
+        {{"vk.relaxed.syntaxerror.vert", "vk.relaxed.syntaxerror.frag"}, {}},
     }))
 );
 // clang-format on


### PR DESCRIPTION
Old OpenGL-compatible code was allowed to contain variables named `sampler`.
This is not true under Vulkan semantics anymore, as this has become a reserved keyword.
Compiling shaders with function parameters named like this generates an unnamed parameter followed by a `SAMPLER` token.
Before this fix, such behaviour resulted in a segfault, as `vkRelaxedRemapFunctionParameter()` always expected the input variable to be named.
This PR addresses this issue by adding a function to check whether a type has a field name, and if not, `vkRelaxedRemapFunctionParameter()` generates all variables without prefixing them with anything.