### PR TITLE
glsl: implement Y-inversion for GLSL to SPIR-V

### DIFF
--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -2725,11 +2725,92 @@ void TIntermBranch::updatePrecision(TPrecisionQualifier parentPrecision)
     }
 }
 
+struct TInvertYTraverser : public TIntermTraverser {
+    TInvertYTraverser(TIntermediate& inter)
+        : TIntermTraverser(true, false, false),
+          intermediate(inter) {}
+
+    bool visitAggregate(TVisit visit, TIntermAggregate* node) override
+    {
+        if (visit != EvPreVisit || node->getOp() != EOpSequence)
+            return true;
+
+        TIntermSequence& seq = node->getSequence();
+        for (size_t i = 0; i < seq.size(); ++i) {
+            TIntermBinary* assign = seq[i]->getAsBinaryNode();
+
+            if (!assign || assign->getOp() != EOpAssign)
+                continue;
+
+            const bool isPositionBuiltIn =
+                (assign->getLeft()->getType().getQualifier().builtIn == EbvPosition);
+            if (!isPositionBuiltIn)
+                continue;
+
+            // Skip step 3 of a prior transformation: rhs is our
+            // anonymous temp (id==0, EvqTemporary)
+            TIntermSymbol* rhsSym = assign->getRight()->getAsSymbolNode();
+            if (rhsSym && rhsSym->getId() == 0 && rhsSym->getName().empty())
+                continue;
+
+            const TSourceLoc& loc = assign->getLoc();
+            TIntermTyped* lhs = assign->getLeft();
+            TIntermTyped* rhs = assign->getRight();
+
+            TType tempType(EbtVoid);
+            tempType.shallowCopy(rhs->getType());
+            tempType.getQualifier().storage = EvqTemporary;
+            tempType.getQualifier().builtIn  = EbvNone;
+
+            TIntermAggregate* replacement = nullptr;
+
+            TIntermTyped* tempSym = intermediate.addSymbol(tempType, loc);
+            TIntermTyped* tmpRHS =
+                intermediate.addAssign(EOpAssign, tempSym, rhs, loc);
+            replacement =
+                intermediate.growAggregate(replacement, tmpRHS, loc);
+
+            TIntermTyped* tempSymL = intermediate.addSymbol(tempType, loc);
+            TIntermTyped* tempSymR = intermediate.addSymbol(tempType, loc);
+            TIntermTyped* index    = intermediate.addConstantUnion(1, loc);
+            TIntermTyped* lhsY     =
+                intermediate.addIndex(EOpIndexDirect, tempSymL, index, loc);
+            TIntermTyped* rhsY     =
+                intermediate.addIndex(EOpIndexDirect, tempSymR, index, loc);
+            const TType compType(rhs->getType(), 0);
+            lhsY->setType(compType);
+            rhsY->setType(compType);
+            TIntermTyped* yNeg =
+                intermediate.addUnaryMath(EOpNegative, rhsY, loc);
+            TIntermTyped* tmpYNeg =
+                intermediate.addAssign(EOpAssign, lhsY, yNeg, loc);
+            replacement =
+                intermediate.growAggregate(replacement, tmpYNeg);
+
+            TIntermTyped* tempSymFinal = intermediate.addSymbol(tempType, loc);
+            TIntermTyped* tmpLHS = intermediate.addAssign(EOpAssign, lhs, tempSymFinal, loc);
+            replacement = intermediate.growAggregate(replacement, tmpLHS);
+
+            replacement->setOperator(EOpSequence);
+            seq[i] = replacement;
+        }
+        return true;
+    }
+
+    TIntermediate& intermediate;
+};
+
+void TIntermediate::invertPositions(TIntermNode* root)
+{
+    TInvertYTraverser traverser(*this);
+    root->traverse(&traverser);
+}
+
 //
 // This is to be executed after the final root is put on top by the parsing
 // process.
 //
