### PR TITLE
Ignore .jj tree for .gitignore and license check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .cache/
 .vscode/
 .vs/
+.jj/
 tags
 TAGS
 bazel-*

--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -17,6 +17,7 @@
                     ".*",
                     ".github/workflows/*.yml",
                     ".github/workflows/*.js",
+                    ".jj/**",
                     "CMakeSettings.json",
                     "known_good_khr.json",
                     "known_good.json",


### PR DESCRIPTION
The jj version control system uses .jj/** for storing its data, like git uses .git/**