### PR TITLE
Add --discard-is-terminate option (#4081)

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -62,6 +62,7 @@ path = [
     "Test/find_package/example.c",
     "Test/find_package/stub.cpp",
     "gtests/InvertY.cpp",
+    "gtests/Discard.cpp",
 ]
 SPDX-FileCopyrightText = "The Khronos Group Inc."
 SPDX-License-Identifier = "BSD-3-Clause"

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -5283,8 +5283,12 @@ bool TGlslangToSpvTraverser::visitBranch(glslang::TVisit /* visit */, glslang::T
     switch (node->getFlowOp()) {
     case glslang::EOpKill:
         if (glslangIntermediate->getSpv().spv >= glslang::EShTargetSpv_1_6) {
-            builder.addCapability(spv::Capability::DemoteToHelperInvocation);
-            builder.createNoResultOp(spv::Op::OpDemoteToHelperInvocationEXT);
+            if (glslangIntermediate->getDiscardIsTerminate() && glslangIntermediate->getSource() == glslang::EShSourceGlsl) {
+                builder.makeStatementTerminator(spv::Op::OpTerminateInvocation, "post-terminate-invocation");
+            } else {
+                builder.addCapability(spv::Capability::DemoteToHelperInvocation);
+                builder.createNoResultOp(spv::Op::OpDemoteToHelperInvocationEXT);
+            }
         } else {
             builder.makeStatementTerminator(spv::Op::OpKill, "post-discard");
         }

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -115,6 +115,7 @@ enum TOptions : uint64_t {
     EOptionValidateCrossStageIO = (1ull << 35),
     EOptionBindingsPerResourceType = (1ull << 36),
     EOptionRelaxSetBindingLimits = (1ull << 37),
+    EOptionDiscardIsTerminate = (1ull << 38),
 };
 bool targetHlslFunctionality1 = false;
 bool SpvToolsDisassembler = false;
@@ -739,6 +740,8 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                         AbsolutePath = true;
                     } else if (lowerword == "auto-sampled-textures") {
                         autoSampledTextures = true;
+                    } else if (lowerword == "discard-is-terminate") {
+                        Options |= EOptionDiscardIsTerminate;
                     } else if (lowerword == "invert-y" ||  // synonyms
                                lowerword == "iy") {
                         Options |= EOptionInvertY;
@@ -1476,6 +1479,9 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
         if (Options & EOptionBindingsPerResourceType)
             shader->setBindingsPerResourceType();
 
+        if (Options & EOptionDiscardIsTerminate)
+            shader->setDiscardIsTerminate(true);
+
         // Set up the environment, some subsettings take precedence over earlier
         // ways of setting things.
         if (Options & EOptionSpv) {
@@ -2071,6 +2077,8 @@ void usage()
            "  --client {vulkan<ver> | opengl<ver>}\n"
            "                                    see -V and -G\n"
            "  --depfile <file>                  writes depfile for build systems\n"
+           "  --discard-is-terminate            map GLSL discard to OpTerminateInvocation\n"
+           "                                    instead of OpDemoteToHelperInvocation\n"
            "  --dump-builtin-symbols            prints builtin symbol table prior each\n"
            "                                    compile\n"
            "  -dumpfullversion | -dumpversion   print bare major.minor.patchlevel\n"

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1818,6 +1818,7 @@ void TShader::setInvertY(bool invert)                   { intermediate->setInver
 void TShader::setDxPositionW(bool invert)               { intermediate->setDxPositionW(invert); }
 void TShader::setEnhancedMsgs()                         { intermediate->setEnhancedMsgs(); }
 void TShader::setNanMinMaxClamp(bool useNonNan)         { intermediate->setNanMinMaxClamp(useNonNan); }
+void TShader::setDiscardIsTerminate(bool discardIsTerminate) { intermediate->setDiscardIsTerminate(discardIsTerminate); }
 
 // Set binding base for given resource type
 void TShader::setShiftBinding(TResourceType res, unsigned int base) {

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -313,6 +313,7 @@ public:
         useStorageBuffer(false),
         invariantAll(false),
         nanMinMaxClamp(false),
+        discardIsTerminate(false),
         depthReplacing(false),
         stencilReplacing(false),
         uniqueId(0),
@@ -520,6 +521,14 @@ public:
         enhancedMsgs = true;
     }
     bool getEnhancedMsgs() const { return enhancedMsgs && getSource() == EShSourceGlsl; }
+
+    void setDiscardIsTerminate(bool discardIsTerminateP)
+    {
+        discardIsTerminate = discardIsTerminateP;
+        if (discardIsTerminate)
+            processes.addProcess("discard-is-terminate");
+    }
+    bool getDiscardIsTerminate() const { return discardIsTerminate; }
 
 #ifdef ENABLE_HLSL
     void setSource(EShSource s) { source = s; }
@@ -1258,6 +1267,7 @@ protected:
     bool useStorageBuffer;
     bool invariantAll;
     bool nanMinMaxClamp;            // true if desiring min/max/clamp to favor non-NaN over NaN
+    bool discardIsTerminate; // true if discard should be emitted as OpTerminateInvocation instead of OpDemoteToHelperInvocation
     bool depthReplacing;
     bool stencilReplacing;
     int localSize[3];

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -509,6 +509,7 @@ public:
 #endif
     void setNoStorageFormat(bool useUnknownFormat);
     void setNanMinMaxClamp(bool nanMinMaxClamp);
+    void setDiscardIsTerminate(bool discardIsTerminate);
     void setTextureSamplerTransformMode(EShTextureSamplerTransformMode mode);
     void addBlockStorageOverride(const char* nameStr, glslang::TBlockStorageClass backing);
 

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -49,6 +49,7 @@ if(GLSLANG_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/BuiltInResource.FromFile.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Common.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Config.FromFile.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/Discard.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/HexFloat.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Hlsl.FromFile.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Link.FromFile.cpp

--- a/gtests/Discard.cpp
+++ b/gtests/Discard.cpp
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 The Khronos Group Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of The Khronos Group Inc. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "TestFixture.h"
+#include "glslang/Public/ShaderLang.h"
+#include "SPIRV/GlslangToSpv.h"
+#include "SPIRV/disassemble.h"
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace glslangtest {
+
+class DiscardTest : public ::testing::Test {
+protected:
+    struct CompileResult {
+        bool success;
+        std::string spirvText;
+        std::string infoLog;
+    };
+
+    CompileResult compileGlsl(const std::string& source, glslang::EShTargetLanguageVersion spvVersion,
+                              bool discardIsTerminate)
+    {
+        const char* const src = source.c_str();
+
+        glslang::TShader shader(EShLangFragment);
+        shader.setStrings(&src, 1);
+        shader.setEnvInput(glslang::EShSourceGlsl, EShLangFragment, glslang::EShClientVulkan, 100);
+        shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_4);
+        shader.setEnvTarget(glslang::EShTargetSpv, spvVersion);
+        shader.setAutoMapBindings(true);
+        shader.setAutoMapLocations(true);
+        shader.setDiscardIsTerminate(discardIsTerminate);
+
+        const EShMessages msgs = static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules);
+        if (!shader.parse(GetDefaultResources(), 450, false, msgs)) {
+            return {false, "", shader.getInfoLog()};
+        }
+
+        glslang::TProgram program;
+        program.addShader(&shader);
+        if (!program.link(msgs)) {
+            return {false, "", program.getInfoLog()};
+        }
+
+        std::vector<uint32_t> spirv;
+        glslang::GlslangToSpv(*program.getIntermediate(EShLangFragment), spirv);
+
+        std::ostringstream dis;
+        spv::Disassemble(dis, spirv);
+        return {true, dis.str(), ""};
+    }
+
+    // Helper function to check if the given SPIR-V string contains a specific pattern.
+    static bool containsPattern(const std::string& spirvText, const std::string& pattern)
+    {
+        return spirvText.find(pattern) != std::string::npos;
+    }
+};
+
+static const char kSimpleFrag[] = R"glsl(
+#version 450
+uniform sampler2D tex;
+in vec2 texCoord;
+out vec4 outColor;
+void main() {
+    outColor = texture(tex, texCoord);
+    if (outColor.a == 0.0)
+        discard;
+}
+)glsl";
+
+TEST_F(DiscardTest, DiscardMappedToOpKill)
+{
+    const bool discardIsTerminate = false;
+    auto const r = compileGlsl(kSimpleFrag, glslang::EShTargetSpv_1_4, discardIsTerminate);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_TRUE(containsPattern(r.spirvText, "Kill"))
+        << "Expected OpKill in SPIR-V when SPIR-V version < 1.6 is used.\n"
+        << r.spirvText;
+    EXPECT_FALSE(containsPattern(r.spirvText, "DemoteToHelperInvocation"))
+        << "Did not expect OpDemoteToHelperInvocation in SPIR-V when SPIR-V version < 1.6 is used.\n"
+        << r.spirvText;
+    EXPECT_FALSE(containsPattern(r.spirvText, "TerminateInvocation"))
+        << "Did not expect OpTerminateInvocation in SPIR-V when SPIR-V version < 1.6 is used.\n"
+        << r.spirvText;
+}
+
+TEST_F(DiscardTest, DiscardMappedToOpDemoteToHelperInvocation)
+{
+    const bool discardIsTerminate = false;
+    auto const r = compileGlsl(kSimpleFrag, glslang::EShTargetSpv_1_6, discardIsTerminate);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_FALSE(containsPattern(r.spirvText, "Kill"))
+        << "Did not expect OpKill in SPIR-V when SPIR-V version >= 1.6 is used.\n"
+        << r.spirvText;
+    EXPECT_TRUE(containsPattern(r.spirvText, "DemoteToHelperInvocation"))
+        << "Expected OpDemoteToHelperInvocation in SPIR-V when setDiscardIsTerminate(false) is used.\n"
+        << r.spirvText;
+    EXPECT_FALSE(containsPattern(r.spirvText, "TerminateInvocation"))
+        << "Did not expect OpTerminateInvocation in SPIR-V when setDiscardIsTerminate(false) is used.\n"
+        << r.spirvText;
+}
+
+TEST_F(DiscardTest, DiscardMappedToOpTerminateInvocation)
+{
+    const bool discardIsTerminate = true;
+    auto const r = compileGlsl(kSimpleFrag, glslang::EShTargetSpv_1_6, discardIsTerminate);
+    ASSERT_TRUE(r.success) << r.infoLog;
+    EXPECT_FALSE(containsPattern(r.spirvText, "Kill"))
+        << "Did not expect OpKill in SPIR-V when SPIR-V version >= 1.6 is used.\n"
+        << r.spirvText;
+    EXPECT_FALSE(containsPattern(r.spirvText, "DemoteToHelperInvocation"))
+        << "Did not expect OpDemoteToHelperInvocation in SPIR-V when setDiscardIsTerminate(true) is used.\n"
+        << r.spirvText;
+    EXPECT_TRUE(containsPattern(r.spirvText, "TerminateInvocation"))
+        << "Expected OpTerminateInvocation in SPIR-V when setDiscardIsTerminate(true) is used.\n"
+        << r.spirvText;
+}
+
+} // namespace glslangtest


### PR DESCRIPTION
Adds an option to map discard to OpTerminateInvocation instead of OpDemoteToHelperInvocation.
(see issue #4081 for context)

Only affects GLSL input and SPIR-V >= 1.6.
The current behavior (emitting OpDemoteToHelperInvocation) is not changed, and remains the default.

I am not 100% convinced about the naming of the option and new public API method, so suggestions are welcome.

Also, was I supposed to add any documentation in the public header for the new API? (Similar methods do not seem to have any doc)