### PR TITLE
hlsl: Ensure scope is popped even when method body fails to parse

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -157,6 +157,7 @@ template("glslang_sources_common") {
       "glslang/Include/SpirvIntrinsics.h",
       "glslang/Include/Types.h",
       "glslang/Include/arrays.h",
+      "glslang/Include/defer.h",
       "glslang/Include/intermediate.h",
       "glslang/Include/visibility.h",
       "glslang/MachineIndependent/Constant.cpp",

--- a/Test/baseResults/hlsl.do.nested.error.frag.out
+++ b/Test/baseResults/hlsl.do.nested.error.frag.out
@@ -1,10 +1,9 @@
-hlsl.if.nested.error.frag
-ERROR: 0:3: ')' : Expected 
+hlsl.do.nested.error.frag
 ERROR: 0:3: 'resurn' : unknown variable 
 ERROR: 0:3: ';' : Expected 
-ERROR: 0:3: 'then statement' : Expected 
+ERROR: 0:3: 'do sub-statement' : Expected 
 ERROR: 0:8: '' : function does not return a value: @main
-ERROR: 5 compilation errors.  No code generated.
+ERROR: 4 compilation errors.  No code generated.
 
 
 Shader version: 500

--- a/Test/baseResults/hlsl.for.nested.error.frag.out
+++ b/Test/baseResults/hlsl.for.nested.error.frag.out
@@ -1,10 +1,9 @@
-hlsl.if.nested.error.frag
-ERROR: 0:3: ')' : Expected 
+hlsl.for.nested.error.frag
 ERROR: 0:3: 'resurn' : unknown variable 
 ERROR: 0:3: ';' : Expected 
-ERROR: 0:3: 'then statement' : Expected 
+ERROR: 0:3: 'for sub-statement' : Expected 
 ERROR: 0:8: '' : function does not return a value: @main
-ERROR: 5 compilation errors.  No code generated.
+ERROR: 4 compilation errors.  No code generated.
 
 
 Shader version: 500

--- a/Test/baseResults/hlsl.if.nested.error.frag.out
+++ b/Test/baseResults/hlsl.if.nested.error.frag.out
@@ -1,0 +1,56 @@
+hlsl.if.nested.error.frag
+ERROR: 0:3: ')' : Expected
+ERROR: 0:3: 'resurn' : unknown variable
+ERROR: 0:3: ';' : Expected
+ERROR: 0:3: 'then statement' : Expected
+ERROR: 0:8: '' : function does not return a value: @main
+ERROR: 5 compilation errors.  No code generated.
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:2  Function Definition: S::m( ( temp void)
+0:2    Function Parameters:
+0:2      '@this' ( temp structure{})
+0:?     Sequence
+0:3      Constant:
+0:3        true (const bool)
+0:8  Function Definition: @main( ( temp 4-component vector of float)
+0:8    Function Parameters:
+0:8  Function Definition: main( ( temp void)
+0:8    Function Parameters:
+0:?     Sequence
+0:8      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:8        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:2  Function Definition: S::m( ( temp void)
+0:2    Function Parameters:
+0:2      '@this' ( temp structure{})
+0:?     Sequence
+0:3      Constant:
+0:3        true (const bool)
+0:8  Function Definition: @main( ( temp 4-component vector of float)
+0:8    Function Parameters:
+0:8  Function Definition: main( ( temp void)
+0:8    Function Parameters:
+0:?     Sequence
+0:8      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:8        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+SPIR-V is not generated for failed compile or link\n
+
+

--- a/Test/baseResults/hlsl.nested.name.error.frag.out
+++ b/Test/baseResults/hlsl.nested.name.error.frag.out
@@ -1,0 +1,53 @@
+hlsl.nested.name.error.frag
+ERROR: 0:4: 'resurn' : unknown variable 
+ERROR: 0:4: ';' : Expected 
+ERROR: 0:4: 'm3' : no matching overloaded function found 
+ERROR: 0:9: '' : function does not return a value: @main
+ERROR: 4 compilation errors.  No code generated.
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:3  Function Definition: S::m( ( temp void)
+0:3    Function Parameters: 
+0:3      '@this' ( temp structure{})
+0:?     Sequence
+0:4      Constant:
+0:4        0.000000
+0:9  Function Definition: @main( ( temp 4-component vector of float)
+0:9    Function Parameters: 
+0:9  Function Definition: main( ( temp void)
+0:9    Function Parameters: 
+0:?     Sequence
+0:9      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:9        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:3  Function Definition: S::m( ( temp void)
+0:3    Function Parameters: 
+0:3      '@this' ( temp structure{})
+0:?     Sequence
+0:4      Constant:
+0:4        0.000000
+0:9  Function Definition: @main( ( temp 4-component vector of float)
+0:9    Function Parameters: 
+0:9  Function Definition: main( ( temp void)
+0:9    Function Parameters: 
+0:?     Sequence
+0:9      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:9        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+SPIR-V is not generated for failed compile or link

--- a/Test/baseResults/hlsl.while.nested.error.frag.out
+++ b/Test/baseResults/hlsl.while.nested.error.frag.out
@@ -1,8 +1,8 @@
-hlsl.if.nested.error.frag
+hlsl.while.nested.error.frag
 ERROR: 0:3: ')' : Expected 
 ERROR: 0:3: 'resurn' : unknown variable 
 ERROR: 0:3: ';' : Expected 
-ERROR: 0:3: 'then statement' : Expected 
+ERROR: 0:3: 'while sub-statement' : Expected 
 ERROR: 0:8: '' : function does not return a value: @main
 ERROR: 5 compilation errors.  No code generated.
 

--- a/Test/hlsl.do.nested.error.frag
+++ b/Test/hlsl.do.nested.error.frag
@@ -1,0 +1,9 @@
+struct S {
+    void m() {
+       void m2() { do { resurn true; }(alse); }
+    }
+};
+
+float4 main() : SV_TARGET0
+{
+}

--- a/Test/hlsl.for.nested.error.frag
+++ b/Test/hlsl.for.nested.error.frag
@@ -1,0 +1,9 @@
+struct S {
+    void m() {
+       void m2() { for(;;) { resurn true; } }
+    }
+};
+
+float4 main() : SV_TARGET0
+{
+}

--- a/Test/hlsl.if.nested.error.frag
+++ b/Test/hlsl.if.nested.error.frag
@@ -1,0 +1,9 @@
+struct S {
+    void m() {
+       void m2() { if (true { resurn true; } }
+    }
+};
+
+float4 main() : SV_TARGET0
+{
+}

--- a/Test/hlsl.nested.name.error.frag
+++ b/Test/hlsl.nested.name.error.frag
@@ -1,0 +1,10 @@
+
+struct S {
+    void m() {
+       void m2() { resurn m3(); }
+    }
+};
+
+float4 main() : SV_TARGET0
+{
+}

--- a/Test/hlsl.while.nested.error.frag
+++ b/Test/hlsl.while.nested.error.frag
@@ -1,0 +1,9 @@
+struct S {
+    void m() {
+       void m2() { while (true { resurn true; } }
+    }
+};
+
+float4 main() : SV_TARGET0
+{
+}

--- a/glslang/HLSL/hlslGrammar.cpp
+++ b/glslang/HLSL/hlslGrammar.cpp
@@ -52,6 +52,7 @@
 // in the rule will have been consumed, and none left in 'token'.
 //
 
+#include "../Include/defer.h"
 #include "hlslTokens.h"
 #include "hlslGrammar.h"
 #include "hlslAttributes.h"
@@ -2985,8 +2986,10 @@ bool HlslGrammar::acceptFunctionBody(TFunctionDeclarator& declarator, TIntermNod
 
     // compound_statement
     TIntermNode* functionBody = nullptr;
-    if (! acceptCompoundStatement(functionBody))
+    if (! acceptCompoundStatement(functionBody)) {
+        parseContext.popScope();
         return false;
+    }
 
     // this does a popScope()
     parseContext.handleFunctionBody(declarator.loc, *declarator.function, functionBody, functionNode);
@@ -3935,6 +3938,7 @@ bool HlslGrammar::acceptSelectionStatement(TIntermNode*& statement, const TAttri
     // so that something declared in the condition is scoped to the lifetimes
     // of the then-else statements
     parseContext.pushScope();
+    Defer d([this]{parseContext.popScope();});
 
     // LEFT_PAREN expression RIGHT_PAREN
     TIntermTyped* condition;
@@ -3968,7 +3972,6 @@ bool HlslGrammar::acceptSelectionStatement(TIntermNode*& statement, const TAttri
     statement = intermediate.addSelection(condition, thenElse, loc);
     parseContext.handleSelectionAttributes(loc, statement->getAsSelectionNode(), attributes);
 
-    parseContext.popScope();
     --parseContext.controlFlowNestingLevel;
 
     return true;

--- a/glslang/HLSL/hlslGrammar.cpp
+++ b/glslang/HLSL/hlslGrammar.cpp
@@ -3938,7 +3938,7 @@ bool HlslGrammar::acceptSelectionStatement(TIntermNode*& statement, const TAttri
     // so that something declared in the condition is scoped to the lifetimes
     // of the then-else statements
     parseContext.pushScope();
-    Defer d([this]{parseContext.popScope();});
+    Defer d([this]{ parseContext.popScope(); });
 
     // LEFT_PAREN expression RIGHT_PAREN
     TIntermTyped* condition;
@@ -4033,61 +4033,67 @@ bool HlslGrammar::acceptIterationStatement(TIntermNode*& statement, const TAttri
     TIntermLoop* loopNode = nullptr;
     switch (loop) {
     case EHTokWhile:
-        // so that something declared in the condition is scoped to the lifetime
-        // of the while sub-statement
-        parseContext.pushScope();  // this only needs to work right if no errors
-        parseContext.nestLooping();
-        ++parseContext.controlFlowNestingLevel;
+        {
+            // so that something declared in the condition is scoped to the lifetime
+            // of the while sub-statement
+            parseContext.pushScope();
+            parseContext.nestLooping();
+            ++parseContext.controlFlowNestingLevel;
+            Defer d([this]{
+                parseContext.unnestLooping();
+                parseContext.popScope();
+                --parseContext.controlFlowNestingLevel;
+            });
 
-        // LEFT_PAREN condition RIGHT_PAREN
-        if (! acceptParenExpression(condition))
-            return false;
-        condition = parseContext.convertConditionalExpression(loc, condition);
-        if (condition == nullptr)
-            return false;
+            // LEFT_PAREN condition RIGHT_PAREN
+            if (! acceptParenExpression(condition))
+                return false;
+            condition = parseContext.convertConditionalExpression(loc, condition);
+            if (condition == nullptr)
+                return false;
 
-        // statement
-        if (! acceptScopedStatement(statement)) {
-            expected("while sub-statement");
-            return false;
+            // statement
+            if (! acceptScopedStatement(statement)) {
+                expected("while sub-statement");
+                return false;
+            }
         }
-
-        parseContext.unnestLooping();
-        parseContext.popScope();
-        --parseContext.controlFlowNestingLevel;
 
         loopNode = intermediate.addLoop(statement, condition, nullptr, true, loc);
         statement = loopNode;
         break;
 
     case EHTokDo:
-        parseContext.nestLooping();  // this only needs to work right if no errors
-        ++parseContext.controlFlowNestingLevel;
+        {
+            parseContext.nestLooping();  // this only needs to work right if no errors
+            ++parseContext.controlFlowNestingLevel;
+            Defer d([this]{
+              parseContext.unnestLooping();
+              --parseContext.controlFlowNestingLevel;
+            });
 
-        // statement
-        if (! acceptScopedStatement(statement)) {
-            expected("do sub-statement");
-            return false;
+            // statement
+            if (! acceptScopedStatement(statement)) {
+                expected("do sub-statement");
+                return false;
+            }
+
+            // WHILE
+            if (! acceptTokenClass(EHTokWhile)) {
+                expected("while");
+                return false;
+            }
+
+            // LEFT_PAREN condition RIGHT_PAREN
+            if (! acceptParenExpression(condition))
+                return false;
+            condition = parseContext.convertConditionalExpression(loc, condition);
+            if (condition == nullptr)
+                return false;
+
+            if (! acceptTokenClass(EHTokSemicolon))
+                expected(";");
         }
-
-        // WHILE
-        if (! acceptTokenClass(EHTokWhile)) {
-            expected("while");
-            return false;
-        }
-
-        // LEFT_PAREN condition RIGHT_PAREN
-        if (! acceptParenExpression(condition))
-            return false;
-        condition = parseContext.convertConditionalExpression(loc, condition);
-        if (condition == nullptr)
-            return false;
-
-        if (! acceptTokenClass(EHTokSemicolon))
-            expected(";");
-
-        parseContext.unnestLooping();
-        --parseContext.controlFlowNestingLevel;
 
         loopNode = intermediate.addLoop(statement, condition, nullptr, false, loc);
         statement = loopNode;
@@ -4102,6 +4108,7 @@ bool HlslGrammar::acceptIterationStatement(TIntermNode*& statement, const TAttri
         // so that something declared in the condition is scoped to the lifetime
         // of the for sub-statement
         parseContext.pushScope();
+        Defer d([this]{ parseContext.popScope(); });
 
         // initializer
         TIntermNode* initNode = nullptr;
@@ -4110,6 +4117,10 @@ bool HlslGrammar::acceptIterationStatement(TIntermNode*& statement, const TAttri
 
         parseContext.nestLooping();  // this only needs to work right if no errors
         ++parseContext.controlFlowNestingLevel;
+        Defer d2([this]{
+            parseContext.unnestLooping();
+            --parseContext.controlFlowNestingLevel;
+        });
 
         // condition SEMI_COLON
         acceptExpression(condition);
@@ -4134,10 +4145,6 @@ bool HlslGrammar::acceptIterationStatement(TIntermNode*& statement, const TAttri
         }
 
         statement = intermediate.addForLoop(statement, initNode, condition, iterator, true, loc, loopNode);
-
-        parseContext.popScope();
-        parseContext.unnestLooping();
-        --parseContext.controlFlowNestingLevel;
 
         break;
     }

--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -5566,6 +5566,7 @@ TIntermTyped* HlslParseContext::handleFunctionCall(const TSourceLoc& loc, TFunct
                 callerName = fnCandidate->getMangledName();
             else {
                 // get the explicit (full) name of the function
+                assert(currentTypePrefix.size() >= size_t(thisDepth));
                 callerName = currentTypePrefix[currentTypePrefix.size() - thisDepth];
                 callerName += fnCandidate->getMangledName();
                 // insert the implicit calling argument

--- a/glslang/Include/defer.h
+++ b/glslang/Include/defer.h
@@ -1,0 +1,59 @@
+//
+// Copyright 2026 Google LLC
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of 3Dlabs Inc. Ltd. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef GLSLANG_INCLUDE_DEFER_H
+#define GLSLANG_INCLUDE_DEFER_H
+
+#include <utility>
+
+namespace glslang {
+
+// An object that, when destroyed, executes a given function.
+// Use this to perform work along all exit paths from a function.
+template <typename F>
+class Defer {
+ public:
+  explicit Defer(F&& f) : f_(std::move(f)) { }
+  Defer(Defer&&) = default;
+  ~Defer() { f_(); } // Run the given function.
+ private:
+  Defer(const Defer&) = delete;
+  Defer& operator=(const Defer&) = delete;
+  F f_;
+};
+
+} // namespace glslang
+
+#endif

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -325,6 +325,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.multiReturn.frag", "main"},
         {"hlsl.multiView.frag", "main"},
         {"hlsl.matrixindex.frag", "main"},
+        {"hlsl.nested.name.error.frag", "main"},
         {"hlsl.nonstaticMemberFunction.frag", "main"},
         {"hlsl.numericsuffixes.frag", "main"},
         {"hlsl.numericsuffixes.negative.frag", "main"},

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -264,6 +264,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.groupid.comp", "main"},
         {"hlsl.identifier.sample.frag", "main"},
         {"hlsl.if.frag", "PixelShaderFunction"},
+        {"hlsl.if.nested.error.frag", "main"},
         {"hlsl.imageload-subvec4.comp", "main"},
         {"hlsl.imagefetch-subvec4.comp", "main"},
         {"hlsl.implicitBool.frag", "main"},

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -247,6 +247,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.getsampleposition.dx10.frag", "main"},
         {"hlsl.global-const-init.frag", "main"},
         {"hlsl.gs-hs-mix.tesc", "HSMain"},
+        {"hlsl.do.nested.error.frag", "main"},
         {"hlsl.domain.1.tese", "main"},
         {"hlsl.domain.2.tese", "main"},
         {"hlsl.domain.3.tese", "main"},
@@ -260,6 +261,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.hull.void.tesc", "main"},
         {"hlsl.hull.ctrlpt-1.tesc", "main"},
         {"hlsl.hull.ctrlpt-2.tesc", "main"},
+        {"hlsl.for.nested.error.frag", "main"},
         {"hlsl.format.rwtexture.frag", "main"},
         {"hlsl.groupid.comp", "main"},
         {"hlsl.identifier.sample.frag", "main"},
@@ -465,7 +467,8 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.whileLoop.frag", "PixelShaderFunction"},
         {"hlsl.void.frag", "PixelShaderFunction"},
         {"hlsl.type.type.conversion.all.frag", "main"},
-        {"hlsl.instance.geom", "GeometryShader"}
+        {"hlsl.instance.geom", "GeometryShader"},
+        {"hlsl.while.nested.error.frag", "main"},
     }),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
Scopes are created and destroyed in the process of parsing HLSL method bodies (and function bodies in general).
On some error paths, the scope was not being popped.  This caused a crash later on.

Update the function body parsing so that scopes are popped even if function body parsing fails.

Bug: crbug.com/481635421
