### PR TITLE
Add semantic check for cooperative vector loads/stores.

### DIFF
--- a/Test/baseResults/spv.coopvecStoreLocal.comp.out
+++ b/Test/baseResults/spv.coopvecStoreLocal.comp.out
@@ -1,0 +1,6 @@
+spv.coopvecStoreLocal.comp
+ERROR: 0:18: 'coopVecStoreNV' : buffer argument must be in buffer or shared storage 
+ERROR: 1 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/baseResults/spv.coopvecloadstore_Error.comp.out
+++ b/Test/baseResults/spv.coopvecloadstore_Error.comp.out
@@ -1,0 +1,7 @@
+spv.coopvecloadstore_Error.comp
+ERROR: 0:20: 'coopVecStoreNV' : buffer argument must be in buffer or shared storage 
+ERROR: 0:25: 'coopVecLoadNV' : buffer argument must be in buffer or shared storage 
+ERROR: 2 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.coopvecStoreLocal.comp
+++ b/Test/spv.coopvecStoreLocal.comp
@@ -1,0 +1,20 @@
+#version 450 core
+#extension GL_NV_gpu_shader5 : require
+#extension GL_NV_cooperative_vector : require
+
+layout(local_size_x = 8, local_size_y = 8) in;
+layout(binding = 0, rgba8) uniform image2D image;
+
+layout(std430, binding = 1) buffer MatrixBuffer
+{
+    float matrix[];
+};
+
+void main()
+{
+    float vecOut[4];
+    coopvecNV<float, 4> coopVecOut;
+
+    coopVecStoreNV(coopVecOut, vecOut, 0);
+}
+

--- a/Test/spv.coopvecloadstore_Error.comp
+++ b/Test/spv.coopvecloadstore_Error.comp
@@ -1,0 +1,40 @@
+#version 450 core
+#extension GL_NV_gpu_shader5 : require
+#extension GL_NV_cooperative_vector : require
+
+layout(local_size_x = 8, local_size_y = 8) in;
+layout(binding = 0, rgba8) uniform image2D image;
+
+layout(std430, binding = 1) buffer MatrixBuffer
+{
+    float matrix[];
+};
+
+shared float sharedArray[16];
+
+void main()
+{
+    // Test error: storing to local variable (should fail)
+    float vecOut[4];
+    coopvecNV<float, 4> coopVecOut;
+    coopVecStoreNV(coopVecOut, vecOut, 0);  // ERROR: vecOut is local
+
+    // Test error: loading from local variable (should fail)
+    float vecIn[4];
+    coopvecNV<float, 4> coopVecIn;
+    coopVecLoadNV(coopVecIn, vecIn, 0);     // ERROR: vecIn is local
+
+    // These should work correctly:
+    // Store to buffer storage
+    coopVecStoreNV(coopVecOut, matrix, 0);
+
+    // Load from buffer storage
+    coopVecLoadNV(coopVecIn, matrix, 0);
+
+    // Store to shared storage
+    coopVecStoreNV(coopVecOut, sharedArray, 0);
+
+    // Load from shared storage
+    coopVecLoadNV(coopVecIn, sharedArray, 0);
+}
+

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1484,6 +1484,17 @@ TIntermTyped* TParseContext::handleFunctionCall(const TSourceLoc& loc, TFunction
                         i == 1 && arg->getAsTyped()->getType().getBasicType() != aggregate->getSequence()[0]->getAsTyped()->getType().getBasicType())
                         error(arguments->getLoc(), "cooperative vector basic types must match", fnCandidate->getName().c_str(), "");
 
+                    // Check that coopVecLoadNV and coopVecStoreNV buffer parameter is in buffer or shared storage
+                    if (builtIn && (fnCandidate->getBuiltInOp() == EOpCooperativeVectorLoadNV ||
+                                    fnCandidate->getBuiltInOp() == EOpCooperativeVectorStoreNV) &&
+                        i == 1) {
+                        TStorageQualifier storage = arg->getAsTyped()->getType().getQualifier().storage;
+                        if (storage != EvqBuffer && storage != EvqShared) {
+                            error(arguments->getLoc(), "buffer argument must be in buffer or shared storage", 
+                                  fnCandidate->getName().c_str(), "");
+                        }
+                    }
+
                     // TODO 4.5 functionality:  A shader will fail to compile
                     // if the value passed to the memargument of an atomic memory function does not correspond to a buffer or
                     // shared variable. It is acceptable to pass an element of an array or a single component of a vector to the

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -693,6 +693,8 @@ INSTANTIATE_TEST_SUITE_P(
         "spv.coopvec2.comp",
         "spv.coopvecloadstore.comp",
         "spv.coopvec_Error.comp",
+        "spv.coopvecloadstore_Error.comp",
+        "spv.coopvecStoreLocal.comp",
         "spv.coopvecTraining.comp",
         "spv.coopvecTraining_Error.comp",
         "spv.intcoopmat.comp",


### PR DESCRIPTION
For cooperative vector loads and stores, the buffer arrays cannot be local variables. The compiler was not validating this and when it went to generate debug information, it would hit an assertion because the ID could not be retrieved.

This adds a semantic check that fails compilation when the array is neither in buffer nor shared storage.