### PR TITLE
Avoid useless copies in SpirvIntrinsics.cpp

### DIFF
--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -46,7 +46,7 @@ namespace {
 
 using namespace glslang;
 
-const double pi = 3.1415926535897932384626433832795;
+constexpr double pi = 3.1415926535897932384626433832795;
 
 } // end anonymous namespace
 

--- a/glslang/MachineIndependent/SpirvIntrinsics.cpp
+++ b/glslang/MachineIndependent/SpirvIntrinsics.cpp
@@ -63,13 +63,13 @@ TSpirvRequirement* TParseContext::makeSpirvRequirement(const TSourceLoc& loc, co
 
     if (name == "extensions") {
         assert(extensions);
-        for (auto extension : extensions->getSequence()) {
+        for (const auto& extension : extensions->getSequence()) {
             assert(extension->getAsConstantUnion());
             spirvReq->extensions.insert(*extension->getAsConstantUnion()->getConstArray()[0].getSConst());
         }
     } else if (name == "capabilities") {
         assert(capabilities);
-        for (auto capability : capabilities->getSequence()) {
+        for (const auto& capability : capabilities->getSequence()) {
             assert(capability->getAsConstantUnion());
             spirvReq->capabilities.insert(capability->getAsConstantUnion()->getConstArray()[0].getIConst());
         }
@@ -105,10 +105,10 @@ void TIntermediate::insertSpirvRequirement(const TSpirvRequirement* spirvReq)
     if (!spirvRequirement)
         spirvRequirement = new TSpirvRequirement;
 
-    for (auto extension : spirvReq->extensions)
+    for (const auto& extension : spirvReq->extensions)
         spirvRequirement->extensions.insert(extension);
 
-    for (auto capability : spirvReq->capabilities)
+    for (const auto& capability : spirvReq->capabilities)
         spirvRequirement->capabilities.insert(capability);
 }
 
@@ -122,7 +122,7 @@ void TIntermediate::insertSpirvExecutionMode(int executionMode, const TIntermAgg
 
     TVector<const TIntermConstantUnion*> extraOperands;
     if (args) {
-        for (auto arg : args->getSequence()) {
+        for (const auto& arg : args->getSequence()) {
             auto extraOperand = arg->getAsConstantUnion();
             assert(extraOperand != nullptr);
             extraOperands.push_back(extraOperand);
@@ -139,7 +139,7 @@ void TIntermediate::insertSpirvExecutionModeId(int executionMode, const TIntermA
     assert(args);
     TVector<const TIntermTyped*> extraOperands;
 
-    for (auto arg : args->getSequence()) {
+    for (const auto& arg : args->getSequence()) {
         auto extraOperand = arg->getAsTyped();
         assert(extraOperand != nullptr && extraOperand->getQualifier().isConstant());
         extraOperands.push_back(extraOperand);
@@ -157,7 +157,7 @@ void TQualifier::setSpirvDecorate(int decoration, const TIntermAggregate* args)
 
     TVector<const TIntermConstantUnion*> extraOperands;
     if (args) {
-        for (auto arg : args->getSequence()) {
+        for (const auto& arg : args->getSequence()) {
             auto extraOperand = arg->getAsConstantUnion();
             assert(extraOperand != nullptr);
             extraOperands.push_back(extraOperand);
@@ -173,7 +173,7 @@ void TQualifier::setSpirvDecorateId(int decoration, const TIntermAggregate* args
 
     assert(args);
     TVector<const TIntermTyped*> extraOperands;
-    for (auto arg : args->getSequence()) {
+    for (const auto& arg : args->getSequence()) {
         auto extraOperand = arg->getAsTyped();
         assert(extraOperand != nullptr);
         extraOperands.push_back(extraOperand);
@@ -188,7 +188,7 @@ void TQualifier::setSpirvDecorateString(int decoration, const TIntermAggregate* 
 
     assert(args);
     TVector<const TIntermConstantUnion*> extraOperands;
-    for (auto arg : args->getSequence()) {
+    for (const auto& arg : args->getSequence()) {
         auto extraOperand = arg->getAsConstantUnion();
         assert(extraOperand != nullptr);
         extraOperands.push_back(extraOperand);
@@ -234,30 +234,30 @@ TString TQualifier::getSpirvDecorateQualifierString() const
         }
     };
 
-    for (auto& decorate : spirvDecorate->decorates) {
+    for (const auto& decorate : spirvDecorate->decorates) {
         appendStr("spirv_decorate(");
         appendInt(decorate.first);
-        for (auto extraOperand : decorate.second) {
+        for (const auto& extraOperand : decorate.second) {
             appendStr(", ");
             appendDecorate(extraOperand);
         }
         appendStr(") ");
     }
 
-    for (auto& decorateId : spirvDecorate->decorateIds) {
+    for (const auto& decorateId : spirvDecorate->decorateIds) {
         appendStr("spirv_decorate_id(");
         appendInt(decorateId.first);
-        for (auto extraOperand : decorateId.second) {
+        for (const auto& extraOperand : decorateId.second) {
             appendStr(", ");
             appendDecorate(extraOperand);
         }
         appendStr(") ");
     }
 
-    for (auto& decorateString : spirvDecorate->decorateStrings) {
+    for (const auto& decorateString : spirvDecorate->decorateStrings) {
         appendStr("spirv_decorate_string(");
         appendInt(decorateString.first);
-        for (auto extraOperand : decorateString.second) {
+        for (const auto& extraOperand : decorateString.second) {
             appendStr(", ");
             appendDecorate(extraOperand);
         }


### PR DESCRIPTION
`SpirvIntrinsics.cpp`: Avoid a lot of useless copies
`Constant.cpp`: Make π constexpr