### PR TITLE
Fix inconsistent labeling of capability strings

### DIFF
--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -977,7 +977,7 @@ const char* CapabilityString(int info)
     case (int)Capability::SubgroupBallotKHR: return "SubgroupBallotKHR";
     case (int)Capability::DrawParameters:    return "DrawParameters";
     case (int)Capability::SubgroupVoteKHR:   return "SubgroupVoteKHR";
-    case (int)Capability::GroupNonUniformRotateKHR: return "CapabilityGroupNonUniformRotateKHR";
+    case (int)Capability::GroupNonUniformRotateKHR: return "GroupNonUniformRotateKHR";
 
     case (int)Capability::StorageUniformBufferBlock16: return "StorageUniformBufferBlock16";
     case (int)Capability::StorageUniform16:            return "StorageUniform16";
@@ -1023,7 +1023,7 @@ const char* CapabilityString(int info)
     case (int)Capability::RayTracingPositionFetchKHR:      return "RayTracingPositionFetchKHR";
     case (int)Capability::DisplacementMicromapNV:           return "DisplacementMicromapNV";
     case (int)Capability::RayTracingOpacityMicromapEXT:    return "RayTracingOpacityMicromapEXT";
-    case (int)Capability::RayTracingDisplacementMicromapNV: return "CapabilityRayTracingDisplacementMicromapNV";
+    case (int)Capability::RayTracingDisplacementMicromapNV: return "RayTracingDisplacementMicromapNV";
     case (int)Capability::RayQueryPositionFetchKHR:        return "RayQueryPositionFetchKHR";
     case (int)Capability::ComputeDerivativeGroupQuadsNV:   return "ComputeDerivativeGroupQuadsNV";
     case (int)Capability::ComputeDerivativeGroupLinearNV:  return "ComputeDerivativeGroupLinearNV";
@@ -1071,9 +1071,9 @@ const char* CapabilityString(int info)
     case (int)Capability::CooperativeVectorNV:                     return "CooperativeVectorNV";
     case (int)Capability::CooperativeVectorTrainingNV:             return "CooperativeVectorTrainingNV";
 
-    case (int)Capability::FragmentShaderSampleInterlockEXT:        return "CapabilityFragmentShaderSampleInterlockEXT";
-    case (int)Capability::FragmentShaderPixelInterlockEXT:         return "CapabilityFragmentShaderPixelInterlockEXT";
-    case (int)Capability::FragmentShaderShadingRateInterlockEXT:   return "CapabilityFragmentShaderShadingRateInterlockEXT";
+    case (int)Capability::FragmentShaderSampleInterlockEXT:        return "FragmentShaderSampleInterlockEXT";
+    case (int)Capability::FragmentShaderPixelInterlockEXT:         return "FragmentShaderPixelInterlockEXT";
+    case (int)Capability::FragmentShaderShadingRateInterlockEXT:   return "FragmentShaderShadingRateInterlockEXT";
 
     case (int)Capability::TileImageColorReadAccessEXT:           return "TileImageColorReadAccessEXT";
     case (int)Capability::TileImageDepthReadAccessEXT:           return "TileImageDepthReadAccessEXT";
@@ -1090,7 +1090,7 @@ const char* CapabilityString(int info)
     case (int)Capability::QuadControlKHR:                          return "QuadControlKHR";
     case (int)Capability::Int64ImageEXT:                           return "Int64ImageEXT";
 
-    case (int)Capability::IntegerFunctions2INTEL:              return "CapabilityIntegerFunctions2INTEL";
+    case (int)Capability::IntegerFunctions2INTEL:              return "IntegerFunctions2INTEL";
 
     case (int)Capability::ExpectAssumeKHR:                         return "ExpectAssumeKHR";
 
@@ -1101,9 +1101,9 @@ const char* CapabilityString(int info)
     case (int)Capability::AtomicFloat32MinMaxEXT:                  return "AtomicFloat32MinMaxEXT";
     case (int)Capability::AtomicFloat64MinMaxEXT:                  return "AtomicFloat64MinMaxEXT";
 
