### PR TITLE
cmake: Install glslang.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,5 +454,5 @@ if (GLSLANG_ENABLE_INSTALL)
         "${CMAKE_CURRENT_BINARY_DIR}/glslang.pc"
         @ONLY
     )
-    install(CODE "configure_file(\"${CMAKE_CURRENT_BINARY_DIR}/glslang.pc\" \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/glslang.pc\"  @ONLY) ")
+    install(CODE "cmake_path(ABSOLUTE_PATH CMAKE_INSTALL_PREFIX NORMALIZE OUTPUT_VARIABLE ABS_INSTALL_PREFIX)\nconfigure_file(\"${CMAKE_CURRENT_BINARY_DIR}/glslang.pc\" \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/glslang.pc\"  @ONLY) ")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,9 @@ if (GLSLANG_ENABLE_INSTALL)
         @INSTALL_CONFIG_UNIX@
         include("@PACKAGE_PATH_EXPORT_TARGETS@")
     ]=])
+    if (ENABLE_OPT)
+        set(GLSLANG_PRIVATE_LIBS "-lSPIRV-Tools-opt")
+    endif()
 
     set(PATH_EXPORT_TARGETS "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake")
     if(UNIX OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Fuchsia")
@@ -403,6 +406,7 @@ if (GLSLANG_ENABLE_INSTALL)
             set(THREADS_PREFER_PTHREAD_FLAG ON)
             find_dependency(Threads)
         ]=])
+        set(GLSLANG_PRIVATE_LIBS "${GLSLANG_PRIVATE_LIBS} -lpthread")
     endif()
     configure_package_config_file(
         "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in"
@@ -430,4 +434,25 @@ if (GLSLANG_ENABLE_INSTALL)
         DESTINATION
             "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
     )
+
+    # Don't install glslang.pc on Windows.
+    # See Test/find_package/CMakeLists.txt for full reasoning.
+    if (WIN32)
+        return()
+    endif()
+
+    # CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_INCLUDEDIR can be absolute paths or relative.
+    cmake_path(APPEND CMAKE_INSTALL_LIBDIR_PC "\${exec_prefix}" ${CMAKE_INSTALL_LIBDIR})
+    cmake_path(APPEND CMAKE_INSTALL_INCLUDEDIR_PC "\${prefix}" ${CMAKE_INSTALL_INCLUDEDIR})
+    # The substitutions in glslang.pc.in are run twice, the first time at configure time
+    # for most of the variables, and the second at install time once the actual
+    # CMAKE_INSTALL_PREFIX is known. To protect the latter we need something that expands
+    # a literal @ sign.
+    set(AT "@")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/glslang/glslang.pc.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/glslang.pc"
+        @ONLY
+    )
+    install(CODE "configure_file(\"${CMAKE_CURRENT_BINARY_DIR}/glslang.pc\" \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/glslang.pc\"  @ONLY) ")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,5 +454,8 @@ if (GLSLANG_ENABLE_INSTALL)
         "${CMAKE_CURRENT_BINARY_DIR}/glslang.pc"
         @ONLY
     )
