### PR TITLE
fix out-of-bounds read on short matrix swizzle in parseMatrixSwizzleSelector

### DIFF
--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -581,8 +581,8 @@ bool HlslParseContext::parseMatrixSwizzleSelector(const TSourceLoc& loc, const T
                 error(loc, "matrix component swizzle has too many components", compString.c_str(), "");
                 return false;
             }
-            if (c > compString.size() - 3 ||
-                    ((compString[c+1] == 'm' || compString[c+1] == 'M') && c > compString.size() - 4)) {
+            if (c + 3 > compString.size() ||
+                    ((compString[c+1] == 'm' || compString[c+1] == 'M') && c + 4 > compString.size())) {
                 error(loc, "matrix component swizzle missing", compString.c_str(), "");
                 return false;
             }


### PR DESCRIPTION
libc++ hardening, compiling HLSL `return m._;` (or `m._m`) on a float4x4:

    string:1340: libc++ Hardening assertion __pos <= size() failed: string index out of bounds

The length guard in parseMatrixSwizzleSelector uses `c > compString.size() - 3` (and `- 4` for the `_m` form). compString.size() is size_t, so when the swizzle field is shorter than the constant the subtraction wraps to a huge value and the check passes. The per-component loop then reads compString[pos+1] past the end of the field. Switching the comparisons to the addition form rejects the short swizzle before the read. Valid swizzles like `_m00`/`_11` are unaffected.