-    case (int)Capability::WorkgroupMemoryExplicitLayoutKHR:            return "CapabilityWorkgroupMemoryExplicitLayoutKHR";
-    case (int)Capability::WorkgroupMemoryExplicitLayout8BitAccessKHR:  return "CapabilityWorkgroupMemoryExplicitLayout8BitAccessKHR";
-    case (int)Capability::WorkgroupMemoryExplicitLayout16BitAccessKHR: return "CapabilityWorkgroupMemoryExplicitLayout16BitAccessKHR";
+    case (int)Capability::WorkgroupMemoryExplicitLayoutKHR:            return "WorkgroupMemoryExplicitLayoutKHR";
+    case (int)Capability::WorkgroupMemoryExplicitLayout8BitAccessKHR:  return "WorkgroupMemoryExplicitLayout8BitAccessKHR";
+    case (int)Capability::WorkgroupMemoryExplicitLayout16BitAccessKHR: return "WorkgroupMemoryExplicitLayout16BitAccessKHR";
     case (int)Capability::CoreBuiltinsARM:                             return "CoreBuiltinsARM";
 
     case (int)Capability::ShaderInvocationReorderNV:                return "ShaderInvocationReorderNV";
@@ -1116,7 +1116,7 @@ const char* CapabilityString(int info)
 
     case (int)Capability::CooperativeMatrixConversionQCOM:     return "CooperativeMatrixConversionQCOM";
 
-    case (int)Capability::ReplicatedCompositesEXT:             return "CapabilityReplicatedCompositesEXT";
+    case (int)Capability::ReplicatedCompositesEXT:             return "ReplicatedCompositesEXT";
 
     case (int)Capability::DotProductKHR:                       return "DotProductKHR";
     case (int)Capability::DotProductInputAllKHR:               return "DotProductInputAllKHR";
@@ -1128,12 +1128,12 @@ const char* CapabilityString(int info)
     case (int)Capability::RayTracingSpheresGeometryNV:             return "RayTracingSpheresGeometryNV";
     case (int)Capability::RayTracingLinearSweptSpheresGeometryNV:  return "RayTracingLinearSweptSpheresGeometryNV";
 
-    case (int)Capability::BFloat16TypeKHR:                     return "CapabilityBFloat16TypeKHR";
-    case (int)Capability::BFloat16DotProductKHR:               return "CapabilityBFloat16DotProductKHR";
-    case (int)Capability::BFloat16CooperativeMatrixKHR:        return "CapabilityBFloat16CooperativeMatrixKHR";
+    case (int)Capability::BFloat16TypeKHR:                     return "BFloat16TypeKHR";
+    case (int)Capability::BFloat16DotProductKHR:               return "BFloat16DotProductKHR";
+    case (int)Capability::BFloat16CooperativeMatrixKHR:        return "BFloat16CooperativeMatrixKHR";
 
-    case (int)Capability::Float8EXT:                           return "CapabilityFloat8EXT";
-    case (int)Capability::Float8CooperativeMatrixEXT:          return "CapabilityFloat8CooperativeMatrixEXT";
+    case (int)Capability::Float8EXT:                           return "Float8EXT";
+    case (int)Capability::Float8CooperativeMatrixEXT:          return "Float8CooperativeMatrixEXT";
 
     default: return "Bad";
     }

--- a/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.16BitAccess.comp.out
+++ b/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.16BitAccess.comp.out
@@ -6,8 +6,8 @@ spv.WorkgroupMemoryExplicitLayout.16BitAccess.comp
                               Capability Shader
                               Capability Float16
                               Capability Int16
