### PR TITLE
Make GN builds work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ CMakeUserPresets.json
 third_party/
 buildtools/
 tools/
+.gclient_previous_sync_commits
+.gcs_entries
+.gclient_previous_custom_vars
 
 # Random OS stuff
 .DS_Store

--- a/.gn
+++ b/.gn
@@ -31,9 +31,29 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# Use the mostly-generic build configuration that comes from Chromium.
+# Do this to ensure that this project can be embedded in Chromium itself
+# or a Chromium-adjacent project.
 buildconfig = "//build/config/BUILDCONFIG.gn"
 
+# Use Python3 to run scripts. On Windows this will use python.exe or python.bat
+script_executable = "python3"
+
 default_args = {
-    clang_use_chrome_plugins = false
-    use_custom_libcxx = false
+  # Requst a non-hermetic build.
+  # This is reasonable for standalone usage in upstream Glslang.
+  # It avoids a lot of overhead in the DEPS file and developer source trees.
+  # For example, don't download and use a custom Clang and libc++.
+  is_clang = false
+
+  # Disable various things that are are automatically turned on even
+  # we don't request a hermetic build with Clang.
+  use_custom_libcxx = false
+  # Needed only for std::atomic_ref<T> for large Ts http://crbug.com/402171653
+  # Disable it to avoid the need to add the compiler-rt third_party dependency.
+  use_llvm_libatomic = false
 }
