### PR TITLE
Fix C4146 unary minus operator applied to unsigned type

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -1418,7 +1418,7 @@ Id Builder::createDebugLocalVariable(Id type, char const*const name, size_t cons
     inst->addIdOperand(currentDebugScopeId.top()); // scope id
     inst->addIdOperand(makeUintConstant(NonSemanticShaderDebugInfo100FlagIsLocal)); // flags id
     if(argNumber != 0) {
-        inst->addIdOperand(makeUintConstant(argNumber));
+        inst->addIdOperand(makeUintConstant(static_cast<unsigned int>(argNumber)));
     }
 
     constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(inst));

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -8642,7 +8642,7 @@ static void ForEachOpaque(const TType& type, const TString& path, Function callb
                 for (size_t dimIndex = 0; dimIndex < indices.size(); ++dimIndex)
                 {
                     ++indices[dimIndex];
-                    if (indices[dimIndex] < type.getArraySizes()->getDimSize(dimIndex))
+                    if (indices[dimIndex] < type.getArraySizes()->getDimSize(static_cast<int>(dimIndex)))
                         break;
                     else
                         indices[dimIndex] = 0;


### PR DESCRIPTION
When compiled with `/sdl` flag on MSVC, [C4146 - unary minus operator applied to unsigned type, result still unsigned](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?view=msvc-170) is promoted to an compiler error.
```
C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\src\glslang\MachineIndependent\ParseHelper.cpp(1865,30): error C4146: unary minus operator applied to unsigned type, result still unsigned [C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\build\src\glslang\glslang.vcxproj]
C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\src\glslang\MachineIndependent\ParseHelper.cpp(1866,31): error C4146: unary minus operator applied to unsigned type, result still unsigned [C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\build\src\glslang\glslang.vcxproj]
C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\src\glslang\MachineIndependent\ParseHelper.cpp(1866,53): error C4146: unary minus operator applied to unsigned type, result still unsigned [C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\build\src\glslang\glslang.vcxproj]
C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\src\glslang\MachineIndependent\ParseHelper.cpp(1949,30): error C4146: unary minus operator applied to unsigned type, result still unsigned [C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\build\src\glslang\glslang.vcxproj]
C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\src\glslang\MachineIndependent\ParseHelper.cpp(2011,24): error C4146: unary minus operator applied to unsigned type, result still unsigned [C:\Users\runneradmin\.conan2\p\b\glslab3c2c15dbce12\b\build\src\glslang\glslang.vcxproj]
```
PR fixes occurences of this warning/error and silences two narrowing warnings.