### PR TITLE
Deprecate the HLSL front-end.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## NEXT
+
+* Deprecate the HLSL front-end. It will be removed at the next major version.
+  See issue #4210 for details.
+
 ## 16.2.0 2026-01-22
 * Allow gl_FragDepth identifier to be redeclared
 * Replace 'GL_TASK(MESH)_SHADER_NV' with 'GL_TASK(MESH)_SHADER_EXT'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,12 @@ cmake_dependent_option(ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE
     OFF)
 
 option(ENABLE_HLSL "Enables HLSL input support" ON)
+if(ENABLE_HLSL)
+    message(DEPRECATION
+        "ENABLE_HLSL is deprecated. The HLSL front-end will be removed in "
+        "a future major release of glslang. "
+        "See https://github.com/KhronosGroup/glslang/issues/4210 for details.")
+endif()
 option(ENABLE_RTTI "Enables RTTI")
 option(ENABLE_EXCEPTIONS "Enables Exceptions")
 cmake_dependent_option(ENABLE_OPT "Enables spirv-opt capability if present" ON "ENABLE_SPIRV" OFF)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 # News
 
-1. The --shift-texture-binding\[s\] option no longer affects combined samplers. The new --shift-combined-sampler-binding\[s\] option should be used to control combined sampler bindings independently from separate textures. The old behavior can be achieved by setting both options to the same value.
+1. The HLSL front-end is deprecated as of April 2026 and will be removed at the next major version of glslang. See [issue #4210](https://github.com/KhronosGroup/glslang/issues/4210) for rationale and migration guidance.
 
-2. The spirv-remap utility from glslang has been ported to the SPIRV-Tools repository as a new optimization pass called canonicalize-ids, available in spirv-opt. See spirv-opt --help for usage details.
+2. The --shift-texture-binding\[s\] option no longer affects combined samplers. The new --shift-combined-sampler-binding\[s\] option should be used to control combined sampler bindings independently from separate textures. The old behavior can be achieved by setting both options to the same value.
 
-3. Building glslang as a DLL or shared library is now possible and supported.
+3. The spirv-remap utility from glslang has been ported to the SPIRV-Tools repository as a new optimization pass called canonicalize-ids, available in spirv-opt. See spirv-opt --help for usage details.
+
+4. Building glslang as a DLL or shared library is now possible and supported.
 
 # Glslang Components and Status
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ An OpenGL GLSL and OpenGL|ES GLSL (ESSL) front-end for reference validation and 
 
 An HLSL front-end for translation of an approximation of HLSL to glslang's AST form.
 
-**Status**: Partially complete. Semantics are not reference quality and input is not validated.
-This is in contrast to the [DXC project](https://github.com/Microsoft/DirectXShaderCompiler), which receives a much larger investment and attempts to have definitive/reference-level semantics.
+**Status**: Deprecated as of April 2026. The HLSL front-end will be removed at the next major version of glslang, with at least 18 months of notice from this announcement.
 
-See [issue 362](https://github.com/KhronosGroup/glslang/issues/362) and [issue 701](https://github.com/KhronosGroup/glslang/issues/701) for current status.
+Bug reports for the HLSL front-end will no longer be accepted. Security issues will be assessed on a case-by-case basis. Projects that require continued HLSL support should maintain a fork of glslang at the tag corresponding to the deprecation announcement.
+
+See [issue #4210](https://github.com/KhronosGroup/glslang/issues/4210) for the rationale and migration guidance.
 
 ### AST -> SPIR-V Back End
 

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -133,7 +133,7 @@ class TType;
 typedef enum {
     EShSourceNone,
     EShSourceGlsl,               // GLSL, includes ESSL (OpenGL ES GLSL)
-    EShSourceHlsl,               // HLSL
+    EShSourceHlsl,               // HLSL (deprecated, see issue #4210)
     LAST_ELEMENT_MARKER(EShSourceCount),
 } EShSource;                     // if EShLanguage were EShStage, this could be EShLanguage instead
 
@@ -260,14 +260,14 @@ enum EShMessages : unsigned {
     EShMsgSpvRules             = (1 << 3),  // issue messages for SPIR-V generation
     EShMsgVulkanRules          = (1 << 4),  // issue messages for Vulkan-requirements of GLSL for SPIR-V
     EShMsgOnlyPreprocessor     = (1 << 5),  // only print out errors produced by the preprocessor
-    EShMsgReadHlsl             = (1 << 6),  // use HLSL parsing rules and semantics
+    EShMsgReadHlsl             = (1 << 6),  // use HLSL parsing rules and semantics (deprecated, see issue #4210)
     EShMsgCascadingErrors      = (1 << 7),  // get cascading errors; risks error-recovery issues, instead of an early exit
     EShMsgKeepUncalled         = (1 << 8),  // for testing, don't eliminate uncalled functions
-    EShMsgHlslOffsets          = (1 << 9),  // allow block offsets to follow HLSL rules instead of GLSL rules
+    EShMsgHlslOffsets          = (1 << 9),  // allow block offsets to follow HLSL rules instead of GLSL rules (deprecated, see issue #4210)
     EShMsgDebugInfo            = (1 << 10), // save debug information
-    EShMsgHlslEnable16BitTypes = (1 << 11), // enable use of 16-bit types in SPIR-V for HLSL
-    EShMsgHlslLegalization     = (1 << 12), // enable HLSL Legalization messages
-    EShMsgHlslDX9Compatible    = (1 << 13), // enable HLSL DX9 compatible mode (for samplers and semantics)
+    EShMsgHlslEnable16BitTypes = (1 << 11), // enable use of 16-bit types in SPIR-V for HLSL (deprecated, see issue #4210)
+    EShMsgHlslLegalization     = (1 << 12), // enable HLSL Legalization messages (deprecated, see issue #4210)
+    EShMsgHlslDX9Compatible    = (1 << 13), // enable HLSL DX9 compatible mode (for samplers and semantics) (deprecated, see issue #4210)
     EShMsgBuiltinSymbolTable   = (1 << 14), // print the builtin symbol table
     EShMsgEnhanced             = (1 << 15), // enhanced message readability
     EShMsgAbsolutePath         = (1 << 16), // Output Absolute path for messages
@@ -503,8 +503,8 @@ public:
     void setDxPositionW(bool dxPosW);
     void setEnhancedMsgs();
 #ifdef ENABLE_HLSL
-    void setHlslIoMapping(bool hlslIoMap);
-    void setFlattenUniformArrays(bool flatten);
+    void setHlslIoMapping(bool hlslIoMap);      // deprecated, see issue #4210
+    void setFlattenUniformArrays(bool flatten); // deprecated, see issue #4210
 #endif
     void setNoStorageFormat(bool useUnknownFormat);
     void setNanMinMaxClamp(bool nanMinMaxClamp);
@@ -573,8 +573,8 @@ public:
     void getStrings(const char* const* &s, int& n) { s = strings; n = numStrings; }
 
 #ifdef ENABLE_HLSL
-    void setEnvTargetHlslFunctionality1() { environment.target.hlslFunctionality1 = true; }
-    bool getEnvTargetHlslFunctionality1() const { return environment.target.hlslFunctionality1; }
+    void setEnvTargetHlslFunctionality1() { environment.target.hlslFunctionality1 = true; }  // deprecated, see issue #4210
+    bool getEnvTargetHlslFunctionality1() const { return environment.target.hlslFunctionality1; }  // deprecated, see issue #4210
 #else
     bool getEnvTargetHlslFunctionality1() const { return false; }
 #endif


### PR DESCRIPTION
This PR marks the HLSL front-end as deprecated in the `README`, `CHANGES.md`, the CMake build system, and the public API comments in `ShaderLang.h`.

See https://github.com/KhronosGroup/glslang/issues/4210 for the rationale and migration guidance.
