### PR TITLE
Fix string conversion warning in assert

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -3069,7 +3069,7 @@ Instruction* Builder::createDescHeapLoadStoreBaseRemap(Id baseId, Op op)
         baseVal = chain->getResultId();
         clearAccessChain();
     } else if (instOp != Op::OpUntypedAccessChainKHR) {
-        assert("Not a untyped load type");
+        assert(false && "Not a untyped load type");
     }
 
     Instruction* inst = nullptr;


### PR DESCRIPTION
The assert wasn't doing what was expected.