### PR TITLE
Add template deduction guide for Defer

### DIFF
--- a/glslang/Include/defer.h
+++ b/glslang/Include/defer.h
@@ -54,6 +54,10 @@ class Defer {
   F f_;
 };
 
+// Template argument deduction guide for Defer.
+template <typename T>
+Defer(T) -> Defer<T>;
+
 } // namespace glslang
 
 #endif


### PR DESCRIPTION
This avoids a Clang -Wctad-maybe-unsupported in some compiler configurations.