-                              Capability CapabilityWorkgroupMemoryExplicitLayoutKHR
-                              Capability CapabilityWorkgroupMemoryExplicitLayout16BitAccessKHR
+                              Capability WorkgroupMemoryExplicitLayoutKHR
+                              Capability WorkgroupMemoryExplicitLayout16BitAccessKHR
                               Extension  "SPV_KHR_workgroup_memory_explicit_layout"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.8BitAccess.comp.out
+++ b/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.8BitAccess.comp.out
@@ -5,8 +5,8 @@ spv.WorkgroupMemoryExplicitLayout.8BitAccess.comp
 
                               Capability Shader
                               Capability Int8
-                              Capability CapabilityWorkgroupMemoryExplicitLayoutKHR
-                              Capability CapabilityWorkgroupMemoryExplicitLayout8BitAccessKHR
+                              Capability WorkgroupMemoryExplicitLayoutKHR
+                              Capability WorkgroupMemoryExplicitLayout8BitAccessKHR
                               Extension  "SPV_KHR_workgroup_memory_explicit_layout"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.MultiBlock.comp.out
+++ b/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.MultiBlock.comp.out
@@ -4,7 +4,7 @@ spv.WorkgroupMemoryExplicitLayout.MultiBlock.comp
 // Id's are bound by 24
 
                               Capability Shader
-                              Capability CapabilityWorkgroupMemoryExplicitLayoutKHR
+                              Capability WorkgroupMemoryExplicitLayoutKHR
                               Extension  "SPV_KHR_workgroup_memory_explicit_layout"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.SingleBlock.comp.out
+++ b/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.SingleBlock.comp.out
@@ -4,7 +4,7 @@ spv.WorkgroupMemoryExplicitLayout.SingleBlock.comp
 // Id's are bound by 19
 
                               Capability Shader
-                              Capability CapabilityWorkgroupMemoryExplicitLayoutKHR
+                              Capability WorkgroupMemoryExplicitLayoutKHR
                               Extension  "SPV_KHR_workgroup_memory_explicit_layout"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.scalar.comp.out
+++ b/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.scalar.comp.out
@@ -4,7 +4,7 @@ spv.WorkgroupMemoryExplicitLayout.scalar.comp
 // Id's are bound by 29
 
                               Capability Shader
-                              Capability CapabilityWorkgroupMemoryExplicitLayoutKHR
+                              Capability WorkgroupMemoryExplicitLayoutKHR
                               Extension  "SPV_KHR_workgroup_memory_explicit_layout"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.std140.comp.out
+++ b/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.std140.comp.out
@@ -4,7 +4,7 @@ spv.WorkgroupMemoryExplicitLayout.std140.comp
 // Id's are bound by 29
 
                               Capability Shader
-                              Capability CapabilityWorkgroupMemoryExplicitLayoutKHR
+                              Capability WorkgroupMemoryExplicitLayoutKHR
                               Extension  "SPV_KHR_workgroup_memory_explicit_layout"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.std430.comp.out
+++ b/Test/baseResults/spv.WorkgroupMemoryExplicitLayout.std430.comp.out
@@ -4,7 +4,7 @@ spv.WorkgroupMemoryExplicitLayout.std430.comp
 // Id's are bound by 29
 
                               Capability Shader
-                              Capability CapabilityWorkgroupMemoryExplicitLayoutKHR
+                              Capability WorkgroupMemoryExplicitLayoutKHR
                               Extension  "SPV_KHR_workgroup_memory_explicit_layout"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.bfloat16.comp.out
+++ b/Test/baseResults/spv.bfloat16.comp.out
@@ -9,9 +9,9 @@ spv.bfloat16.comp
                               Capability Int64
                               Capability Int16
                               Capability Int8
-                              Capability CapabilityBFloat16TypeKHR
-                              Capability CapabilityBFloat16DotProductKHR
-                              Capability CapabilityBFloat16CooperativeMatrixKHR
+                              Capability BFloat16TypeKHR
+                              Capability BFloat16DotProductKHR
+                              Capability BFloat16CooperativeMatrixKHR
                               Capability VulkanMemoryModelKHR
                               Capability CooperativeMatrixKHR
                               Extension  "SPV_KHR_bfloat16"