+
+# Export compile_commands.json to the build dir for all generated targets.
+# This is useful for editors that parse the compilation database for symbol lookup.
+export_compile_commands = [ "*" ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -31,7 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import("//build_overrides/glslang.gni")
+# The GN build for Glslang.
+# See the DEPS for usage instructions.
+
+import("gn_scripts/glslang_overrides_with_defaults.gni")
 
 # Both Chromium and Fuchsia use by default a set of warning errors
 # that is far too strict to compile this project. These are also
@@ -289,12 +292,12 @@ template("glslang_sources_common") {
 
 glslang_sources_common("glslang_lib_sources") {
   enable_opt = true
-  enable_hlsl = true
+  enable_hlsl = glslang_enable_hlsl
 }
 
 glslang_sources_common("glslang_sources") {
   enable_opt = true
-  enable_hlsl = true
+  enable_hlsl = glslang_enable_hlsl
 }
 
 source_set("glslang_default_resource_limits_sources") {
@@ -328,7 +331,9 @@ executable("glslang_validator") {
     ":glslang_sources",
     ":glslang_extension_headers",
   ]
-  public_configs = [ ":glslang_hlsl" ]
+  if (glslang_enable_hlsl) {
+    public_configs = [ ":glslang_hlsl" ]
+  }
 
   include_dirs = [
     "${target_gen_dir}/include",

--- a/DEPS
+++ b/DEPS
@@ -31,52 +31,125 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# This file defines Glslang's build infra dependencies for GN builds.
+# It assumes you have already have the source files for Glslang
+# *and* its dependencies (as downloaded by ./update_glslang_sources.py)
+
+# Usage:
+#   1. Get Chromium depot_tools, and put it in your path.
+#      See https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
+#
+#   2. From the Glslang source tree:
+#
+#      # Get additional build tooling, using the info in the DEPS file.
+#      gclient sync --gclientfile=standalone.gclient
+#
+#   3. One of the tools downloaded in the previous step is the binary for 'gn'.
+#      Put it on your path.
+#
+#      # This is for Linux amd64 environments:
+#      PATH=$(pwd)/build/linux64:$PATH
+#
+#   3. Create a build tree with Ninja build recipes.
+#
+#      gn gen out/Debug
+#
+#      # Or disable HLSL support:
+#      gn gen out/Debug-no-hlsl --args="glslang_enable_hlsl=false"
+#
+#      # Or make a release build without HLSL support:
+#      gn gen out/Release --args="glslang_enable_hlsl=false is_debug=false"
+#
+#   4. Use ninja to build the project
+#
+#      ninja -C out/Debug
+
 use_relative_paths = True
 
 gclient_gn_args_file = 'build/config/gclient_args.gni'
 
+# Emit this vars for use in .gn and .gni files
+gclient_gn_args = [
+  # Needed by //build/toolchain/linux/BUILD.gn
+  # which was needed by 'action' in ./BUILD.gn
+  'build_with_chromium',
+]
+
+git_dependencies = 'SYNC'
+
 vars = {
+  # Repo sources
   'chromium_git': 'https://chromium.googlesource.com',
+
+  # Building context
   'build_with_chromium': False,
+  'glslang_standalone': True,
+
+  # Commits
+  'glslang_gn_version': 'git_revision:ec56d4d935a0e2ab9d52b88dd00c93ec51233055',
+  'glslang_build_version': '2316930a88b15a036fa5f72e2b2c2ba08e2904a0',
 }
 
 deps = {
-
-  './build': {
-    'url': '{chromium_git}/chromium/src/build.git@85ee3b7692e5284f08bd3c9459fb5685eed7b838',
-    'condition': 'not build_with_chromium',
+  # Get buildtools.
+  # We need the 'gn' binary.
+  'buildtools': {
+    'url': '{chromium_git}/chromium/src/buildtools@11cc2bd83053cb790b7516aa3eb3f3935fb05a0e',
+    'condition': 'glslang_standalone',
+  },
+  'buildtools/linux64': {
+    'packages': [{
+      'package': 'gn/gn/linux-${{arch}}',
+      'version': Var('glslang_gn_version'),
+    }],
+    'dep_type': 'cipd',
+    'condition': 'glslang_standalone and host_os == "linux"',
+  },
+  'buildtools/mac': {
+    'packages': [{
+      'package': 'gn/gn/mac-${{arch}}',
+      'version': Var('glslang_gn_version'),
+    }],
+    'dep_type': 'cipd',
+    'condition': 'glslang_standalone and host_os == "mac"',
+  },
+  'buildtools/win': {
+    'packages': [{
+      'package': 'gn/gn/windows-amd64',
+      'version': Var('glslang_gn_version'),
+    }],
+    'dep_type': 'cipd',
+    'condition': 'glslang_standalone and host_os == "win"',
   },
 
-  './buildtools': {
-    'url': '{chromium_git}/chromium/src/buildtools.git@4be464e050b3d05060471788f926b34c641db9fd',
-    'condition': 'not build_with_chromium',
+  # Get //build from Chromium.
+  # It contains the generic //build/config/BUILDCONFIG.gn that sets up most rules
+  # for C++ compilation.
+  'build': {
+  'url': '{chromium_git}/chromium/src/build@{glslang_build_version}',
+    'condition': 'glslang_standalone',
   },
-
-  './tools/clang': {
-    'url': '{chromium_git}/chromium/src/tools/clang.git@3a982adabb720aa8f3e3885d40bf3fe506990157',
-    'condition': 'not build_with_chromium',
-  },
-
 }
 
 hooks = [
+  # The Chromium BUILDCONFIG.gn has a false dependency on the sysroots.
+  # Pull the compilers and system libraries for hermetic builds
+  {
+    'name': 'sysroot_x86',
+    'pattern': '.',
+    'condition': 'glslang_standalone and checkout_linux and checkout_x86',
+    'action': ['vpython3', 'build/linux/sysroot_scripts/install-sysroot.py',
+               '--arch=x86'],
+  },
   {
     'name': 'sysroot_x64',
     'pattern': '.',
-    'condition': 'checkout_linux and (checkout_x64 and not build_with_chromium)',
-    'action': ['python', './build/linux/sysroot_scripts/install-sysroot.py',
+    'condition': 'glslang_standalone and checkout_linux and checkout_x64',
+    'action': ['vpython3', 'build/linux/sysroot_scripts/install-sysroot.py',
                '--arch=x64'],
-  },
-  {
-    # Note: On Win, this should run after win_toolchain, as it may use it.
-    'name': 'clang',
-    'pattern': '.',
-    'action': ['python', './tools/clang/scripts/update.py'],
-    'condition': 'not build_with_chromium',
   },
 ]
 
 recursedeps = [
-  # buildtools provides clang_format, libc++, and libc++abi
   'buildtools',
 ]

--- a/build_overrides/glslang.gni
+++ b/build_overrides/glslang.gni
@@ -31,7 +31,13 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import("//build/config/gclient_args.gni")
+
 # These are variables that are overridable by projects that include glslang.
+
+# Whether we are building from the Glslang repository.
+# MUST be unset in other pojects (will default to false)
+glslang_standalone = true
 
 # The path to glslang dependencies.
 glslang_spirv_tools_dir = "//External/spirv-tools"

--- a/gn_scripts/glslang_overrides_with_defaults.gni
+++ b/gn_scripts/glslang_overrides_with_defaults.gni
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 The Khronos Group Inc.
+# Copyright 2026 Google LLC.
 #
 # All rights reserved.
 #
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of The Khronos Group Inc. nor the names of its
+#    Neither the name of Google Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -31,13 +31,22 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# This file is imported from //build/BUILD.gn
+import("//build_overrides/glslang.gni")
 
-# Get user-specfied settings. This path is specified in the top-level DEPS file.
-import("//build/config/gclient_args.gni")
-
-glslang_standalone = true
-
+# Standalone builds 
+if (!defined(glslang_standalone)) {
+  glslang_standalone = false
+}
+if (!defined(build_with_chromium)) {
+  build_with_chromium = false
+}
 declare_args() {
-   build_with_chromium = false
+  if (!defined(glslang_enable_hlsl)) {
+    # If true, enables compilation of HLSL in Glslang.
+    # Glslang's HLSL frontend is deprecated, and will be removed
+    # at a future date.
+    # See https://github.com/KhronosGroup/glslang/issues/4210
+    # For now, this option defaults to true.
+    glslang_enable_hlsl = true
+  }
 }

--- a/kokoro/linux-gcc-gn-nohlsl/build.sh
+++ b/kokoro/linux-gcc-gn-nohlsl/build.sh
@@ -1,4 +1,6 @@
-# Copyright (C) 2020 The Khronos Group Inc.
+#!/bin/bash
+
+# Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
 #
@@ -14,7 +16,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of The Khronos Group Inc. nor the names of its
+#    Neither the name of Google Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -31,13 +33,18 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# This file is imported from //build/BUILD.gn
+set -e # Fail on any error.
 
-# Get user-specfied settings. This path is specified in the top-level DEPS file.
-import("//build/config/gclient_args.gni")
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
-glslang_standalone = true
+docker run --rm -i \
+  --volume "${ROOT_DIR}:${ROOT_DIR}" \
+  --workdir "${ROOT_DIR}" \
+  --env ROOT_DIR="${ROOT_DIR}" \
+  --env SCRIPT_DIR="${SCRIPT_DIR}" \
+  --env GLSLANG_ENABLE_HLSL="false" \
+  --entrypoint "${ROOT_DIR}/kokoro/scripts/linux/build-docker-gn.sh" \
+  us-east4-docker.pkg.dev/shaderc-build/radial-docker/ubuntu-24.04-amd64/cpp-builder
 
-declare_args() {
-   build_with_chromium = false
-}
+exit $?

--- a/kokoro/linux-gcc-gn-nohlsl/continuous.cfg
+++ b/kokoro/linux-gcc-gn-nohlsl/continuous.cfg
@@ -31,5 +31,5 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Presubmit build configuration.
-build_file: "glslang/kokoro/linux-clang-gn/build.sh"
+# Continuous build configuration.
+build_file: "glslang/kokoro/linux-gcc-gn-nohlsl/build.sh"

--- a/kokoro/linux-gcc-gn-nohlsl/presubmit.cfg
+++ b/kokoro/linux-gcc-gn-nohlsl/presubmit.cfg
@@ -31,5 +31,5 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Continuous build configuration.
-build_file: "glslang/kokoro/linux-clang-gn/build.sh"
+# Presubmit build configuration.
+build_file: "glslang/kokoro/linux-gcc-gn-nohlsl/build.sh"

--- a/kokoro/linux-gcc-gn/build.sh
+++ b/kokoro/linux-gcc-gn/build.sh
@@ -38,18 +38,13 @@ set -e # Fail on any error.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
-set +e # Allow build failure
 docker run --rm -i \
   --volume "${ROOT_DIR}:${ROOT_DIR}" \
   --workdir "${ROOT_DIR}" \
   --env ROOT_DIR="${ROOT_DIR}" \
   --env SCRIPT_DIR="${SCRIPT_DIR}" \
-  --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
+  --env GLSLANG_ENABLE_HLSL="true" \
+  --entrypoint "${ROOT_DIR}/kokoro/scripts/linux/build-docker-gn.sh" \
   us-east4-docker.pkg.dev/shaderc-build/radial-docker/ubuntu-24.04-amd64/cpp-builder
 
-# This is important. If the permissions are not fixed, kokoro will fail
-# to pull build artifacts, and put the build in tool-failure state, which
-# blocks the logs.
-RESULT=$?
-sudo chown -R "$(id -u):$(id -g)" "${ROOT_DIR}"
-exit $RESULT
+exit $?

--- a/kokoro/linux-gcc-gn/continuous.cfg
+++ b/kokoro/linux-gcc-gn/continuous.cfg
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 The Khronos Group Inc.
+# Copyright 2026 Google LLC.
 #
 # All rights reserved.
 #
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of The Khronos Group Inc. nor the names of its
+#    Neither the name of Google Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -31,13 +31,5 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# This file is imported from //build/BUILD.gn
-
-# Get user-specfied settings. This path is specified in the top-level DEPS file.
-import("//build/config/gclient_args.gni")
-
-glslang_standalone = true
-
-declare_args() {
-   build_with_chromium = false
-}
+# Continuous build configuration.
+build_file: "glslang/kokoro/linux-gcc-gn/build.sh"

--- a/kokoro/linux-gcc-gn/presubmit.cfg
+++ b/kokoro/linux-gcc-gn/presubmit.cfg
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-# Copyright (C) 2020 Google, Inc.
+# Copyright 2026 Google LLC.
 #
 # All rights reserved.
 #
@@ -33,32 +31,5 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
-
-. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
-
-set -x # Display commands being run.
-
-using ninja-1.10.0
-
-# Disable git's "detected dubious ownership" error - kokoro checks out the repo
-# with a different user, and we don't care about this warning.
-git config --global --add safe.directory '*'
-
-echo "Fetching external projects..."
-./update_glslang_sources.py
-
-echo "Fetching depot_tools..."
-mkdir -p /tmp/depot_tools
-curl https://storage.googleapis.com/chrome-infra/depot_tools.zip -o /tmp/depot_tools.zip
-unzip /tmp/depot_tools.zip -d /tmp/depot_tools
-rm /tmp/depot_tools.zip
-export PATH="/tmp/depot_tools:$PATH"
-
-echo "Syncing client..."
-gclient sync --gclientfile=standalone.gclient
-gn gen out/Default
-
-echo "Building..."
-cd out/Default
-ninja
+# Presubmit build configuration.
+build_file: "glslang/kokoro/linux-gcc-gn/build.sh"

--- a/kokoro/scripts/linux/build-docker-gn.sh
+++ b/kokoro/scripts/linux/build-docker-gn.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Copyright 2026 Google LLC.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#    Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+#    Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+#    Neither the name of Google Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+set -e # Fail on any error.
+
+# 'true' or 'false'
+GLSLANG_ENABLE_HLSL=${GLSLANG_ENABLE_HLSL-true}
+
+. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
+
+using ninja-1.10.0
+using python-3.12.4
+
+# Don't set the compiler here
+# The GN build uses the g++ compiler that it downloads from the sysroot.
+# See DEPS for details.
+
+set -x # Display commands being run.
+
+# Disable git's "detected dubious ownership" error - kokoro checks out the repo
+# with a different user, and we don't care about this warning.
+git config --global --add safe.directory '*'
+
+echo "Fetching external projects..."
+./update_glslang_sources.py
+
+echo "Fetching depot_tools..."
+rm -rf /tmp/depot_tools
+mkdir -p /tmp/depot_tools
+git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /tmp/depot_tools
+export PATH="/tmp/depot_tools:$PATH"
+
+
+echo "Syncing client..."
+
+# Silence gn related babble
+export GCLIENT_SUPPRESS_GIT_VERSION_WARNING=1
+# For the 'root' user, silence gclient metrics collection.
+if [[ -z "$USER" ]]; then
+  mkdir -p $HOME/.config/depot_tools
+  cat  >$HOME/.config/depot_tools/metrics.cfg <<'EOF'
+  {"is-googler": false, "countdown": 0, "opt-in": false, "version": 1}
+EOF
+fi
+
+# Erase the GN args from any previous run of gclient.
+# This is important for local testing.
+rm -f build/config/gclient_args.gni
+
+# Sync dependencies and generate default GN args from the DEPS file.
+gclient sync -D --gclientfile=standalone.gclient
+
+echo "Generate ninja build plan..."
+
+# Ensure the gn binary is on the path
+export PATH=$(pwd)/buildtools/linux64:$PATH
+# which -a gn  # There should be two
+
+BUILD_DIR=out/Default-hlsl-${GLSLANG_ENABLE_HLSL}
+
+rm -rf "$BUILD_DIR"
+gn gen "$BUILD_DIR" --args="glslang_enable_hlsl=${GLSLANG_ENABLE_HLSL}"
+
+echo "Building..."
+ninja -v -C "$BUILD_DIR"


### PR DESCRIPTION
- Create or update files as needed to make a working standalone GN build. It assumes sources for dependencies have already been downloaded, as is done by ./update_glslang_sources.py

  See DEPS for build instructions.

- Add Kokoro configurations for Linux with GCC that exercise the default build, and one that disables the HLSL frontend. The GCC is the one taken from the 'sysroot' downloaded by gclient.

Issue: #4210