### PR TITLE
Update CI MacOS runner

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -156,17 +156,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-13]
+        os: [macos-latest]
         compiler: [{cc: clang, cxx: clang++}]
         cmake_build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: lukka/get-cmake@bb2faa721a800324b726fec00f7c1ff7641964d1 # v4.2.0
       - run: ./update_glslang_sources.py
-      - run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}} -G Ninja -DBUILD_WERROR=ON -D GLSLANG_TESTS=ON
+      - run: |
+          cmake -S . -B build \
+          -D CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}} \
+          -G Ninja \
+          -D BUILD_WERROR=ON \
+          -D GLSLANG_TESTS=ON \
+          -D "CMAKE_OSX_ARCHITECTURES=arm64;x86_64"
         env:
           CC: ${{matrix.compiler.cc}}
           CXX: ${{matrix.compiler.cxx}}
+          MACOSX_DEPLOYMENT_TARGET: 11.0
       - run: cmake --build build
       - run: cmake --install build --prefix build/install
       - name: Test find_package support
@@ -180,17 +187,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14]
+        os: [macos-latest]
         compiler: [{cc: clang, cxx: clang++}]
         cmake_build_type: [Release]
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: lukka/get-cmake@bb2faa721a800324b726fec00f7c1ff7641964d1 # v4.2.0
       - run: ./update_glslang_sources.py
-      - run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}} -G Ninja -DBUILD_WERROR=ON -D GLSLANG_TESTS=ON -DBUILD_SHARED_LIBS=ON
+      - run: |
+          cmake -S . -B build \
+          -D CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}} \
+          -G Ninja \
+          -D BUILD_WERROR=ON \
+          -D GLSLANG_TESTS=ON \
+          -DBUILD_SHARED_LIBS=ON \
+          -D "CMAKE_OSX_ARCHITECTURES=arm64;x86_64"
         env:
           CC: ${{matrix.compiler.cc}}
           CXX: ${{matrix.compiler.cxx}}
+          MACOSX_DEPLOYMENT_TARGET: 11.0
       - run: cmake --build build
       - run: cmake --install build --prefix build/install
       - name: Test find_package support
@@ -248,7 +263,7 @@ jobs:
         run: ctest -C ${{matrix.cmake_build_type}} --output-on-failure --test-dir build
 
   iOS:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: lukka/get-cmake@bb2faa721a800324b726fec00f7c1ff7641964d1 # v4.2.0


### PR DESCRIPTION
Use latest MacOS
Set deployment target

The continuous deployment script had already been updated with these changes but the continous integration script had not.