--- a/Test/baseResults/spv.coopvec.comp.out
+++ b/Test/baseResults/spv.coopvec.comp.out
@@ -10,7 +10,7 @@ spv.coopvec.comp
                               Capability StorageBuffer8BitAccess
                               Capability VulkanMemoryModelKHR
                               Capability CooperativeVectorNV
-                              Capability CapabilityReplicatedCompositesEXT
+                              Capability ReplicatedCompositesEXT
                               Extension  "SPV_EXT_replicated_composites"
                               Extension  "SPV_KHR_8bit_storage"
                               Extension  "SPV_KHR_vulkan_memory_model"

--- a/Test/baseResults/spv.coopvec2.comp.out
+++ b/Test/baseResults/spv.coopvec2.comp.out
@@ -8,7 +8,7 @@ spv.coopvec2.comp
                               Capability Int8
                               Capability VulkanMemoryModelKHR
                               Capability CooperativeVectorNV
-                              Capability CapabilityReplicatedCompositesEXT
+                              Capability ReplicatedCompositesEXT
                               Extension  "SPV_EXT_replicated_composites"
                               Extension  "SPV_KHR_vulkan_memory_model"
                               Extension  "SPV_NV_cooperative_vector"

--- a/Test/baseResults/spv.floate4m3.comp.out
+++ b/Test/baseResults/spv.floate4m3.comp.out
@@ -9,8 +9,8 @@ spv.floate4m3.comp
                               Capability Int64
                               Capability Int16
                               Capability Int8
-                              Capability CapabilityFloat8EXT
-                              Capability CapabilityFloat8CooperativeMatrixEXT
+                              Capability Float8EXT
+                              Capability Float8CooperativeMatrixEXT
                               Capability VulkanMemoryModelKHR
                               Capability CooperativeMatrixConversionsNV
                               Capability CooperativeMatrixKHR

--- a/Test/baseResults/spv.floate4m3.const.comp.out
+++ b/Test/baseResults/spv.floate4m3.const.comp.out
@@ -5,7 +5,7 @@ spv.floate4m3.const.comp
 
                               Capability Shader
                               Capability Int8
-                              Capability CapabilityFloat8EXT
+                              Capability Float8EXT
                               Extension  "SPV_EXT_float8"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.floate5m2.comp.out
+++ b/Test/baseResults/spv.floate5m2.comp.out
@@ -9,8 +9,8 @@ spv.floate5m2.comp
                               Capability Int64
                               Capability Int16
                               Capability Int8
-                              Capability CapabilityFloat8EXT
-                              Capability CapabilityFloat8CooperativeMatrixEXT
+                              Capability Float8EXT
+                              Capability Float8CooperativeMatrixEXT
                               Capability VulkanMemoryModelKHR
                               Capability CooperativeMatrixConversionsNV
                               Capability CooperativeMatrixKHR

--- a/Test/baseResults/spv.floate5m2.const.comp.out
+++ b/Test/baseResults/spv.floate5m2.const.comp.out
@@ -5,7 +5,7 @@ spv.floate5m2.const.comp
 
                               Capability Shader
                               Capability Int8
-                              Capability CapabilityFloat8EXT
+                              Capability Float8EXT
                               Extension  "SPV_EXT_float8"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.fsi.frag.out
+++ b/Test/baseResults/spv.fsi.frag.out
@@ -4,7 +4,7 @@ spv.fsi.frag
 // Id's are bound by 24
 
                               Capability Shader
-                              Capability CapabilityFragmentShaderSampleInterlockEXT
+                              Capability FragmentShaderSampleInterlockEXT
                               Extension  "SPV_EXT_fragment_shader_interlock"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.nv.dmm-allops.rahit.out
