### PR TITLE
fix out-of-bounds read on empty block in layoutObjectCheck

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -7767,7 +7767,8 @@ void TParseContext::layoutObjectCheck(const TSourceLoc& loc, const TSymbol& symb
         case EvqVaryingOut:
             if (!type.getQualifier().isTaskMemory() && !type.getQualifier().hasSpirvDecorate() &&
                 (type.getBasicType() != EbtBlock ||
-                 (!(*type.getStruct())[0].type->getQualifier().hasLocation() &&
+                 (type.getStruct()->size() > 0 &&
+                  !(*type.getStruct())[0].type->getQualifier().hasLocation() &&
                    (*type.getStruct())[0].type->getQualifier().builtIn == EbvNone)))
                 error(loc, "SPIR-V requires location for user input/output", "location", "");
             break;


### PR DESCRIPTION
ASan, Vulkan/SPIR-V target, tessellation-control stage:

    ParseHelper.cpp:7770: container-overflow ... layoutObjectCheck
    READ of size 8 ... (*type.getStruct())[0]

Redeclaring a built-in block with an instance name and members that don't match
the originals erases every original member (the instance-name erase in
redeclareBuiltinBlock), so the block is left with an empty member list.
layoutObjectCheck then reads member [0] to inspect its location qualifier, past
the end of an empty list. Skip the member check when the block has no members.

Repro:

    #version 450
    in gl_PerVertex {
        float bad;
    } gl_in[];
    void main() {}

compiled for a tesc stage with a Vulkan target.