### PR TITLE
fix oob read on empty struct texture template type

### DIFF
--- a/glslang/HLSL/hlslGrammar.cpp
+++ b/glslang/HLSL/hlslGrammar.cpp
@@ -1211,7 +1211,8 @@ bool HlslGrammar::acceptSubpassInputType(TType& type)
         }
     }
 
-    const TBasicType subpassBasicType = subpassType.isStruct() ? (*subpassType.getStruct())[0].type->getBasicType()
+    const TBasicType subpassBasicType = (subpassType.isStruct() && !subpassType.getStruct()->empty())
+        ? (*subpassType.getStruct())[0].type->getBasicType()
         : subpassType.getBasicType();
 
     TSampler sampler;
@@ -1436,7 +1437,8 @@ bool HlslGrammar::acceptTextureType(TType& type)
     if (image || dim == EsdBuffer)
         format = parseContext.getLayoutFromTxType(token.loc, txType);
 
-    const TBasicType txBasicType = txType.isStruct() ? (*txType.getStruct())[0].type->getBasicType()
+    const TBasicType txBasicType = (txType.isStruct() && !txType.getStruct()->empty())
+        ? (*txType.getStruct())[0].type->getBasicType()
         : txType.getBasicType();
 
     // Non-image Buffers are combined


### PR DESCRIPTION
1. acceptTextureType and acceptSubpassInputType read member [0] of the template return-type struct guarded only by isStruct().
2. an empty struct written as the template argument, e.g. `Texture2D<struct {}>` or `SubpassInput<struct {}>`, has a zero-length member list, so (*type.getStruct())[0].type dereferences past the empty vector and segfaults before setTextureReturnType runs the member-count check that would reject it.
Added a non-empty check at both sites so an empty template struct falls through to that existing validation.