-bool TIntermediate::postProcess(TIntermNode* root, EShLanguage /*language*/)
+bool TIntermediate::postProcess(TIntermNode* root, EShLanguage language)
 {
     if (root == nullptr)
         return true;
@@ -2741,6 +2822,13 @@ bool TIntermediate::postProcess(TIntermNode* root, EShLanguage /*language*/)
 
     // Propagate 'noContraction' label in backward from 'precise' variables.
     glslang::PropagateNoContraction(*this);
+
+    if (invertY && getSource() == EShSourceGlsl &&
+        (language == EShLangVertex ||
+         language == EShLangGeometry ||
+         language == EShLangTessEvaluation)) {
+        invertPositions(root);
+    }
 
     switch (textureSamplerTransformMode) {
     case EShTexSampTransKeep:

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -503,6 +503,7 @@ public:
             processes.addProcess("invert-y");
     }
     bool getInvertY() const { return invertY; }
+    void invertPositions(TIntermNode* root);
 
     void setDxPositionW(bool dxPosW)
     {

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -59,6 +59,7 @@ if(GLSLANG_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/StructName.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/SpvPatternTest.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/SpvDebugInfoTest.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/InvertY.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/VkRelaxed.FromFile.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/GlslMapIO.FromFile.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/UboUnsizedArray.cpp)

--- a/gtests/InvertY.cpp
+++ b/gtests/InvertY.cpp
@@ -1,0 +1,225 @@
+// Copyright (C) 2026 The Khronos Group Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of The Khronos Group Inc. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "TestFixture.h"
+#include "glslang/Public/ResourceLimits.h"
+#include "glslang/Public/ShaderLang.h"
+#include "SPIRV/GlslangToSpv.h"
+#include "SPIRV/disassemble.h"
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace glslangtest {
+
+class InvertYTest : public ::testing::Test {
+protected:
+    struct CompileResult {
+        bool success;
+        std::string spirvText;
+        std::string infoLog;
+    };
+
+    CompileResult compileGlsl(const std::string& source, EShLanguage stage, bool invertY)
+    {
+        glslang::TShader shader(stage);
+        glslang::TProgram program;
+
+        const char* src = source.c_str();
+        shader.setStrings(&src, 1);
+        shader.setEnvInput(glslang::EShSourceGlsl, stage, glslang::EShClientVulkan, 100);
+        shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_0);
+        shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetSpv_1_0);
+        shader.setInvertY(invertY);
+
+        EShMessages msgs = static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules);
+        if (!shader.parse(GetDefaultResources(), 450, false, msgs)) {
+            return {false, "", shader.getInfoLog()};
+        }
+
+        program.addShader(&shader);
+        if (!program.link(msgs)) {
+            return {false, "", program.getInfoLog()};
+        }
+
+        std::vector<uint32_t> spirv;
+        glslang::GlslangToSpv(*program.getIntermediate(stage), spirv);
+
+        std::ostringstream dis;
+        spv::Disassemble(dis, spirv);
+        return {true, dis.str(), ""};
+    }
+
+    // Helper function to check if the given SPIR-V string contains a specific pattern.
+    bool containsPattern(const std::string& spirvText, const std::string& pattern)
+    {
+        return spirvText.find(pattern) != std::string::npos;
+    }
+
+    // Helper function to check if the given SPIR-V string contains a FNegate instruction.
+    bool containsFNegate(const std::string& spirvText) { return containsPattern(spirvText, "FNegate"); }
+};
+
+// A minimal vertex shader that writes gl_Position.
+static const char* kSimpleVert = R"glsl(
+#version 450
+layout(location = 0) in vec3 pos;
+void main() {
+    gl_Position = vec4(pos, 1.0);
+}
+)glsl";
+
+// A vertex shader that writes gl_Position multiple times to exercise all
+// assignment sites (braces ensure each branch is a sequence node).
+static const char* kMultiAssignVert = R"glsl(
+#version 450
+layout(location = 0) in vec3 pos;
+layout(location = 1) in float w;
+void main() {
+    if (w > 0.0) {
+        gl_Position = vec4(pos, w);
+    } else {
+        gl_Position = vec4(-pos, -w);
+    }
+}
+)glsl";
+
+// A geometry shader (takes triangles, emits a single vertex).
+static const char* kSimpleGeom = R"glsl(
+#version 450
+layout(triangles) in;
+layout(triangle_strip, max_vertices = 3) out;
+void main() {
+    gl_Position = gl_in[0].gl_Position;
+    EmitVertex();
+}
+)glsl";
+
+// A tessellation evaluation shader.
+static const char* kSimpleTese = R"glsl(
+#version 450
+layout(triangles, equal_spacing, ccw) in;
+void main() {
+    gl_Position = gl_in[0].gl_Position;
+}
+)glsl";
+
+// --- Vertex stage ---
+
+TEST_F(InvertYTest, VertexWithInvertYContainsFNegate)
+{
+    auto r = compileGlsl(kSimpleVert, EShLangVertex, true);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_TRUE(containsFNegate(r.spirvText))
+        << "Expected OpFNegate in SPIR-V when setInvertY(true) is used.\n"
+        << r.spirvText;
+}
+
+TEST_F(InvertYTest, VertexWithoutInvertYNoFNegate)
+{
+    auto r = compileGlsl(kSimpleVert, EShLangVertex, false);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_FALSE(containsFNegate(r.spirvText))
+        << "Expected no OpFNegate in SPIR-V when setInvertY(false) is used.\n"
+        << r.spirvText;
+}
+
+TEST_F(InvertYTest, VertexMultipleAssignmentsAllInverted)
+{
+    auto r = compileGlsl(kMultiAssignVert, EShLangVertex, true);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_TRUE(containsFNegate(r.spirvText))
+        << "Expected OpFNegate in SPIR-V for shader with multiple gl_Position assignments.\n"
+        << r.spirvText;
+}
+
+// --- Geometry stage ---
+
+TEST_F(InvertYTest, GeometryWithInvertYContainsFNegate)
+{
+    auto r = compileGlsl(kSimpleGeom, EShLangGeometry, true);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_TRUE(containsFNegate(r.spirvText))
+        << "Expected OpFNegate in geometry shader SPIR-V when setInvertY(true).\n"
+        << r.spirvText;
+}
+
+TEST_F(InvertYTest, GeometryWithoutInvertYNoFNegate)
+{
+    auto r = compileGlsl(kSimpleGeom, EShLangGeometry, false);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_FALSE(containsFNegate(r.spirvText))
+        << "Expected no OpFNegate in geometry shader SPIR-V when setInvertY(false).\n"
+        << r.spirvText;
+}
+
+// --- Tessellation evaluation stage ---
+
+TEST_F(InvertYTest, TessEvalWithInvertYContainsFNegate)
+{
+    auto r = compileGlsl(kSimpleTese, EShLangTessEvaluation, true);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_TRUE(containsFNegate(r.spirvText))
+        << "Expected OpFNegate in tessellation evaluation shader SPIR-V when setInvertY(true).\n"
+        << r.spirvText;
+}
+
+TEST_F(InvertYTest, TessEvalWithoutInvertYNoFNegate)
+{
+    auto r = compileGlsl(kSimpleTese, EShLangTessEvaluation, false);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_FALSE(containsFNegate(r.spirvText))
+        << "Expected no OpFNegate in tessellation evaluation shader SPIR-V when setInvertY(false).\n"
+        << r.spirvText;
+}
+
+// --- Compute stage should not be affected ---
+
+TEST_F(InvertYTest, ComputeWithInvertYFlagNoFNegate)
+{
+    // Compute shaders have no gl_Position; the flag must be a no-op.
+    const char* src = R"glsl(
+#version 450
+layout(local_size_x = 1) in;
+layout(binding = 0) buffer Out { float val; };
+void main() { val = 1.0; }
+)glsl";
+    auto r = compileGlsl(src, EShLangCompute, true);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_FALSE(containsFNegate(r.spirvText))
+        << "OpFNegate should not appear in a compute shader even with setInvertY(true).\n"
+        << r.spirvText;
+}
+
+} // namespace glslangtest


### PR DESCRIPTION
setInvertY() recorded the "invert-y" process string but had no effect on GLSL shaders - the actual position transformation only existed in the HLSL parse path (HlslParseContext::assignPosition()).

Add a post-parse AST traversal pass (TInvertYTraverser) that rewrites gl_Position assignments as: temp=rhs; temp.y=-temp.y; gl_Position=temp. The pass runs in postProcess() for GLSL vertex, geometry, and tessellation-evaluation stages only, so HLSL shaders (which already invert at parse time) are unaffected.

Fixes #2936