### PR TITLE
Revert "Fix logic in CMakeFiles for tests on Windows (#3955)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,16 +337,16 @@ if(GLSLANG_TESTS)
         set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
     endif()
 
-    if(WIN32 AND BUILD_SHARED_LIBS)
-        # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
-        if(CMAKE_VERSION VERSION_LESS "3.27")
-            message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
-        else()
-            add_test(NAME glslang-testsuite
-                COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
+    # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
+    if(WIN32 AND BUILD_SHARED_LIBS AND CMAKE_VERSION VERSION_LESS "3.27")
+        message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
+    else()
+        add_test(NAME glslang-testsuite
+            COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
 
-            # Prepend paths to shared libraries.
+        # Prepend paths to shared libraries.
+        if (BUILD_SHARED_LIBS)
             set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslang-standalone>,\;>")
             set_tests_properties(glslang-testsuite PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:spirv-remap>,\;>")
         endif()

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -98,15 +98,15 @@ if(GLSLANG_TESTS)
 
         target_link_libraries(glslangtests PRIVATE ${LIBRARIES} gmock)
 
-        if(WIN32 AND BUILD_SHARED_LIBS)
-            # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
-            if(CMAKE_VERSION VERSION_LESS "3.27")
-                message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
-            else()
-                add_test(NAME glslang-gtests
-                        COMMAND glslangtests --test-root "${GLSLANG_TEST_DIRECTORY}")
+        # The TARGET_RUNTIME_DLL_DIRS feature requires CMake 3.27 or greater.
+        if(WIN32 AND BUILD_SHARED_LIBS AND CMAKE_VERSION VERSION_LESS "3.27")
+            message(WARNING "The Windows shared library test configuration requires CMake 3.27 or greater")
+        else()
+            add_test(NAME glslang-gtests
+                     COMMAND glslangtests --test-root "${GLSLANG_TEST_DIRECTORY}")
 
-                # Prepend paths to shared libraries.
+            # Prepend paths to shared libraries.
+            if (BUILD_SHARED_LIBS)
                 set_tests_properties(glslang-gtests PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:glslangtests>,\;>")
             endif()
         endif()


### PR DESCRIPTION
This reverts commit f828eadd3688ca1a27815f0ac6e425c9f54db853 as it caused the test suite to remain empty for non-WIN32 platforms.

Fixes https://github.com/KhronosGroup/glslang/issues/3979 .