### PR TITLE
Raise the maximum limit for specialization constant IDs

### DIFF
--- a/Test/baseResults/vulkan.vert.out
+++ b/Test/baseResults/vulkan.vert.out
@@ -17,7 +17,7 @@ ERROR: 0:13: 'constant_id' : specialization-constant id already used
 ERROR: 0:13: 'binding' : sampler/texture/image requires layout(binding=X) 
 ERROR: 0:13: 'constant_id' : can only be applied to 'const'-qualified scalar 
 ERROR: 0:13: 'constant_id' : cannot be applied to this type 
-ERROR: 0:14: 'constant_id' : specialization-constant id is too large 
+ERROR: 0:14: 'layout-id value' : cannot be negative 
 ERROR: 0:15: 'constant_id' : can only be applied to a scalar 
 ERROR: 0:16: 'constant_id' : specialization-constant id already used 
 ERROR: 0:16: 'constant_id' : cannot declare a default, can only be used on a scalar 

--- a/Test/vulkan.vert
+++ b/Test/vulkan.vert
@@ -11,7 +11,7 @@ out vec4 color;
 
 layout(constant_id = 17) const ivec2 arraySizes = ivec2(12,13);    // ERROR, not a scalar
 layout(constant_id = 17) uniform sampler2D s2D;                    // ERROR, not the right type or qualifier
-layout(constant_id = 4000) const int c1 = 12;                      // ERROR, too big
+layout(constant_id = 4294967295) const int c1 = 12;                      // ERROR, too big
 layout(constant_id = 4) const float c2[2] = float[2](1.0, 2.0);    // ERROR, not a scalar
 layout(constant_id = 4) in;
 

--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -1977,7 +1977,7 @@ void HlslParseContext::transferTypeAttributes(const TSourceLoc& loc, const TAttr
             if (it->getInt(value)) {
                 TSourceLoc loc;
                 loc.init();
-                setSpecConstantId(loc, type.getQualifier(), value);
+                setSpecConstantId(loc, type.getQualifier(), (unsigned)value);
             }
             break;
 
@@ -7363,7 +7363,7 @@ void HlslParseContext::setLayoutQualifier(const TSourceLoc& loc, TQualifier& qua
         return;
     }
     if (id == "constant_id") {
-        setSpecConstantId(loc, qualifier, value);
+        setSpecConstantId(loc, qualifier, (unsigned)value);
         return;
     }
 
@@ -7458,9 +7458,9 @@ void HlslParseContext::setLayoutQualifier(const TSourceLoc& loc, TQualifier& qua
     error(loc, "there is no such layout identifier for this stage taking an assigned value", id.c_str(), "");
 }
 
-void HlslParseContext::setSpecConstantId(const TSourceLoc& loc, TQualifier& qualifier, int value)
+void HlslParseContext::setSpecConstantId(const TSourceLoc& loc, TQualifier& qualifier, unsigned value)
 {
-    if (value >= (int)TQualifier::layoutSpecConstantIdEnd) {
+    if (value >= TQualifier::layoutSpecConstantIdEnd) {
         error(loc, "specialization-constant id is too large", "constant_id", "");
     } else {
         qualifier.layoutSpecConstantId = value;

--- a/glslang/HLSL/hlslParseHelper.h
+++ b/glslang/HLSL/hlslParseHelper.h
@@ -138,7 +138,7 @@ public:
 
     void setLayoutQualifier(const TSourceLoc&, TQualifier&, TString&);
     void setLayoutQualifier(const TSourceLoc&, TQualifier&, TString&, const TIntermTyped*);
-    void setSpecConstantId(const TSourceLoc&, TQualifier&, int value);
+    void setSpecConstantId(const TSourceLoc&, TQualifier&, unsigned value);
     void mergeObjectLayoutQualifiers(TQualifier& dest, const TQualifier& src, bool inheritOnly);
     void checkNoShaderLayouts(const TSourceLoc&, const TShaderQualifiers&);
 

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -47,6 +47,7 @@
 #include "SpirvIntrinsics.h"
 
 #include <algorithm>
+#include <climits>
 
 namespace glslang {
 
@@ -958,8 +959,8 @@ public:
                  unsigned int layoutAttachment           :  8;  // for input_attachment_index
     static const unsigned int layoutAttachmentEnd      = 0XFF;
 
-                 unsigned int layoutSpecConstantId       : 11;
-    static const unsigned int layoutSpecConstantIdEnd = 0x7FF;
+                 unsigned int layoutSpecConstantId;
+    static const unsigned int layoutSpecConstantIdEnd = UINT_MAX;
 
                  unsigned int layoutBank                 : 4;
     static const unsigned int layoutBankEnd            = 0xF;

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -7139,7 +7139,7 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
     }
     if (id == "constant_id") {
         requireSpv(loc, "constant_id");
-        if (value >= (int)TQualifier::layoutSpecConstantIdEnd) {
+        if ((unsigned)value >= TQualifier::layoutSpecConstantIdEnd) {
             error(loc, "specialization-constant id is too large", id.c_str(), "");
         } else {
             publicType.qualifier.layoutSpecConstantId = value;


### PR DESCRIPTION
This was capped at 0x7ff for unclear reasons, now it can be any 32-bit value up to INT_MAX.

Fixes #3852 