+++ b/Test/baseResults/spv.nv.dmm-allops.rahit.out
@@ -4,7 +4,7 @@ spv.nv.dmm-allops.rahit
 // Id's are bound by 77
 
                               Capability RayTracingKHR
-                              Capability CapabilityRayTracingDisplacementMicromapNV
+                              Capability RayTracingDisplacementMicromapNV
                               Extension  "SPV_KHR_ray_tracing"
                               Extension  "SPV_NV_displacement_micromap"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.nv.dmm-allops.rchit.out
+++ b/Test/baseResults/spv.nv.dmm-allops.rchit.out
@@ -4,7 +4,7 @@ spv.nv.dmm-allops.rchit
 // Id's are bound by 77
 
                               Capability RayTracingKHR
-                              Capability CapabilityRayTracingDisplacementMicromapNV
+                              Capability RayTracingDisplacementMicromapNV
                               Extension  "SPV_KHR_ray_tracing"
                               Extension  "SPV_NV_displacement_micromap"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.nv.dmm-allops.rgen.out
+++ b/Test/baseResults/spv.nv.dmm-allops.rgen.out
@@ -5,7 +5,7 @@ spv.nv.dmm-allops.rgen
 
                               Capability RayTracingKHR
                               Capability DisplacementMicromapNV
-                              Capability CapabilityRayTracingDisplacementMicromapNV
+                              Capability RayTracingDisplacementMicromapNV
                               Extension  "SPV_KHR_ray_tracing"
                               Extension  "SPV_NV_displacement_micromap"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.replicate.comp.out
+++ b/Test/baseResults/spv.replicate.comp.out
@@ -6,7 +6,7 @@ spv.replicate.comp
                               Capability Shader
                               Capability VulkanMemoryModelKHR
                               Capability CooperativeMatrixKHR
-                              Capability CapabilityReplicatedCompositesEXT
+                              Capability ReplicatedCompositesEXT
                               Extension  "SPV_EXT_replicated_composites"
                               Extension  "SPV_KHR_cooperative_matrix"
                               Extension  "SPV_KHR_vulkan_memory_model"

--- a/Test/baseResults/spv.replicatespec.comp.out
+++ b/Test/baseResults/spv.replicatespec.comp.out
@@ -6,7 +6,7 @@ spv.replicatespec.comp
                               Capability Shader
                               Capability VulkanMemoryModelKHR
                               Capability CooperativeMatrixKHR
-                              Capability CapabilityReplicatedCompositesEXT
+                              Capability ReplicatedCompositesEXT
                               Extension  "SPV_EXT_replicated_composites"
                               Extension  "SPV_KHR_cooperative_matrix"
                               Extension  "SPV_KHR_vulkan_memory_model"

--- a/Test/baseResults/spv.subgroupExtendedTypesRotate.comp.out
+++ b/Test/baseResults/spv.subgroupExtendedTypesRotate.comp.out
@@ -10,7 +10,7 @@ spv.subgroupExtendedTypesRotate.comp
                               Capability Int8
                               Capability StorageUniformBufferBlock16
                               Capability StorageBuffer8BitAccess
-                              Capability CapabilityGroupNonUniformRotateKHR
+                              Capability GroupNonUniformRotateKHR
                               Extension  "SPV_KHR_8bit_storage"
                               Extension  "SPV_KHR_subgroup_rotate"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.subgroupRotate.comp.out
+++ b/Test/baseResults/spv.subgroupRotate.comp.out
@@ -5,7 +5,7 @@ spv.subgroupRotate.comp
 
                               Capability Shader
                               Capability Float64
-                              Capability CapabilityGroupNonUniformRotateKHR
+                              Capability GroupNonUniformRotateKHR
                               Extension  "SPV_KHR_subgroup_rotate"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450


### PR DESCRIPTION
This fixes #4018

Capability names do not include the "Capability" prefix, but some capabilities where being labeled with it. This PR addresses the inconsistency.

Tests adjusted to match the new labels.