### PR TITLE
Print compile/link logs to stderr

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -1506,9 +1506,9 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
         if (! (Options & EOptionSuppressInfolog) &&
             ! (Options & EOptionMemoryLeakMode)) {
             if (!beQuiet)
-                PutsIfNonEmpty(compUnit.fileName[0].c_str());
-            PutsIfNonEmpty(shader->getInfoLog());
-            PutsIfNonEmpty(shader->getInfoDebugLog());
+                StderrIfNonEmpty(compUnit.fileName[0].c_str());
+            StderrIfNonEmpty(shader->getInfoLog());
+            StderrIfNonEmpty(shader->getInfoDebugLog());
         }
     }
 
@@ -1529,8 +1529,8 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
 
         // Report
         if (!(Options & EOptionSuppressInfolog) && !(Options & EOptionMemoryLeakMode)) {
-            PutsIfNonEmpty(program.getInfoLog());
-            PutsIfNonEmpty(program.getInfoDebugLog());
+            StderrIfNonEmpty(program.getInfoLog());
+            StderrIfNonEmpty(program.getInfoDebugLog());
         }
 
         // Reflect

--- a/Test/runtests
+++ b/Test/runtests
@@ -16,7 +16,7 @@ if [ -d "${LIBPATH}" ]; then
 fi
 
 function run {
-    "$EXE" "$@"
+    "$EXE" "$@" 2>&1
     result=$?
     case "$result" in
     [0-6]) # Valid success and error codes


### PR DESCRIPTION
When glslang is integrated into a build system (like Meson), stdout is stored in an output file and stderr is printed to the user. This hides error messages from the user. See: https://github.com/mesonbuild/meson/issues/11506

stderr is the standard stream errors should get printed to, always use that.