### PR TITLE
Fix generated decorate string from old UTF8EncodedKHR to new UTFEncodedKHR

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -3172,7 +3172,7 @@ void TGlslangToSpvTraverser::createAbortEXT(const glslang::TIntermSequence &glsl
 {
     bool isEmptyMsg =
         glslangOperands.empty() ||
-        strcmp(glslangOperands[0]->getAsConstantUnion()->getConstArray()[0].getSConst()->c_str(), "") == 0;
+        glslangOperands[0]->getAsConstantUnion()->getConstArray()[0].getSConst()->empty();
     // Add Capability and extensions.
     builder.addCapability(spv::Capability::AbortKHR);
     builder.addCapability(spv::Capability::ConstantDataKHR);

--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -359,7 +359,7 @@ const char* DecorationString(int decoration)
 
     case (int)Decoration::ArrayStrideIdEXT:        return "DecorationArrayStrideIdEXT";
     case (int)Decoration::OffsetIdEXT:             return "DecorationOffsetIdEXT";
-    case (int)Decoration::UTFEncodedKHR:          return "UTF8EncodedKHR";
+    case (int)Decoration::UTFEncodedKHR:           return "UTFEncodedKHR";
     }
 }
 

--- a/Test/baseResults/spv.shader.abort.comp.out
+++ b/Test/baseResults/spv.shader.abort.comp.out
@@ -44,43 +44,43 @@ spv.shader.abort.comp
                               MemberDecorate 18(Output) 0 Offset 0
                               Decorate 20(outputBuffer) Binding 0
                               Decorate 20(outputBuffer) DescriptorSet 0
-                              Decorate 28 UTF8EncodedKHR
-                              Decorate 29 UTF8EncodedKHR
-                              Decorate 33 UTF8EncodedKHR
-                              Decorate 34 UTF8EncodedKHR
+                              Decorate 28 UTFEncodedKHR
+                              Decorate 29 UTFEncodedKHR
+                              Decorate 33 UTFEncodedKHR
+                              Decorate 34 UTFEncodedKHR
                               MemberDecorate 38(abortMessageLoadType) 0 Offset 0
                               MemberDecorate 38(abortMessageLoadType) 1 Offset 12
                               MemberDecorate 38(abortMessageLoadType) 2 Offset 16
                               Decorate 50(gl_GlobalInvocationID) BuiltIn GlobalInvocationId
-                              Decorate 59 UTF8EncodedKHR
-                              Decorate 60 UTF8EncodedKHR
+                              Decorate 59 UTFEncodedKHR
+                              Decorate 60 UTFEncodedKHR
                               MemberDecorate 62(abortMessageLoadType) 0 Offset 0
-                              Decorate 69 UTF8EncodedKHR
-                              Decorate 70 UTF8EncodedKHR
+                              Decorate 69 UTFEncodedKHR
+                              Decorate 70 UTFEncodedKHR
                               MemberDecorate 72(abortMessageLoadType) 0 Offset 0
-                              Decorate 89 UTF8EncodedKHR
-                              Decorate 90 UTF8EncodedKHR
-                              Decorate 93 UTF8EncodedKHR
-                              Decorate 94 UTF8EncodedKHR
-                              Decorate 96 UTF8EncodedKHR
-                              Decorate 97 UTF8EncodedKHR
-                              Decorate 100 UTF8EncodedKHR
-                              Decorate 101 UTF8EncodedKHR
+                              Decorate 89 UTFEncodedKHR
+                              Decorate 90 UTFEncodedKHR
+                              Decorate 93 UTFEncodedKHR
+                              Decorate 94 UTFEncodedKHR
+                              Decorate 96 UTFEncodedKHR
+                              Decorate 97 UTFEncodedKHR
+                              Decorate 100 UTFEncodedKHR
+                              Decorate 101 UTFEncodedKHR
                               MemberDecorate 106(abortMessageLoadType) 0 Offset 0
                               MemberDecorate 106(abortMessageLoadType) 1 Offset 44
                               MemberDecorate 106(abortMessageLoadType) 2 Offset 48
                               MemberDecorate 106(abortMessageLoadType) 3 Offset 52
                               MemberDecorate 106(abortMessageLoadType) 4 Offset 56
                               MemberDecorate 106(abortMessageLoadType) 5 Offset 60
-                              Decorate 114 UTF8EncodedKHR
-                              Decorate 115 UTF8EncodedKHR
+                              Decorate 114 UTFEncodedKHR
+                              Decorate 115 UTFEncodedKHR
                               MemberDecorate 119(abortMessageLoadType) 0 Offset 0
                               MemberDecorate 119(abortMessageLoadType) 1 Offset 4
-                              Decorate 125 UTF8EncodedKHR
-                              Decorate 126 UTF8EncodedKHR
+                              Decorate 125 UTFEncodedKHR
+                              Decorate 126 UTFEncodedKHR
                               MemberDecorate 128(abortMessageLoadType) 0 Offset 0
-                              Decorate 137 UTF8EncodedKHR
-                              Decorate 138 UTF8EncodedKHR
+                              Decorate 137 UTFEncodedKHR
+                              Decorate 138 UTFEncodedKHR
                               MemberDecorate 140(abortMessageLoadType) 0 Offset 0
                               Decorate 144 BuiltIn WorkgroupSize
                2:             TypeVoid


### PR DESCRIPTION
Fix enum string name to keep same with current SPIRV-Header's implementation:

https://github.com/KhronosGroup/SPIRV-Headers/blob/main/include/spirv/unified1/spirv.hpp