### PR TITLE
Don't use uninitialized stack values when parsing invalid swizzles.

### DIFF
--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -537,6 +537,7 @@ void TParseContextBase::parseSwizzleSelector(const TSourceLoc& loc, const TStrin
         exyzw,
         ergba,
         estpq,
+        ebadswizzle,
     } fieldSet[MaxSwizzleSelectors];
 
     // Decode the swizzle string.
@@ -596,13 +597,19 @@ void TParseContextBase::parseSwizzleSelector(const TSourceLoc& loc, const TStrin
             break;
 
         default:
-            error(loc, "unknown swizzle selection", compString.c_str(), "");
+            fieldSet[i] = ebadswizzle;
             break;
         }
     }
 
     // Additional error checking.
     for (int i = 0; i < selector.size(); ++i) {
+        if (fieldSet[i] == ebadswizzle) {
+            error(loc, "unknown swizzle selection", compString.c_str(), "");
+            selector.resize(i);
+            break;
+        }
+
         if (selector[i] >= vecSize) {
             error(loc, "vector swizzle selection out of range",  compString.c_str(), "");
             selector.resize(i);


### PR DESCRIPTION
Related to issue #4281, this at least removes the use of uninitialized stack memory.