### PR TITLE
kokoro: update license-check.cfg to allow REUSE license updates

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -15,6 +15,7 @@
 
                     "_config.yml",
                     ".*",
+                    ".*/**",
                     ".github/workflows/*.yml",
                     ".github/workflows/*.js",
                     ".jj/**",
@@ -23,6 +24,9 @@
                     "known_good.json",
                     "LICENSE.txt",
                     "make-revision",
+                    "standalone.gclient_entries",
+                    "LICENSES/*",
+                    "REUSE.toml",
                     "WORKSPACE",
 
                     "glslang/OSDependent/Web/glslang.*.js",


### PR DESCRIPTION
See changes in PR #4256

This updates the license check configuration file to ignore the license check for the license file metadata itself. Also exclude local temporary files in .jj and .cipd, which helps me with my local testing.