### PR TITLE
fix elseSeen out-of-bounds at maximum #if/#ifdef nesting depth

### DIFF
--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -634,7 +634,7 @@ int TPpContext::CPPif(TPpToken* ppToken)
 int TPpContext::CPPifdef(int defined, TPpToken* ppToken)
 {
     int token = scanToken(ppToken);
-    if (ifdepth > maxIfNesting || elsetracker > maxIfNesting) {
+    if (ifdepth >= maxIfNesting || elsetracker >= maxIfNesting) {
         parseContext.ppError(ppToken->loc, "maximum nesting depth exceeded", "#ifdef", "");
         return EndOfInput;
     } else {

--- a/glslang/MachineIndependent/preprocessor/PpContext.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpContext.cpp
@@ -92,7 +92,7 @@ TPpContext::TPpContext(TParseContextBase& pc, const std::string& rootFileName, T
     inElseSkip(false)
 {
     ifdepth = 0;
-    for (elsetracker = 0; elsetracker < maxIfNesting; elsetracker++)
+    for (elsetracker = 0; elsetracker <= maxIfNesting; elsetracker++)
         elseSeen[elsetracker] = false;
     elsetracker = 0;
 

--- a/glslang/MachineIndependent/preprocessor/PpContext.h
+++ b/glslang/MachineIndependent/preprocessor/PpContext.h
@@ -393,9 +393,9 @@ protected:
 
     static const int maxIfNesting = 65;
 
-    int ifdepth;                  // current #if-#else-#endif nesting in the cpp.c file (pre-processor)
-    bool elseSeen[maxIfNesting];  // Keep a track of whether an else has been seen at a particular depth
-    int elsetracker;              // #if-#else and #endif constructs...Counter.
+    int ifdepth;                      // current #if-#else-#endif nesting in the cpp.c file (pre-processor)
+    bool elseSeen[maxIfNesting + 1];  // Keep a track of whether an else has been seen at a particular depth
+    int elsetracker;                  // #if-#else and #endif constructs...Counter.
 
     class tMacroInput : public tInput {
     public:


### PR DESCRIPTION
UBSan, clang -fsanitize=bounds, on a shader with maxIfNesting (65) nested #if followed by #endif:

    Pp.cpp:1001:17: runtime error: index 65 out of bounds for type 'bool[65]'

elseSeen is sized maxIfNesting, but ifdepth/elsetracker reach maxIfNesting before further nesting is rejected: CPPif and CPPelse compare with >=, so the deepest accepted level equals maxIfNesting, and CPPifdef compared with > let it climb one higher still. elseSeen[elsetracker] at the deepest #if/#ifdef/#else/#elif/#endif then reads and writes one (or two for #ifdef) past the end. Size the array for the full 0..maxIfNesting range, initialize the added slot, and bring the #ifdef bound in line with #if.