### PR TITLE
Allow spec constant matrix use

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -5238,7 +5238,7 @@ spv::Id TGlslangToSpvTraverser::convertGlslangToSpvType(const glslang::TType& ty
         spv::Id scope = makeArraySizeId(*type.getTypeParameters()->arraySizes, 0);
         spv::Id rows = makeArraySizeId(*type.getTypeParameters()->arraySizes, 1);
         spv::Id cols = makeArraySizeId(*type.getTypeParameters()->arraySizes, 2);
-        spv::Id use = builder.makeUintConstant(type.getCoopMatKHRuse());
+        spv::Id use = makeArraySizeId(*type.getTypeParameters()->arraySizes, 3, true);
 
         spvType = builder.makeCooperativeMatrixTypeKHR(spvType, scope, rows, cols, use);
     }


### PR DESCRIPTION
In SPIR-V specification `SPV_KHR_cooperative_matrix`, allows the `use` of cooperative matrix is a constant instruction.
The use in this context is: how to use the matrix as matrixA, matrixB or matrixAccumulate.

> gl_MatrixUse* are constant integer values which can be used for the MatrixUse template
parameter in cooperative matrix types.