### PR TITLE
fix out-of-bounds localSize write on over-long numthreads

### DIFF
--- a/Test/baseResults/hlsl.numthreads.negative.comp.out
+++ b/Test/baseResults/hlsl.numthreads.negative.comp.out
@@ -1,0 +1,44 @@
+hlsl.numthreads.negative.comp
+ERROR: 0:3: 'numthreads' : expected at most three arguments 
+ERROR: 1 compilation errors.  No code generated.
+
+
+Shader version: 500
+local_size = (1, 1, 1)
+ERROR: node is still EOpNull!
+0:3  Function Definition: @main(vu3; ( temp void)
+0:3    Function Parameters: 
+0:3      'tid' ( in 3-component vector of uint)
+0:3  Function Definition: main( ( temp void)
+0:3    Function Parameters: 
+0:?     Sequence
+0:3      move second child to first child ( temp 3-component vector of uint)
+0:?         'tid' ( temp 3-component vector of uint)
+0:?         'tid' ( in 3-component vector of uint GlobalInvocationID)
+0:3      Function Call: @main(vu3; ( temp void)
+0:?         'tid' ( temp 3-component vector of uint)
+0:?   Linker Objects
+0:?     'tid' ( in 3-component vector of uint GlobalInvocationID)
+
+
+Linked compute stage:
+
+
+Shader version: 500
+local_size = (1, 1, 1)
+ERROR: node is still EOpNull!
+0:3  Function Definition: @main(vu3; ( temp void)
+0:3    Function Parameters: 
+0:3      'tid' ( in 3-component vector of uint)
+0:3  Function Definition: main( ( temp void)
+0:3    Function Parameters: 
+0:?     Sequence
+0:3      move second child to first child ( temp 3-component vector of uint)
+0:?         'tid' ( temp 3-component vector of uint)
+0:?         'tid' ( in 3-component vector of uint GlobalInvocationID)
+0:3      Function Call: @main(vu3; ( temp void)
+0:?         'tid' ( temp 3-component vector of uint)
+0:?   Linker Objects
+0:?     'tid' ( in 3-component vector of uint GlobalInvocationID)
+
+SPIR-V is not generated for failed compile or link

--- a/Test/hlsl.numthreads.negative.comp
+++ b/Test/hlsl.numthreads.negative.comp
@@ -1,0 +1,4 @@
+[numthreads(1,1,1,1)]
+void main(uint3 tid : SV_DispatchThreadID )
+{
+}

--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -1755,6 +1755,12 @@ void HlslParseContext::handleEntryPointAttributes(const TSourceLoc& loc, const T
         case EatNumThreads:
         {
             const TIntermSequence& sequence = it->args->getSequence();
+            // numthreads has three dimensions (x, y, z); localSize is sized to match,
+            // so reject extra arguments rather than indexing past it.
+            if (sequence.size() > 3) {
+                error(loc, "expected at most three arguments", "numthreads", "");
+                break;
+            }
             for (int lid = 0; lid < int(sequence.size()); ++lid)
                 intermediate.setLocalSize(lid, sequence[lid]->getAsConstantUnion()->getConstArray()[0].getIConst());
             break;

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -342,6 +342,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.numericsuffixes.frag", "main"},
         {"hlsl.numericsuffixes.negative.frag", "main"},
         {"hlsl.numthreads.comp", "main_aux2"},
+        {"hlsl.numthreads.negative.comp", "main"},
         {"hlsl.overload.frag", "PixelShaderFunction"},
         {"hlsl.opaque-type-bug.frag", "main"},
         {"hlsl.params.default.frag", "main"},


### PR DESCRIPTION
The HLSL numthreads attribute handler in handleEntryPointAttributes walks the attribute's argument list and calls setLocalSize(lid, ...) once per argument, with lid running up to the argument count. localSize is a three element array for the x, y and z workgroup dimensions, and setLocalSize does not range check its dim argument. The attribute grammar puts no limit on how many comma separated expressions a shader can pass, so a compute entry point declared with [numthreads(1,1,1,1)] or more begins writing at localSize[3] and keeps going. With a long enough argument list it runs off the end of the TIntermediate allocation entirely; asan reports a heap-buffer-overflow read and write from setLocalSize while parsing such a shader. numthreads only ever has three dimensions, so I clamp the loop to three and let any extra arguments fall away. Valid three argument shaders produce identical SPIR-V and the HLSL test suite is unchanged.