-    install(CODE "cmake_path(ABSOLUTE_PATH CMAKE_INSTALL_PREFIX NORMALIZE OUTPUT_VARIABLE ABS_INSTALL_PREFIX)\nconfigure_file(\"${CMAKE_CURRENT_BINARY_DIR}/glslang.pc\" \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/glslang.pc\"  @ONLY) ")
+    install(CODE "\
+        message(STATUS \"Installing \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/glslang.pc\")
+        cmake_path(ABSOLUTE_PATH CMAKE_INSTALL_PREFIX NORMALIZE OUTPUT_VARIABLE ABS_INSTALL_PREFIX)
+        configure_file(\"${CMAKE_CURRENT_BINARY_DIR}/glslang.pc\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/glslang.pc\"  @ONLY) ")
 endif()

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -35,6 +35,7 @@ path = [
     "build_overrides/build.gni",
     "build_overrides/spirv_tools.gni",
     "glslang/CMakeLists.txt",
+    "glslang/glslang.pc.in",
     "glslang/OSDependent/Unix/CMakeLists.txt",
     "glslang/OSDependent/Web/CMakeLists.txt",
     "glslang/OSDependent/Windows/CMakeLists.txt",

--- a/Test/find_package/CMakeLists.txt
+++ b/Test/find_package/CMakeLists.txt
@@ -75,3 +75,46 @@ if (target_type STREQUAL STATIC_LIBRARY)
         COMMAND glslang::glslang-standalone --version
     )
 endif()
+
+# Ensure glslang.pc was installed
+find_file(glslang_PC glslang.pc PATH_SUFFIXES lib/pkgconfig)
+
+# NOTE: Windows cannot ship a single reliable glslang.pc
+#
+# pkg-config simply doesn't have a way to handle binaries having
+# different names based on the configuration. While CMake configuration files
+# do support multi-config.
+# https://github.com/microsoft/vcpkg/discussions/37570
+#
+# IE: glslangd.lib vs glslang.lib
+#
+# The debug binaries have a different name on Windows.
+#
+# CMAKE_DEBUG_POSTFIX has been part of the codebase since 2016 changing it WILL break someone.
+# https://github.com/KhronosGroup/glslang/issues/310
+if (WIN32)
+    if (EXISTS ${glslang_PC})
+        message(FATAL_ERROR "glslang.pc invalid on Windows")
+    endif()
+
+    return()
+endif()
+
+# Use CMake itself to verify the pc file.
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.31")
+    cmake_pkg_config(EXTRACT ${glslang_PC} REQUIRED STRICTNESS "STRICT")
+
+    # Ensure glslang.pc matches up with cmake packaging
+    if (NOT (CMAKE_PKG_CONFIG_VERSION VERSION_EQUAL glslang_VERSION))
+        message(FATAL_ERROR "${CMAKE_PKG_CONFIG_VERSION} != ${glslang_VERSION}")
+    endif()
+endif()
+
+# Additional sanity check the glslang.pc is correct.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(glslang REQUIRED IMPORTED_TARGET glslang)
+
+add_library(stub_pc STATIC stub.cpp)
+target_link_libraries(example PRIVATE
+    PkgConfig::glslang
+)

--- a/Test/find_package/CMakeLists.txt
+++ b/Test/find_package/CMakeLists.txt
@@ -38,7 +38,7 @@ project(FP_TEST LANGUAGES C CXX)
 
 # Assume the user install here to simplify CI
 # It also makes local testing easier.
-list(APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/../../build/install")
+set(CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/../../build/install")
 find_package(glslang REQUIRED CONFIG)
 
 if (NOT DEFINED glslang_VERSION)
@@ -113,8 +113,13 @@ endif()
 # Additional sanity check the glslang.pc is correct.
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(glslang REQUIRED IMPORTED_TARGET glslang)
+pkg_check_modules(SPIRV-Tools REQUIRED IMPORTED_TARGET SPIRV-Tools)
 
-add_library(stub_pc STATIC stub.cpp)
-target_link_libraries(example PRIVATE
+add_executable(example_pc example.c)
+set_target_properties(example_pc PROPERTIES LINKER_LANGUAGE CXX)
+
+target_link_libraries(example_pc PRIVATE
+    PkgConfig::SPIRV-Tools
     PkgConfig::glslang
+    glslang::glslang-default-resource-limits
 )

--- a/glslang/glslang.pc.in
+++ b/glslang/glslang.pc.in
@@ -1,3 +1,6 @@
+# Copyright 2026 The Khronos Group Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
 prefix=@AT@ABS_INSTALL_PREFIX@AT@
 exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_LIBDIR_PC@

--- a/glslang/glslang.pc.in
+++ b/glslang/glslang.pc.in
@@ -1,4 +1,4 @@
-prefix=@AT@CMAKE_INSTALL_PREFIX@AT@
+prefix=@AT@ABS_INSTALL_PREFIX@AT@
 exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_LIBDIR_PC@
 includedir=@CMAKE_INSTALL_INCLUDEDIR_PC@

--- a/glslang/glslang.pc.in
+++ b/glslang/glslang.pc.in
@@ -1,0 +1,11 @@
+prefix=@AT@CMAKE_INSTALL_PREFIX@AT@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_LIBDIR_PC@
+includedir=@CMAKE_INSTALL_INCLUDEDIR_PC@
+
+Name: glslang
+Description: Khronos-reference front end for GLSL/ESSL, partial front end for HLSL, and a SPIR-V generator.
+Version: @GLSLANG_VERSION@
+Cflags: -I${includedir}
+Libs.private: @GLSLANG_PRIVATE_LIBS@
+Libs: -L${libdir} -lglslang

--- a/glslang/glslang.pc.in
+++ b/glslang/glslang.pc.in
@@ -1,3 +1,26 @@
+# Copyright 2026 The Khronos Group Inc.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 prefix=@AT@ABS_INSTALL_PREFIX@AT@
 exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_LIBDIR_PC@


### PR DESCRIPTION
Installs glslang.pc on all platforms except for Windows.

See Test/find_package/CMakeLists.txt for full explanation.

closes #1715