### PR TITLE
Move E_SPV_ARM_cooperative_matrix_layouts into GLSL.ext.ARM.h

### DIFF
--- a/SPIRV/GLSL.ext.ARM.h
+++ b/SPIRV/GLSL.ext.ARM.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 ARM Limited
+** Copyright (c) 2022, 2025 ARM Limited
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and/or associated documentation files (the "Materials"),
@@ -30,6 +30,7 @@
 static const int GLSLextARMVersion = 100;
 static const int GLSLextARMRevision = 1;
 
-static const char * const E_SPV_ARM_core_builtins = "SPV_ARM_core_builtins";
+static const char* const E_SPV_ARM_core_builtins = "SPV_ARM_core_builtins";
+static const char* const E_SPV_ARM_cooperative_matrix_layouts = "SPV_ARM_cooperative_matrix_layouts";
 
 #endif  // #ifndef GLSLextARM_H

--- a/SPIRV/GLSL.ext.EXT.h
+++ b/SPIRV/GLSL.ext.EXT.h
@@ -41,7 +41,6 @@ static const char* const E_SPV_EXT_shader_atomic_float_min_max = "SPV_EXT_shader
 static const char* const E_SPV_EXT_shader_image_int64 = "SPV_EXT_shader_image_int64";
 static const char* const E_SPV_EXT_shader_tile_image = "SPV_EXT_shader_tile_image";
 static const char* const E_SPV_EXT_mesh_shader = "SPV_EXT_mesh_shader";
-static const char* const E_SPV_ARM_cooperative_matrix_layouts = "SPV_ARM_cooperative_matrix_layouts";
 static const char* const E_SPV_EXT_float8 = "SPV_EXT_float8";
 
 #endif  // #ifndef GLSLextEXT_H


### PR DESCRIPTION
This is a vendor extension that was accidentally added into the EXT header.