### PR TITLE
Export spv::Parameterize

### DIFF
--- a/SPIRV/doc.h
+++ b/SPIRV/doc.h
@@ -42,10 +42,25 @@
 
 #include <vector>
 
+#ifdef GLSLANG_IS_SHARED_LIBRARY
+    #ifdef _WIN32
+        #ifdef GLSLANG_EXPORTING
+            #define GLSLANG_EXPORT __declspec(dllexport)
+        #else
+            #define GLSLANG_EXPORT __declspec(dllimport)
+        #endif
+    #elif __GNUC__ >= 4
+        #define GLSLANG_EXPORT __attribute__((visibility("default")))
+    #endif
+#endif // GLSLANG_IS_SHARED_LIBRARY
+#ifndef GLSLANG_EXPORT
+#define GLSLANG_EXPORT
+#endif
+
 namespace spv {
 
 // Fill in all the parameters
-void Parameterize();
+GLSLANG_EXPORT void Parameterize();
 
 // Return the English names of all the enums.
 const char* SourceString(int);


### PR DESCRIPTION
`spv::Parameterize()` needs to be called before working with SPIR-V. When using glslang as a library, not through the disassemble or remap entry-points, `Parameterize` needs to be called explicitly. Therefore the function needs to be exported.
As `doc.h` is used in spirv-remap, the `visibility.h` header cannot be included, so redefine the `GLSLANG_EXPORT` macro like it is done in `SPVRemapper.h`.

Fixes a build with `-DBUILD_SHARED_LIBS=ON`.

For reference, we call `spv::Parameterize()` here:
https://github.com/GPUOpen-Drivers/spvgen/blob/ba3bda984defc22aadb20f3e1fdfaf23972cf636/source/spvgen.cpp#L1748