### PR TITLE
Add basic support to accept extension GL_NV_desktop_lowp_mediump

### DIFF
--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -321,6 +321,7 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_NV_cooperative_matrix_decode_vector]      = EBhDisable;
     extensionBehavior[E_GL_NV_cluster_acceleration_structure]        = EBhDisable;
     extensionBehavior[E_GL_NV_linear_swept_spheres]                  = EBhDisable;
+    extensionBehavior[E_GL_NV_desktop_lowp_mediump]                  = EBhDisable;
     extensionBehavior[E_GL_NV_push_constant_bank]                    = EBhDisable;
     extensionBehavior[E_GL_NV_explicit_typecast]                     = EBhDisable;
 
@@ -617,6 +618,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_NV_shader_invocation_reorder 1\n"
             "#define GL_NV_cooperative_matrix2 1\n"
             "#define GL_NV_cooperative_matrix_decode_vector 1\n"
+            "#define GL_NV_desktop_lowp_mediump 1\n"
             "#define GL_NV_explicit_typecast 1\n"
 
             "#define GL_QCOM_image_processing 1\n"

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -297,6 +297,7 @@ const char* const E_GL_NV_cooperative_matrix_decode_vector      = "GL_NV_coopera
 const char* const E_GL_NV_cooperative_vector                    = "GL_NV_cooperative_vector";
 const char* const E_GL_NV_cluster_acceleration_structure        = "GL_NV_cluster_acceleration_structure";
 const char* const E_GL_NV_linear_swept_spheres                  = "GL_NV_linear_swept_spheres";
+const char* const E_GL_NV_desktop_lowp_mediump                  = "GL_NV_desktop_lowp_mediump";
 const char* const E_GL_NV_gpu_shader5                           = "GL_NV_gpu_shader5";
 const char* const E_GL_NV_push_constant_bank                    = "GL_NV_push_constant_bank";
 const char* const E_GL_NV_explicit_typecast                     = "GL_NV_explicit_typecast";


### PR DESCRIPTION
We have an old internal extension which allowed using precision qualifiers for desktop GLSL shaders since spec only allowed it in ES shaders.

Since glslang now accepts precision qualifiers and generates suitable RelaxedPrecision decorations for all vulkan shaders starting from glsl 140, this extension is effectively a no-op but we still need to add basic plumbing so that such shaders are not rejected
