### PR TITLE
Fix a Wstrict-prototypes warning.

### DIFF
--- a/glslang/Public/resource_limits_c.h
+++ b/glslang/Public/resource_limits_c.h
@@ -46,7 +46,7 @@ GLSLANG_EXPORT const glslang_resource_t* glslang_default_resource(void);
 
 // Returns the DefaultTBuiltInResource as a human-readable string.
 // NOTE: User is responsible for freeing this string.
-GLSLANG_EXPORT const char* glslang_default_resource_string();
+GLSLANG_EXPORT const char* glslang_default_resource_string(void);
 
 // Decodes the resource limits from |config| to |resources|.
 GLSLANG_EXPORT void glslang_decode_resource_limits(glslang_resource_t* resources, char* config);

--- a/glslang/ResourceLimits/resource_limits_c.cpp
+++ b/glslang/ResourceLimits/resource_limits_c.cpp
@@ -42,7 +42,7 @@ const glslang_resource_t* glslang_default_resource(void)
     return reinterpret_cast<const glslang_resource_t*>(GetDefaultResources());
 }
 
-const char* glslang_default_resource_string()
+const char* glslang_default_resource_string(void)
 {
     std::string cpp_str = GetDefaultTBuiltInResourceString();
     char* c_str = (char*)malloc(cpp_str.length() + 1);


### PR DESCRIPTION
This adds an explicit `void` to `glslang_default_resource_string()` which is consistent with other functions in the same file and eliminates a `Wstrict-prototypes` warning.