### PR TITLE
ci: point setup-emsdk at canonical emscripten-core repo

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -326,7 +326,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: ubuntu-emscripten
-      - uses: mymindstorm/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
+      - uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
       - name: Update Glslang Sources
         run: ./update_glslang_sources.py
       - name: Configure


### PR DESCRIPTION
The mymindstorm/setup-emsdk action moved to emscripten-core/setup-emsdk in v16.