### PR TITLE
Fix flat interpolation check on fs inputs qualified with perPrimitiveNV

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -4934,7 +4934,7 @@ void TParseContext::globalQualifierTypeCheck(const TSourceLoc& loc, const TQuali
         profileRequires(loc, ~EEsProfile, 130, nullptr, "non-float shader input/output");
     }
 
-    if (!qualifier.flat && !qualifier.isExplicitInterpolation() && !qualifier.isPervertexNV() && !qualifier.isPervertexEXT()) {
+    if (!qualifier.flat && !qualifier.isExplicitInterpolation() && !qualifier.isPervertexNV() && !qualifier.isPervertexEXT() && !qualifier.isPerPrimitive()) {
         if (isTypeInt(publicType.basicType) ||
             publicType.basicType == EbtDouble ||
             (publicType.userDef && (   publicType.userDef->containsBasicType(EbtInt)


### PR DESCRIPTION
Spec allows any interpolation qualifier on fragment shader inputs qualified with "perprimitiveNV".
https://github.com/KhronosGroup/GLSL/blob/d368fe808d7e11476945901120510edbe490f961/extensions/nv/GLSL_NV_mesh_shader.txt#L1119