### PR TITLE
Generate error when trying to use literal string in constructor

### DIFF
--- a/Test/baseResults/spv.intrinsicsStringConstructorError.vert.out
+++ b/Test/baseResults/spv.intrinsicsStringConstructorError.vert.out
@@ -1,0 +1,12 @@
+spv.intrinsicsStringConstructorError.vert
+ERROR: 0:8: 'constructor' : cannot convert a string 
+ERROR: 0:8: '=' :  cannot convert from ' const float' to ' temp highp uint'
+ERROR: 0:9: 'constructor' : cannot convert a string 
+ERROR: 0:9: '=' :  cannot convert from ' const float' to ' temp highp int'
+ERROR: 0:10: 'constructor' : cannot convert a string 
+ERROR: 0:11: 'constructor' : cannot convert a string 
+ERROR: 0:11: '=' :  cannot convert from ' const float' to ' temp highp 2-component vector of uint'
+ERROR: 7 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.intrinsicsStringConstructorError.vert
+++ b/Test/spv.intrinsicsStringConstructorError.vert
@@ -1,0 +1,12 @@
+#version 460
+
+#extension GL_EXT_spirv_intrinsics : enable
+
+void main()
+{
+    // A string literal is not a valid numeric constructor argument.
+    uint u = uint("foo");
+    int i = int("bar");
+    float f = float("baz");
+    uvec2 v = uvec2(1u, "qux");
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -4580,6 +4580,10 @@ bool TParseContext::constructorError(const TSourceLoc& loc, TIntermNode* node, T
             }
             arrayArg = true;
         }
+        if (function[arg].type->getBasicType() == EbtString) {
+            error(loc, "cannot convert a string", constructorString.c_str(), "");
+            return true;
+        }
         if (constructingMatrix && function[arg].type->isMatrix())
             matrixInMatrix = true;
 

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -472,6 +472,7 @@ INSTANTIATE_TEST_SUITE_P(
         "spv.intrinsicsSpirvType.rgen",
         "spv.intrinsicsSpirvTypeLocalVar.vert",
         "spv.intrinsicsSpirvTypeWithTypeSpecifier.vert",
+        "spv.intrinsicsStringConstructorError.vert",
         "spv.invariantAll.vert",
         "spv.layer.tese",
         "spv.layoutNested.vert",


### PR DESCRIPTION
Trying to use a literal string in a constructor (eg. `uint("blah")`) would not cause an error, but cause undefined behaviour / random constants to be generated. This displays an error message instead.

The fix should be uncontroversial; as far as I'm aware, there are no extensions permitting strings to be used as expressions, much less as constructor arguments.

This was the only path that suffered from this issue that I identified. Assignments, invalid use in expressions, etc. of literal strings already resulted in an error.

Fixes #4293