### PR TITLE
Add error for coopmat *= scalar with bf16/fp8.

### DIFF
--- a/Test/baseResults/spv.bfloat16_error.comp.out
+++ b/Test/baseResults/spv.bfloat16_error.comp.out
@@ -35,7 +35,12 @@ ERROR: 0:66: '--' :  wrong operand type no operation '--' exists that takes an o
 ERROR: 0:67: '-' :  wrong operand type no operation '-' exists that takes an operand of type  temp bfloat16_t (or there is no acceptable conversion)
 ERROR: 0:69: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp bfloat16_t' and a right operand of type ' temp bfloat16_t' (or there is no acceptable conversion)
 ERROR: 0:72: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' temp coopmat<3, 16, 16, 0> bfloat16_t' and a right operand of type ' temp coopmat<3, 16, 16, 0> bfloat16_t' (or there is no acceptable conversion)
-ERROR: 36 compilation errors.  No code generated.
+ERROR: 0:73: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp coopmat<3, 16, 16, 0> bfloat16_t' and a right operand of type ' temp coopmat<3, 16, 16, 0> bfloat16_t' (or there is no acceptable conversion)
+ERROR: 0:74: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp bfloat16_t' and a right operand of type ' temp coopmat<3, 16, 16, 0> bfloat16_t' (or there is no acceptable conversion)
+ERROR: 0:75: '*' :  wrong operand types: no operation '*' exists that takes a left-hand operand of type ' temp coopmat<3, 16, 16, 0> bfloat16_t' and a right operand of type ' temp bfloat16_t' (or there is no acceptable conversion)
+ERROR: 0:76: 'assign' :  cannot convert from ' temp coopmat<3, 16, 16, 0> bfloat16_t' to ' temp coopmat<3, 16, 16, 0> bfloat16_t'
+ERROR: 0:77: 'assign' :  cannot convert from ' temp bfloat16_t' to ' temp coopmat<3, 16, 16, 0> bfloat16_t'
+ERROR: 41 compilation errors.  No code generated.
 
 
 SPIR-V is not generated for failed compile or link

--- a/Test/spv.bfloat16_error.comp
+++ b/Test/spv.bfloat16_error.comp
@@ -70,5 +70,10 @@ void main()
 
     coopmat<bfloat16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> cmA;
     cmA+cmA;
+    cmA*cmA;
+    b*cmA;
+    cmA*b;
+    cmA+=cmA;
+    cmA*=b;
 }
 

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -3247,6 +3247,16 @@ bool TIntermediate::promoteBinary(TIntermBinary& node)
         }
     }
 
+    const bool hasCoopMat = left->getType().isCoopMat() || right->getType().isCoopMat();
+    const bool hasLimitedFloatCoopMat =
+        (left->getType().isCoopMat() &&
+         (left->getType().containsBFloat16() || left->getType().contains8BitFloat())) ||
+        (right->getType().isCoopMat() &&
+         (right->getType().containsBFloat16() || right->getType().contains8BitFloat()));
+
+    if (hasLimitedFloatCoopMat && op != EOpAssign)
+        return false;
+
     // Do general type checks against individual operands (comparing left and right is coming up, checking mixed shapes after that)
     switch (op) {
     case EOpLessThan:
@@ -3387,7 +3397,7 @@ bool TIntermediate::promoteBinary(TIntermBinary& node)
         break;
     }
 
-    if (left->getType().isCoopMat() || right->getType().isCoopMat()) {
+    if (hasCoopMat) {
         // Operations on two cooperative matrices must have identical types
         if (left->getType().isCoopMat() && right->getType().isCoopMat() &&
             left->getType() != right->getType()) {


### PR DESCRIPTION
@0cc4m reported glslang incorrectly accepting coopmat*scalar with bf16, the closest I could reproduce is coopmat *= scalar being incorrectly allowed.