### PR TITLE
Remove Block decoration from descriptor heap image wrappers

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -6382,18 +6382,6 @@ spv::Id TGlslangToSpvTraverser::convertGlslangStructToSpvType(const glslang::TTy
 
     // Decorate it
     if (useDescHeapIdDecorations) {
-        // Only the top-level heap layout struct represents a resourceheap/samplerheap block.
-        // If its last member is a runtime array, Vulkan still requires the struct type to
-        // carry Block/BufferBlock; nested heap member structs should not get this decoration.
-        const bool isTopLevelHeapStruct =
-            qualifier.storage == glslang::EvqResourceHeap ||
-            qualifier.storage == glslang::EvqSamplerHeap;
-        if (isTopLevelHeapStruct && glslangIntermediate->getSpv().vulkan > 0 && !spvMembers.empty() &&
-            builder.getOpCode(spvMembers.back()) == spv::Op::OpTypeRuntimeArray) {
-            builder.addDecoration(spvType, TranslateBlockDecoration(qualifier.storage,
-                                  glslangIntermediate->usingStorageBuffer()));
-        }
-
         assert(descHeapMemberOffsets.size() == glslangMembers->size());
         for (int member = 0; member < (int)glslangMembers->size() && member < (int)spvMembers.size(); ++member) {
             glslang::TType& glslangMember = *(*glslangMembers)[member].type;
@@ -6932,9 +6920,12 @@ void TGlslangToSpvTraverser::decorateStructType(const glslang::TType& type,
     builder.addDecoration(spvType, TranslateLayoutDecoration(type, qualifier.layoutMatrix));
     const auto basicType = type.getBasicType();
     const auto typeStorageQualifier = type.getQualifier().storage;
-    if (basicType == glslang::EbtBlock || qualifier.isBufferType()) {
+    const bool skipBlockDecoration = type.getQualifier().descriptorHeapDescriptorNode ||
+        type.getQualifier().storage == glslang::EvqResourceHeap;
+
+    if ((basicType == glslang::EbtBlock || qualifier.isBufferType()) && !skipBlockDecoration) {
         builder.addDecoration(spvType, TranslateBlockDecoration(typeStorageQualifier, glslangIntermediate->usingStorageBuffer()));
-    } else if (basicType == glslang::EbtStruct && glslangIntermediate->getSpv().vulkan > 0) {
+    } else if ((basicType == glslang::EbtStruct && glslangIntermediate->getSpv().vulkan > 0) && !skipBlockDecoration) {
         const auto hasRuntimeArray = !spvMembers.empty() && builder.getOpCode(spvMembers.back()) == spv::Op::OpTypeRuntimeArray;
         if (hasRuntimeArray) {
             builder.addDecoration(spvType, TranslateBlockDecoration(typeStorageQualifier, glslangIntermediate->usingStorageBuffer()));

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -2451,7 +2451,6 @@ spv::Id TGlslangToSpvTraverser::makeDescHeapImageArrayWrapperType(const glslang:
     spv::Id wrapperType = builder.makeStructType(members, {}, wrapperName.c_str(), false);
 
     builder.addMemberName(wrapperType, 0, symbol.getName().c_str());
-    builder.addDecoration(wrapperType, spv::Decoration::Block);
     builder.addMemberDecorationIdEXT(wrapperType, 0, spv::Decoration::OffsetIdEXT, {memberOffset});
 
     if (qualifier.isReadOnly())

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -251,7 +251,7 @@ protected:
     spv::LinkageType convertGlslangLinkageToSpv(glslang::TLinkType glslangLinkType);
     bool isDescHeapDescriptorType(const glslang::TType& type) const;
     bool containsDescHeapDescriptorType(const glslang::TType& type) const;
-    spv::Id makeDescHeapImageArrayWrapperType(const glslang::TIntermSymbol& symbol, spv::Id arrayType);
+    spv::Id getDescHeapAccessChainBaseType(const glslang::TIntermSymbol& symbol, bool& imageArrayWrapped);
 
     void decorateStructType(const glslang::TType&, const glslang::TTypeList* glslangStruct, glslang::TLayoutPacking,
                             const glslang::TQualifier&, spv::Id, const std::vector<spv::Id>& spvMembers);
@@ -2377,27 +2377,11 @@ void TGlslangToSpvTraverser::visitSymbol(glslang::TIntermSymbol* symbol)
         if (qualifier.builtIn == glslang::EbvResourceHeapEXT ||
             qualifier.builtIn == glslang::EbvSamplerHeapEXT) {
             const glslang::TType& symbolType = symbol->getType();
-            // Direct descriptor-heap image arrays have no variable or member to
-            // carry NonReadable/NonWritable, so wrap them in a one-member block.
-            const bool wrapDescHeapImageArray =
-                symbolType.getQualifier().layoutDescriptorHeap &&
-                symbolType.isArray() &&
-                symbolType.isImage() &&
-                (symbolType.getQualifier().isReadOnly() || symbolType.getQualifier().isWriteOnly());
-
             if (builder.getAccessChainDescHeapBaseType() == spv::NoResult) {
-                const long long symbolId = symbol->getId();
-                auto cachedBaseType = heapDescHeapBaseType.find(symbolId);
-                if (cachedBaseType == heapDescHeapBaseType.end()) {
-                    spv::Id baseType = convertGlslangToSpvType(symbolType);
-                    if (wrapDescHeapImageArray)
-                        baseType = makeDescHeapImageArrayWrapperType(*symbol, baseType);
-                    cachedBaseType = heapDescHeapBaseType.emplace(symbolId, baseType).first;
-                }
-                builder.setAccessChainDescHeapBaseType(cachedBaseType->second);
+                bool imageArrayWrapped = false;
+                spv::Id baseType = getDescHeapAccessChainBaseType(*symbol, imageArrayWrapped);
+                builder.setAccessChainDescHeapBaseType(baseType, imageArrayWrapped);
             }
-            if (wrapDescHeapImageArray)
-                builder.accessChainPushDescHeapIndex(builder.makeIntConstant(0));
             spv::Id heapOffset = makeHeapOffsetId(symbolType);
             if (heapOffset != spv::NoResult)
                 builder.setAccessChainDescHeapBaseOffset(heapOffset);
@@ -2439,26 +2423,30 @@ void TGlslangToSpvTraverser::visitSymbol(glslang::TIntermSymbol* symbol)
 #endif
 }
 
-// Create a one-member heap block so image memory qualifiers can be expressed as
-// legal member decorations instead of decorating an OpLoad result.
-spv::Id TGlslangToSpvTraverser::makeDescHeapImageArrayWrapperType(const glslang::TIntermSymbol& symbol,
-                                                                  spv::Id arrayType)
+// Return the type used as the base type of a descriptor-heap access chain.
+// Also report whether each element of a direct image array is wrapped in a struct,
+// so access-chain construction can select member 0 of that struct.
+spv::Id TGlslangToSpvTraverser::getDescHeapAccessChainBaseType(
+    const glslang::TIntermSymbol& symbol, bool& imageArrayWrapped)
 {
-    const glslang::TQualifier& qualifier = symbol.getType().getQualifier();
-    spv::Id memberOffset = builder.makeUintConstant(0);
-    const std::vector<spv::Id> members = { arrayType };
-    const std::string wrapperName = std::string(symbol.getName().c_str()) + "_heap";
-    spv::Id wrapperType = builder.makeStructType(members, {}, wrapperName.c_str(), false);
+    const glslang::TType& symbolType = symbol.getType();
+    imageArrayWrapped =
+        symbolType.getQualifier().layoutDescriptorHeap &&
+        symbolType.isArray() &&
+        symbolType.isImage() &&
+        (symbolType.getQualifier().isReadOnly() || symbolType.getQualifier().isWriteOnly());
 
-    builder.addMemberName(wrapperType, 0, symbol.getName().c_str());
-    builder.addMemberDecorationIdEXT(wrapperType, 0, spv::Decoration::OffsetIdEXT, {memberOffset});
+    const long long symbolId = symbol.getId();
+    auto cachedBaseType = heapDescHeapBaseType.find(symbolId);
+    if (cachedBaseType == heapDescHeapBaseType.end()) {
+        spv::Id baseType = convertGlslangToSpvType(symbolType);
+        if (symbolType.isArray())
+            builder.addName(baseType, symbol.getName().c_str());
 
-    if (qualifier.isReadOnly())
-        builder.addMemberDecoration(wrapperType, 0, spv::Decoration::NonWritable);
-    if (qualifier.isWriteOnly())
-        builder.addMemberDecoration(wrapperType, 0, spv::Decoration::NonReadable);
+        cachedBaseType = heapDescHeapBaseType.emplace(symbolId, baseType).first;
+    }
 
-    return wrapperType;
+    return cachedBaseType->second;
 }
 
 // Create new untyped access chain instruction to descriptor heap, based on EXT_descriptor_heap extension.
@@ -2469,6 +2457,10 @@ void TGlslangToSpvTraverser::recordDescHeapAccessChainInfo(glslang::TIntermBinar
     if (node->getQualifier().layoutDescriptorHeap) {
         if (builder.hasAccessChainIndex())
             builder.moveAccessChainIndexToDescHeapIndexChain();
+
+        // If the final image is wrapped in a struct, append index 0 to select the image member.
+        if (builder.isAccessChainDescHeapImageArrayWrapped() && !node->getType().isArray())
+            builder.accessChainPushDescHeapIndex(builder.makeIntConstant(0));
     }
 
     // Descriptor leaf nodes need the real resource type for later untyped loads.
@@ -6095,6 +6087,27 @@ spv::Id TGlslangToSpvTraverser::convertGlslangToSpvType(const glslang::TType& ty
         if (type.getQualifier().layoutDescriptorHeap && containsDescHeapDescriptorType(type)) {
             std::vector<spv::Id> arrayStrides = descHeapLayout.getOrCreateArrayStrides(type);
             assert((int)arrayStrides.size() == type.getArraySizes()->getNumDims());
+
+            const glslang::TQualifier& descHeapQualifier = type.getQualifier();
+            const bool wrapDescHeapImageArray = type.isImage() &&
+                (descHeapQualifier.isReadOnly() || descHeapQualifier.isWriteOnly());
+            if (wrapDescHeapImageArray) {
+                // Descriptor-heap images have no memory object declaration on which to place
+                // NonReadable or NonWritable. Wrap each image in a struct so the restriction
+                // can be expressed as a member decoration.
+                const spv::Id zero = builder.makeUintConstant(0);
+                const std::vector<spv::Id> members = { spvType };
+                const char* wrapperName =
+                    descHeapQualifier.isReadOnly() ? "readonly_image_wrapper" : "writeonly_image_wrapper";
+                spvType = builder.makeStructType(members, {}, wrapperName, true);
+                builder.addMemberDecorationIdEXT(
+                    spvType, 0, spv::Decoration::OffsetIdEXT, {zero});
+                if (descHeapQualifier.isReadOnly())
+                    builder.addMemberDecoration(spvType, 0, spv::Decoration::NonWritable);
+                if (descHeapQualifier.isWriteOnly())
+                    builder.addMemberDecoration(spvType, 0, spv::Decoration::NonReadable);
+            }
+
             int strideIndex = 0;
 
             for (int dim = type.getArraySizes()->getNumDims() - 1; dim > 0; --dim) {

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -4586,6 +4586,7 @@ void Builder::clearAccessChain()
     accessChain.descHeapInfo.descHeapBaseTy = NoResult;
     accessChain.descHeapInfo.descHeapBaseOffset = NoResult;
     accessChain.descHeapInfo.descHeapIndexChain.clear();
+    accessChain.descHeapInfo.descHeapImageArrayWrapped = false;
     accessChain.descHeapInfo.descTy = NoResult;
     accessChain.descHeapInfo.descStorageClass = StorageClass::Max;
     accessChain.descHeapInfo.descReadonly = false;

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -826,6 +826,7 @@ public:
             Id descHeapBaseTy;                  // for descriptor heap, record its base data type.
             Id descHeapBaseOffset;              // byte offset applied to the heap base before descriptor lookup.
             std::vector<Id> descHeapIndexChain;
+            bool descHeapImageArrayWrapped;     // the base type wraps each image array element in a struct.
             Id descTy;                          // for target resource type
             StorageClass descStorageClass;      // for descriptor heap, record its basic storage class.
             bool descReadonly;                  // for decorating OpBufferPointerEXT results.
@@ -900,7 +901,15 @@ public:
 
     // for EXT_descriptor_heap and EXT_structured_descriptor_heap
     Id getAccessChainDescHeapBaseType() const { return accessChain.descHeapInfo.descHeapBaseTy; }
-    void setAccessChainDescHeapBaseType(Id baseType) { accessChain.descHeapInfo.descHeapBaseTy = baseType; }
+    void setAccessChainDescHeapBaseType(Id baseType, bool imageArrayWrapped = false)
+    {
+        accessChain.descHeapInfo.descHeapBaseTy = baseType;
+        accessChain.descHeapInfo.descHeapImageArrayWrapped = imageArrayWrapped;
+    }
+    bool isAccessChainDescHeapImageArrayWrapped() const
+    {
+        return accessChain.descHeapInfo.descHeapImageArrayWrapped;
+    }
     void setAccessChainDescHeapBaseOffset(Id baseOffset) { accessChain.descHeapInfo.descHeapBaseOffset = baseOffset; }
     const std::vector<Id>& getAccessChainDescHeapIndexChain() const { return accessChain.descHeapInfo.descHeapIndexChain; }
     void accessChainPushDescHeapIndex(Id index) { accessChain.descHeapInfo.descHeapIndexChain.push_back(index); }

--- a/Test/baseResults/spv.descriptorHeap.AtomicImage.comp.out
+++ b/Test/baseResults/spv.descriptorHeap.AtomicImage.comp.out
@@ -17,8 +17,9 @@ spv.descriptorHeap.AtomicImage.comp
                               SourceExtension  "GL_EXT_descriptor_heap"
                               Name 4  "main"
                               Name 7  "resource_heap"
+                              Name 12  "img"
                               Decorate 7(resource_heap) BuiltIn ResourceHeapEXT
-                              DecorateId 12 ArrayStrideIdEXT 11
+                              DecorateId 12(img) ArrayStrideIdEXT 11
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeUntypedPointerKHR UniformConstant
@@ -27,7 +28,7 @@ spv.descriptorHeap.AtomicImage.comp
                9:             TypeImage 8(int) 1D nonsampled format:R32i
               10:             TypeInt 32 0
               11:     10(int) ConstantSizeOfEXT 9
-              12:             TypeRuntimeArray 9
+         12(img):             TypeRuntimeArray 9
               13:      8(int) Constant 1
               15:     10(int) Constant 0
               16:             TypePointer Image 8(int)
@@ -35,7 +36,7 @@ spv.descriptorHeap.AtomicImage.comp
               19:     10(int) Constant 1
          4(main):           2 Function None 3
                5:             Label
-              14:      6(ptr) UntypedAccessChainKHR 12 7(resource_heap) 13
+              14:      6(ptr) UntypedAccessChainKHR 12(img) 7(resource_heap) 13
               18:     17(ptr) UntypedImageTexelPointerEXT 9 14 13 15
               20:      8(int) AtomicIAdd 18 19 15 13
                               Return

--- a/Test/baseResults/spv.descriptorHeap.Buffer.comp.out
+++ b/Test/baseResults/spv.descriptorHeap.Buffer.comp.out
@@ -22,10 +22,8 @@ spv.descriptorHeap.Buffer.comp
                               MemberName 20(U) 0  "inputData"
                               Decorate 7(resource_heap) BuiltIn ResourceHeapEXT
                               DecorateId 11 ArrayStrideIdEXT 10
-                              Decorate 14(O) Block
                               MemberDecorate 14(O) 0 Offset 0
                               DecorateId 18 ArrayStrideIdEXT 17
-                              Decorate 20(U) Block
                               MemberDecorate 20(U) 0 Offset 0
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.descriptorHeap.Buffer.comp.out
+++ b/Test/baseResults/spv.descriptorHeap.Buffer.comp.out
@@ -16,14 +16,16 @@ spv.descriptorHeap.Buffer.comp
                               SourceExtension  "GL_EXT_descriptor_heap"
                               Name 4  "main"
                               Name 7  "resource_heap"
+                              Name 11  "ssbo"
                               Name 14  "O"
                               MemberName 14(O) 0  "outputData"
+                              Name 18  "ubo"
                               Name 20  "U"
                               MemberName 20(U) 0  "inputData"
                               Decorate 7(resource_heap) BuiltIn ResourceHeapEXT
-                              DecorateId 11 ArrayStrideIdEXT 10
+                              DecorateId 11(ssbo) ArrayStrideIdEXT 10
                               MemberDecorate 14(O) 0 Offset 0
-                              DecorateId 18 ArrayStrideIdEXT 17
+                              DecorateId 18(ubo) ArrayStrideIdEXT 17
                               MemberDecorate 20(U) 0 Offset 0
                2:             TypeVoid
                3:             TypeFunction 2
@@ -32,14 +34,14 @@ spv.descriptorHeap.Buffer.comp
                8:             TypeBufferEXT StorageBuffer
                9:             TypeInt 32 0
               10:      9(int) ConstantSizeOfEXT 8
-              11:             TypeRuntimeArray 8
+        11(ssbo):             TypeRuntimeArray 8
               12:             TypeInt 32 1
               13:     12(int) Constant 8
            14(O):             TypeStruct 9(int)
               15:     12(int) Constant 0
               16:             TypeBufferEXT Uniform
               17:      9(int) ConstantSizeOfEXT 16
-              18:             TypeRuntimeArray 16
+         18(ubo):             TypeRuntimeArray 16
               19:     12(int) Constant 9
            20(U):             TypeStruct 9(int)
               22:             TypePointer Uniform 20(U)
@@ -48,11 +50,11 @@ spv.descriptorHeap.Buffer.comp
               30:             TypePointer StorageBuffer 9(int)
          4(main):           2 Function None 3
                5:             Label
-              21:      6(ptr) UntypedAccessChainKHR 18 7(resource_heap) 19
+              21:      6(ptr) UntypedAccessChainKHR 18(ubo) 7(resource_heap) 19
               23:     22(ptr) BufferPointerEXT 21
               25:     24(ptr) AccessChain 23 15
               26:      9(int) Load 25
-              27:      6(ptr) UntypedAccessChainKHR 11 7(resource_heap) 13
+              27:      6(ptr) UntypedAccessChainKHR 11(ssbo) 7(resource_heap) 13
               29:     28(ptr) BufferPointerEXT 27
               31:     30(ptr) AccessChain 29 15
                               Store 31 26

--- a/Test/baseResults/spv.descriptorHeap.BufferQualifiers.frag.out
+++ b/Test/baseResults/spv.descriptorHeap.BufferQualifiers.frag.out
@@ -26,12 +26,9 @@ spv.descriptorHeap.BufferQualifiers.frag
                               MemberName 20(ReadSSBO) 0  "value"
                               Decorate 7(resource_heap) BuiltIn ResourceHeapEXT
                               DecorateId 11 ArrayStrideIdEXT 10
-                              Decorate 13(WriteHeap) Block
                               MemberDecorateIdEXT 13(WriteHeap) 0 OffsetIdEXT 12
-                              Decorate 17(WriteSSBO) Block
                               MemberDecorate 17(WriteSSBO) 0 Offset 0
                               DecorateId 19 ArrayStrideIdEXT 10
-                              Decorate 20(ReadSSBO) Block
                               MemberDecorate 20(ReadSSBO) 0 NonWritable
                               MemberDecorate 20(ReadSSBO) 0 Offset 0
                               Decorate 23 NonWritable

--- a/Test/baseResults/spv.descriptorHeap.BufferQualifiers.frag.out
+++ b/Test/baseResults/spv.descriptorHeap.BufferQualifiers.frag.out
@@ -22,13 +22,14 @@ spv.descriptorHeap.BufferQualifiers.frag
                               Name 13  "WriteHeap"
                               Name 17  "WriteSSBO"
                               MemberName 17(WriteSSBO) 0  "value"
+                              Name 19  "reads"
                               Name 20  "ReadSSBO"
                               MemberName 20(ReadSSBO) 0  "value"
                               Decorate 7(resource_heap) BuiltIn ResourceHeapEXT
                               DecorateId 11 ArrayStrideIdEXT 10
                               MemberDecorateIdEXT 13(WriteHeap) 0 OffsetIdEXT 12
                               MemberDecorate 17(WriteSSBO) 0 Offset 0
-                              DecorateId 19 ArrayStrideIdEXT 10
+                              DecorateId 19(reads) ArrayStrideIdEXT 10
                               MemberDecorate 20(ReadSSBO) 0 NonWritable
                               MemberDecorate 20(ReadSSBO) 0 Offset 0
                               Decorate 23 NonWritable
@@ -49,7 +50,7 @@ spv.descriptorHeap.BufferQualifiers.frag
               16:     15(int) Constant 0
    17(WriteSSBO):             TypeStruct 9(int)
               18:     15(int) Constant 1
-              19:             TypeRuntimeArray 8
+       19(reads):             TypeRuntimeArray 8
     20(ReadSSBO):             TypeStruct 9(int)
               22:             TypePointer StorageBuffer 20(ReadSSBO)
               24:             TypePointer StorageBuffer 9(int)
@@ -58,7 +59,7 @@ spv.descriptorHeap.BufferQualifiers.frag
               31:             TypePointer StorageBuffer 17(WriteSSBO)
          4(main):           2 Function None 3
                5:             Label
-              21:      6(ptr) UntypedAccessChainKHR 19 7(resource_heap) 16
+              21:      6(ptr) UntypedAccessChainKHR 19(reads) 7(resource_heap) 16
               23:     22(ptr) BufferPointerEXT 21
               25:     24(ptr) AccessChain 23 16
               26:      9(int) Load 25

--- a/Test/baseResults/spv.descriptorHeap.BufferStruct.comp.out
+++ b/Test/baseResults/spv.descriptorHeap.BufferStruct.comp.out
@@ -36,7 +36,6 @@ spv.descriptorHeap.BufferStruct.comp
                               MemberDecorate 20(Data) 0 MatrixStride 16
                               MemberDecorate 20(Data) 0 Offset 0
                               MemberDecorate 20(Data) 1 Offset 64
-                              Decorate 21(U) Block
                               MemberDecorate 21(U) 0 Offset 0
                               DecorateId 38 ArrayStrideIdEXT 37
                               MemberDecorate 40(Data) 0 ColMajor
@@ -44,7 +43,6 @@ spv.descriptorHeap.BufferStruct.comp
                               MemberDecorate 40(Data) 0 Offset 0
                               MemberDecorate 40(Data) 1 Offset 64
                               Decorate 41 ArrayStride 80
-                              Decorate 42(O) Block
                               MemberDecorate 42(O) 0 Offset 0
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.descriptorHeap.BufferStruct.comp.out
+++ b/Test/baseResults/spv.descriptorHeap.BufferStruct.comp.out
@@ -20,24 +20,26 @@ spv.descriptorHeap.BufferStruct.comp
                               MemberName 9(Data) 1  "f"
                               Name 11  "data"
                               Name 13  "resource_heap"
+                              Name 17  "ubo"
                               Name 20  "Data"
                               MemberName 20(Data) 0  "m"
                               MemberName 20(Data) 1  "f"
                               Name 21  "U"
                               MemberName 21(U) 0  "inputData"
+                              Name 38  "ssbo"
                               Name 40  "Data"
                               MemberName 40(Data) 0  "m"
                               MemberName 40(Data) 1  "f"
                               Name 42  "O"
                               MemberName 42(O) 0  "outputData"
                               Decorate 13(resource_heap) BuiltIn ResourceHeapEXT
-                              DecorateId 17 ArrayStrideIdEXT 16
+                              DecorateId 17(ubo) ArrayStrideIdEXT 16
                               MemberDecorate 20(Data) 0 ColMajor
                               MemberDecorate 20(Data) 0 MatrixStride 16
                               MemberDecorate 20(Data) 0 Offset 0
                               MemberDecorate 20(Data) 1 Offset 64
                               MemberDecorate 21(U) 0 Offset 0
-                              DecorateId 38 ArrayStrideIdEXT 37
+                              DecorateId 38(ssbo) ArrayStrideIdEXT 37
                               MemberDecorate 40(Data) 0 ColMajor
                               MemberDecorate 40(Data) 0 MatrixStride 16
                               MemberDecorate 40(Data) 0 Offset 0
@@ -56,7 +58,7 @@ spv.descriptorHeap.BufferStruct.comp
               14:             TypeBufferEXT Uniform
               15:             TypeInt 32 0
               16:     15(int) ConstantSizeOfEXT 14
-              17:             TypeRuntimeArray 14
+         17(ubo):             TypeRuntimeArray 14
               18:             TypeInt 32 1
               19:     18(int) Constant 1
         20(Data):             TypeStruct 8 6(float)
@@ -68,7 +70,7 @@ spv.descriptorHeap.BufferStruct.comp
               31:             TypePointer Function 6(float)
               36:             TypeBufferEXT StorageBuffer
               37:     15(int) ConstantSizeOfEXT 36
-              38:             TypeRuntimeArray 36
+        38(ssbo):             TypeRuntimeArray 36
               39:     18(int) Constant 2
         40(Data):             TypeStruct 8 6(float)
               41:             TypeRuntimeArray 40(Data)
@@ -79,7 +81,7 @@ spv.descriptorHeap.BufferStruct.comp
          4(main):           2 Function None 3
                5:             Label
         11(data):     10(ptr) Variable Function
-              23:     12(ptr) UntypedAccessChainKHR 17 13(resource_heap) 19
+              23:     12(ptr) UntypedAccessChainKHR 17(ubo) 13(resource_heap) 19
               25:     24(ptr) BufferPointerEXT 23
               27:     26(ptr) AccessChain 25 22
               28:    20(Data) Load 27
@@ -91,7 +93,7 @@ spv.descriptorHeap.BufferStruct.comp
               35:     31(ptr) AccessChain 11(data) 19
                               Store 35 34
               44:     9(Data) Load 11(data)
-              45:     12(ptr) UntypedAccessChainKHR 38 13(resource_heap) 39
+              45:     12(ptr) UntypedAccessChainKHR 38(ssbo) 13(resource_heap) 39
               47:     46(ptr) BufferPointerEXT 45
               49:     48(ptr) AccessChain 47 22 43
               50:    40(Data) CopyLogical 44

--- a/Test/baseResults/spv.descriptorHeap.ImageQualifiers.frag.out
+++ b/Test/baseResults/spv.descriptorHeap.ImageQualifiers.frag.out
@@ -24,11 +24,9 @@ spv.descriptorHeap.ImageQualifiers.frag
                               MemberName 23(Reads_heap) 0  "Reads"
                               Decorate 7(resource_heap) BuiltIn ResourceHeapEXT
                               DecorateId 12 ArrayStrideIdEXT 11
-                              Decorate 14(Writes_heap) Block
                               MemberDecorate 14(Writes_heap) 0 NonReadable
                               MemberDecorateIdEXT 14(Writes_heap) 0 OffsetIdEXT 13
                               DecorateId 22 ArrayStrideIdEXT 11
-                              Decorate 23(Reads_heap) Block
                               MemberDecorate 23(Reads_heap) 0 NonWritable
                               MemberDecorateIdEXT 23(Reads_heap) 0 OffsetIdEXT 13
                2:             TypeVoid

--- a/Test/baseResults/spv.descriptorHeap.ImageQualifiers.frag.out
+++ b/Test/baseResults/spv.descriptorHeap.ImageQualifiers.frag.out
@@ -18,17 +18,17 @@ spv.descriptorHeap.ImageQualifiers.frag
                               SourceExtension  "GL_EXT_samplerless_texture_functions"
                               Name 4  "main"
                               Name 7  "resource_heap"
-                              Name 14  "Writes_heap"
-                              MemberName 14(Writes_heap) 0  "Writes"
-                              Name 23  "Reads_heap"
-                              MemberName 23(Reads_heap) 0  "Reads"
+                              Name 13  "writeonly_image_wrapper"
+                              Name 14  "Writes"
+                              Name 22  "readonly_image_wrapper"
+                              Name 23  "Reads"
                               Decorate 7(resource_heap) BuiltIn ResourceHeapEXT
-                              DecorateId 12 ArrayStrideIdEXT 11
-                              MemberDecorate 14(Writes_heap) 0 NonReadable
-                              MemberDecorateIdEXT 14(Writes_heap) 0 OffsetIdEXT 13
-                              DecorateId 22 ArrayStrideIdEXT 11
-                              MemberDecorate 23(Reads_heap) 0 NonWritable
-                              MemberDecorateIdEXT 23(Reads_heap) 0 OffsetIdEXT 13
+                              MemberDecorate 13(writeonly_image_wrapper) 0 NonReadable
+                              MemberDecorateIdEXT 13(writeonly_image_wrapper) 0 OffsetIdEXT 12
+                              DecorateId 14(Writes) ArrayStrideIdEXT 11
+                              MemberDecorate 22(readonly_image_wrapper) 0 NonWritable
+                              MemberDecorateIdEXT 22(readonly_image_wrapper) 0 OffsetIdEXT 12
+                              DecorateId 23(Reads) ArrayStrideIdEXT 11
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeUntypedPointerKHR UniformConstant
@@ -37,23 +37,23 @@ spv.descriptorHeap.ImageQualifiers.frag
                9:             TypeImage 8(float) 2D nonsampled format:R32f
               10:             TypeInt 32 0
               11:     10(int) ConstantSizeOfEXT 9
-              12:             TypeRuntimeArray 9
-              13:     10(int) Constant 0
- 14(Writes_heap):             TypeStruct 12
+              12:     10(int) Constant 0
+13(writeonly_image_wrapper):             TypeStruct 9
+      14(Writes):             TypeRuntimeArray 13(writeonly_image_wrapper)
               15:             TypeInt 32 1
-              16:     15(int) Constant 0
-              17:     15(int) Constant 10
+              16:     15(int) Constant 10
+              17:     15(int) Constant 0
               20:             TypeVector 15(int) 2
-              21:   20(ivec2) ConstantComposite 16 16
-              22:             TypeRuntimeArray 9
-  23(Reads_heap):             TypeStruct 22
+              21:   20(ivec2) ConstantComposite 17 17
+22(readonly_image_wrapper):             TypeStruct 9
+       23(Reads):             TypeRuntimeArray 22(readonly_image_wrapper)
               24:     15(int) Constant 20
               27:             TypeVector 8(float) 4
          4(main):           2 Function None 3
                5:             Label
-              18:      6(ptr) UntypedAccessChainKHR 14(Writes_heap) 7(resource_heap) 16 17
+              18:      6(ptr) UntypedAccessChainKHR 14(Writes) 7(resource_heap) 16 17
               19:           9 Load 18
-              25:      6(ptr) UntypedAccessChainKHR 23(Reads_heap) 7(resource_heap) 16 24
+              25:      6(ptr) UntypedAccessChainKHR 23(Reads) 7(resource_heap) 24 17
               26:           9 Load 25
               28:   27(fvec4) ImageRead 26 21
                               ImageWrite 19 21 28

--- a/Test/baseResults/spv.descriptorHeap.PushConstant.comp.out
+++ b/Test/baseResults/spv.descriptorHeap.PushConstant.comp.out
@@ -27,7 +27,6 @@ spv.descriptorHeap.PushConstant.comp
                               Decorate 20(resource_heap) BuiltIn ResourceHeapEXT
                               DecorateId 24 ArrayStrideIdEXT 23
                               Decorate 25 ArrayStride 4
-                              Decorate 26(O) Block
                               MemberDecorate 26(O) 0 Offset 0
                               Decorate 28 ArrayStride 4
                               Decorate 29(P) Block

--- a/Test/baseResults/spv.descriptorHeap.PushConstant.comp.out
+++ b/Test/baseResults/spv.descriptorHeap.PushConstant.comp.out
@@ -18,6 +18,7 @@ spv.descriptorHeap.PushConstant.comp
                               Name 8  "i"
                               Name 16  "PUSH_LENGTH"
                               Name 20  "resource_heap"
+                              Name 24  "buffers"
                               Name 26  "O"
                               MemberName 26(O) 0  "outputBuffer"
                               Name 29  "P"
@@ -25,7 +26,7 @@ spv.descriptorHeap.PushConstant.comp
                               Name 31  ""
                               Decorate 16(PUSH_LENGTH) SpecId 0
                               Decorate 20(resource_heap) BuiltIn ResourceHeapEXT
-                              DecorateId 24 ArrayStrideIdEXT 23
+                              DecorateId 24(buffers) ArrayStrideIdEXT 23
                               Decorate 25 ArrayStride 4
                               MemberDecorate 26(O) 0 Offset 0
                               Decorate 28 ArrayStride 4
@@ -44,7 +45,7 @@ spv.descriptorHeap.PushConstant.comp
               21:             TypeBufferEXT StorageBuffer
               22:             TypeInt 32 0
               23:     22(int) ConstantSizeOfEXT 21
-              24:             TypeRuntimeArray 21
+     24(buffers):             TypeRuntimeArray 21
               25:             TypeRuntimeArray 22(int)
            26(O):             TypeStruct 25
               28:             TypeArray 6(int) 16(PUSH_LENGTH)
@@ -76,7 +77,7 @@ spv.descriptorHeap.PushConstant.comp
               34:     33(ptr)   AccessChain 31 9 32
               35:      6(int)   Load 34
               36:     22(int)   Bitcast 35
-              37:     19(ptr)   UntypedAccessChainKHR 24 20(resource_heap) 9
+              37:     19(ptr)   UntypedAccessChainKHR 24(buffers) 20(resource_heap) 9
               39:     38(ptr)   BufferPointerEXT 37
               41:     40(ptr)   AccessChain 39 9 27
                                 Store 41 36

--- a/Test/baseResults/spv.descriptorHeap.Stride.comp.out
+++ b/Test/baseResults/spv.descriptorHeap.Stride.comp.out
@@ -25,7 +25,6 @@ spv.descriptorHeap.Stride.comp
                               Decorate 12(resource_heap) BuiltIn ResourceHeapEXT
                               DecorateId 16 ArrayStrideIdEXT 15
                               Decorate 20 ArrayStride 64
-                              Decorate 21(UBO) Block
                               MemberDecorate 21(UBO) 0 ColMajor
                               MemberDecorate 21(UBO) 0 MatrixStride 16
                               MemberDecorate 21(UBO) 0 Offset 0

--- a/Test/baseResults/spv.descriptorHeap.Stride.comp.out
+++ b/Test/baseResults/spv.descriptorHeap.Stride.comp.out
@@ -17,13 +17,15 @@ spv.descriptorHeap.Stride.comp
                               Name 4  "main"
                               Name 10  "mvp"
                               Name 12  "resource_heap"
+                              Name 16  "ubo"
                               Name 21  "UBO"
                               MemberName 21(UBO) 0  "projection"
                               MemberName 21(UBO) 1  "view"
                               MemberName 21(UBO) 2  "model"
                               Name 46  "texel"
+                              Name 49  "img"
                               Decorate 12(resource_heap) BuiltIn ResourceHeapEXT
-                              DecorateId 16 ArrayStrideIdEXT 15
+                              DecorateId 16(ubo) ArrayStrideIdEXT 15
                               Decorate 20 ArrayStride 64
                               MemberDecorate 21(UBO) 0 ColMajor
                               MemberDecorate 21(UBO) 0 MatrixStride 16
@@ -34,7 +36,7 @@ spv.descriptorHeap.Stride.comp
                               MemberDecorate 21(UBO) 2 ColMajor
                               MemberDecorate 21(UBO) 2 MatrixStride 16
                               MemberDecorate 21(UBO) 2 Offset 128
-                              DecorateId 49 ArrayStrideIdEXT 48
+                              DecorateId 49(img) ArrayStrideIdEXT 48
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -46,7 +48,7 @@ spv.descriptorHeap.Stride.comp
               13:             TypeBufferEXT StorageBuffer
               14:             TypeInt 32 0
               15:     14(int) Constant 512
-              16:             TypeRuntimeArray 13
+         16(ubo):             TypeRuntimeArray 13
               17:             TypeInt 32 1
               18:     17(int) Constant 1
               19:     14(int) Constant 2
@@ -60,7 +62,7 @@ spv.descriptorHeap.Stride.comp
               45:             TypePointer Function 7(fvec4)
               47:             TypeImage 6(float) 2D nonsampled format:Rgba32f
               48:     14(int) Constant 1024
-              49:             TypeRuntimeArray 47
+         49(img):             TypeRuntimeArray 47
               52:             TypeVector 17(int) 2
               53:   52(ivec2) ConstantComposite 22 22
               55:     17(int) Constant 3
@@ -68,31 +70,31 @@ spv.descriptorHeap.Stride.comp
                5:             Label
          10(mvp):      9(ptr) Variable Function
        46(texel):     45(ptr) Variable Function
-              23:     11(ptr) UntypedAccessChainKHR 16 12(resource_heap) 18
+              23:     11(ptr) UntypedAccessChainKHR 16(ubo) 12(resource_heap) 18
               25:     24(ptr) BufferPointerEXT 23
               27:     26(ptr) AccessChain 25 22
               28:           8 Load 27
-              29:     11(ptr) UntypedAccessChainKHR 16 12(resource_heap) 18
+              29:     11(ptr) UntypedAccessChainKHR 16(ubo) 12(resource_heap) 18
               30:     24(ptr) BufferPointerEXT 29
               31:     26(ptr) AccessChain 30 18
               32:           8 Load 31
               33:           8 MatrixTimesMatrix 28 32
-              35:     11(ptr) UntypedAccessChainKHR 16 12(resource_heap) 18
+              35:     11(ptr) UntypedAccessChainKHR 16(ubo) 12(resource_heap) 18
               36:     24(ptr) BufferPointerEXT 35
               37:     26(ptr) AccessChain 36 34 22
               38:           8 Load 37
               39:           8 MatrixTimesMatrix 33 38
                               Store 10(mvp) 39
               41:           8 Load 10(mvp)
-              42:     11(ptr) UntypedAccessChainKHR 16 12(resource_heap) 40
+              42:     11(ptr) UntypedAccessChainKHR 16(ubo) 12(resource_heap) 40
               43:     24(ptr) BufferPointerEXT 42
               44:     26(ptr) AccessChain 43 34 18
                               Store 44 41
-              50:     11(ptr) UntypedAccessChainKHR 49 12(resource_heap) 34
+              50:     11(ptr) UntypedAccessChainKHR 49(img) 12(resource_heap) 34
               51:          47 Load 50
               54:    7(fvec4) ImageRead 51 53
                               Store 46(texel) 54
-              56:     11(ptr) UntypedAccessChainKHR 49 12(resource_heap) 55
+              56:     11(ptr) UntypedAccessChainKHR 49(img) 12(resource_heap) 55
               57:          47 Load 56
               58:    7(fvec4) Load 46(texel)
                               ImageWrite 57 53 58

--- a/Test/baseResults/spv.descriptorHeap.heaps.frag.out
+++ b/Test/baseResults/spv.descriptorHeap.heaps.frag.out
@@ -41,13 +41,10 @@ spv.descriptorHeap.heaps.frag
                               DecorateId 38 ArrayStrideIdEXT 37
                               Decorate 40(index) Flat
                               Decorate 40(index) Location 1
-                              Decorate 43(UniformBuffer) Block
                               MemberDecorate 43(UniformBuffer) 0 Offset 0
                               DecorateId 54 ArrayStrideIdEXT 53
-                              Decorate 56(StorageBufferA) Block
                               MemberDecorate 56(StorageBufferA) 0 Offset 0
                               DecorateId 67 ArrayStrideIdEXT 53
-                              Decorate 71(StorageBufferB) Block
                               MemberDecorate 71(StorageBufferB) 0 Offset 0
                               Decorate 87(heapTexture3D) Binding 0
                               Decorate 87(heapTexture3D) DescriptorSet 0

--- a/Test/baseResults/spv.descriptorHeap.heaps.frag.out
+++ b/Test/baseResults/spv.descriptorHeap.heaps.frag.out
@@ -22,29 +22,33 @@ spv.descriptorHeap.heaps.frag
                               Name 4  "main"
                               Name 9  "fragColor"
                               Name 11  "resource_heap"
+                              Name 15  "heapTexture2D"
                               Name 24  "heapSampler"
                               Name 33  "uvs"
+                              Name 38  "heapUniformBuffer"
                               Name 40  "index"
                               Name 43  "UniformBuffer"
                               MemberName 43(UniformBuffer) 0  "colorOffset"
+                              Name 54  "heapStorageBufferA"
                               Name 56  "StorageBufferA"
                               MemberName 56(StorageBufferA) 0  "a"
+                              Name 67  "heapStorageBufferB"
                               Name 71  "StorageBufferB"
                               MemberName 71(StorageBufferB) 0  "b"
                               Name 87  "heapTexture3D"
                               Decorate 9(fragColor) Location 0
                               Decorate 11(resource_heap) BuiltIn ResourceHeapEXT
-                              DecorateId 15 ArrayStrideIdEXT 14
+                              DecorateId 15(heapTexture2D) ArrayStrideIdEXT 14
                               Decorate 24(heapSampler) Binding 0
                               Decorate 24(heapSampler) DescriptorSet 0
                               Decorate 33(uvs) Location 0
-                              DecorateId 38 ArrayStrideIdEXT 37
+                              DecorateId 38(heapUniformBuffer) ArrayStrideIdEXT 37
                               Decorate 40(index) Flat
                               Decorate 40(index) Location 1
                               MemberDecorate 43(UniformBuffer) 0 Offset 0
-                              DecorateId 54 ArrayStrideIdEXT 53
+                              DecorateId 54(heapStorageBufferA) ArrayStrideIdEXT 53
                               MemberDecorate 56(StorageBufferA) 0 Offset 0
-                              DecorateId 67 ArrayStrideIdEXT 53
+                              DecorateId 67(heapStorageBufferB) ArrayStrideIdEXT 53
                               MemberDecorate 71(StorageBufferB) 0 Offset 0
                               Decorate 87(heapTexture3D) Binding 0
                               Decorate 87(heapTexture3D) DescriptorSet 0
@@ -59,7 +63,7 @@ spv.descriptorHeap.heaps.frag
               12:             TypeImage 6(float) 2D sampled format:Unknown
               13:             TypeInt 32 0
               14:     13(int) ConstantSizeOfEXT 12
-              15:             TypeRuntimeArray 12
+15(heapTexture2D):             TypeRuntimeArray 12
               16:             TypeInt 32 1
               17:     16(int) Constant 27
               20:             TypeSampler
@@ -75,7 +79,7 @@ spv.descriptorHeap.heaps.frag
          33(uvs):     32(ptr) Variable Input
               36:             TypeBufferEXT Uniform
               37:     13(int) ConstantSizeOfEXT 36
-              38:             TypeRuntimeArray 36
+38(heapUniformBuffer):             TypeRuntimeArray 36
               39:             TypePointer Input 13(int)
        40(index):     39(ptr) Variable Input
 43(UniformBuffer):             TypeStruct 7(fvec4)
@@ -83,7 +87,7 @@ spv.descriptorHeap.heaps.frag
               47:             TypePointer Uniform 7(fvec4)
               52:             TypeBufferEXT StorageBuffer
               53:     13(int) ConstantSizeOfEXT 52
-              54:             TypeRuntimeArray 52
+54(heapStorageBufferA):             TypeRuntimeArray 52
               55:     16(int) Constant 1
 56(StorageBufferA):             TypeStruct 7(fvec4)
               57:    6(float) Constant 1065353216
@@ -93,7 +97,7 @@ spv.descriptorHeap.heaps.frag
               61:    7(fvec4) ConstantComposite 57 58 59 60
               63:             TypePointer StorageBuffer 56(StorageBufferA)
               65:             TypePointer StorageBuffer 7(fvec4)
-              67:             TypeRuntimeArray 52
+67(heapStorageBufferB):             TypeRuntimeArray 52
               70:             TypeVector 6(float) 3
 71(StorageBufferB):             TypeStruct 70(fvec3)
               72:     13(int) Constant 0
@@ -106,7 +110,7 @@ spv.descriptorHeap.heaps.frag
 87(heapTexture3D):     86(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-              18:     10(ptr) UntypedAccessChainKHR 15 11(resource_heap) 17
+              18:     10(ptr) UntypedAccessChainKHR 15(heapTexture2D) 11(resource_heap) 17
               19:          12 Load 18
               27:     26(ptr) AccessChain 24(heapSampler) 25
               28:          20 Load 27
@@ -116,20 +120,20 @@ spv.descriptorHeap.heaps.frag
                               Store 9(fragColor) 35
               41:     13(int) Load 40(index)
               42:     13(int) CopyObject 41
-              44:     10(ptr) UntypedAccessChainKHR 38 11(resource_heap) 42
+              44:     10(ptr) UntypedAccessChainKHR 38(heapUniformBuffer) 11(resource_heap) 42
               46:     45(ptr) BufferPointerEXT 44
               48:     47(ptr) AccessChain 46 25
               49:    7(fvec4) Load 48
               50:    7(fvec4) Load 9(fragColor)
               51:    7(fvec4) FAdd 50 49
                               Store 9(fragColor) 51
-              62:     10(ptr) UntypedAccessChainKHR 54 11(resource_heap) 55
+              62:     10(ptr) UntypedAccessChainKHR 54(heapStorageBufferA) 11(resource_heap) 55
               64:     63(ptr) BufferPointerEXT 62
               66:     65(ptr) AccessChain 64 25
                               Store 66 61
               68:     13(int) Load 40(index)
               69:     13(int) CopyObject 68
-              73:     10(ptr) UntypedAccessChainKHR 67 11(resource_heap) 69
+              73:     10(ptr) UntypedAccessChainKHR 67(heapStorageBufferB) 11(resource_heap) 69
               75:     74(ptr) BufferPointerEXT 73
               77:     76(ptr) AccessChain 75 25 72
               78:    6(float) Load 77

--- a/Test/baseResults/spv.structuredDescriptorHeap.Buffer.comp.out
+++ b/Test/baseResults/spv.structuredDescriptorHeap.Buffer.comp.out
@@ -28,11 +28,9 @@ spv.structuredDescriptorHeap.Buffer.comp
                               MemberDecorateIdEXT 20(Material) 0 OffsetIdEXT 12
                               MemberDecorateIdEXT 20(Material) 1 OffsetIdEXT 19
                               DecorateId 30 ArrayStrideIdEXT 29
-                              Decorate 41(BufferHeap) Block
                               MemberDecorateIdEXT 41(BufferHeap) 0 OffsetIdEXT 12
                               MemberDecorateIdEXT 41(BufferHeap) 1 OffsetIdEXT 35
                               MemberDecorateIdEXT 41(BufferHeap) 2 OffsetIdEXT 40
-                              Decorate 45(DataBuffer) Block
                               MemberDecorate 45(DataBuffer) 0 Offset 0
                               MemberDecorate 45(DataBuffer) 1 Offset 4
                               Decorate 50 ArrayStride 1

--- a/Test/baseResults/spv.structuredDescriptorHeap.BufferReference.comp.out
+++ b/Test/baseResults/spv.structuredDescriptorHeap.BufferReference.comp.out
@@ -50,7 +50,6 @@ spv.structuredDescriptorHeap.BufferReference.comp
                               Decorate 11(outputBuffer) Binding 0
                               Decorate 11(outputBuffer) DescriptorSet 0
                               Decorate 15(resource_heap) BuiltIn ResourceHeapEXT
-                              Decorate 20(RefHeap) Block
                               MemberDecorate 20(RefHeap) 0 Offset 0
                               MemberDecorate 20(RefHeap) 1 Offset 8
                               MemberDecorate 20(RefHeap) 2 Offset 16

--- a/Test/baseResults/spv.structuredDescriptorHeap.LayoutQualifiers.comp.out
+++ b/Test/baseResults/spv.structuredDescriptorHeap.LayoutQualifiers.comp.out
@@ -66,13 +66,10 @@ spv.structuredDescriptorHeap.LayoutQualifiers.comp
                               MemberDecorate 52 0 Offset 0
                               MemberDecorate 52 1 Offset 12
                               Decorate 56 ArrayStride 1
-                              Decorate 75(Std140Type) Block
                               MemberDecorate 75(Std140Type) 0 Offset 0
                               MemberDecorate 75(Std140Type) 1 Offset 16
-                              Decorate 84(Std430Type) Block
                               MemberDecorate 84(Std430Type) 0 Offset 0
                               MemberDecorate 84(Std430Type) 1 Offset 16
-                              Decorate 92(ScalarType) Block
                               MemberDecorate 92(ScalarType) 0 Offset 0
                               MemberDecorate 92(ScalarType) 1 Offset 12
                               Decorate 102 BuiltIn WorkgroupSize

--- a/Test/baseResults/spv.structuredDescriptorHeap.Offset.comp.out
+++ b/Test/baseResults/spv.structuredDescriptorHeap.Offset.comp.out
@@ -38,7 +38,6 @@ spv.structuredDescriptorHeap.Offset.comp
                               Decorate 7(resource_heap) BuiltIn ResourceHeapEXT
                               MemberDecorateIdEXT 18(BufferHeap0) 0 OffsetIdEXT 10
                               MemberDecorateIdEXT 18(BufferHeap0) 1 OffsetIdEXT 17
-                              Decorate 22(DataBuffer) Block
                               MemberDecorate 22(DataBuffer) 0 Offset 0
                               MemberDecorate 22(DataBuffer) 1 Offset 4
                               DecorateId 28 ArrayStrideIdEXT 26

--- a/Test/baseResults/spv.tensorARM.descriptorHeap.comp.out
+++ b/Test/baseResults/spv.tensorARM.descriptorHeap.comp.out
@@ -27,7 +27,6 @@ spv.tensorARM.descriptorHeap.comp
                               Decorate 11(t) DescriptorSet 0
                               Decorate 19(resource_heap) BuiltIn ResourceHeapEXT
                               DecorateId 22 ArrayStrideIdEXT 21
-                              Decorate 24(O) Block
                               MemberDecorate 24(O) 0 Offset 0
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.tensorARM.descriptorHeap.comp.out
+++ b/Test/baseResults/spv.tensorARM.descriptorHeap.comp.out
@@ -21,12 +21,13 @@ spv.tensorARM.descriptorHeap.comp
                               Name 4  "main"
                               Name 11  "t"
                               Name 19  "resource_heap"
+                              Name 22  "ssbo"
                               Name 24  "O"
                               MemberName 24(O) 0  "out_data"
                               Decorate 11(t) Binding 0
                               Decorate 11(t) DescriptorSet 0
                               Decorate 19(resource_heap) BuiltIn ResourceHeapEXT
-                              DecorateId 22 ArrayStrideIdEXT 21
+                              DecorateId 22(ssbo) ArrayStrideIdEXT 21
                               MemberDecorate 24(O) 0 Offset 0
                2:             TypeVoid
                3:             TypeFunction 2
@@ -45,7 +46,7 @@ spv.tensorARM.descriptorHeap.comp
 19(resource_heap):     18(ptr) UntypedVariableKHR UniformConstant
               20:             TypeBufferEXT StorageBuffer
               21:      7(int) ConstantSizeOfEXT 20
-              22:             TypeRuntimeArray 20
+        22(ssbo):             TypeRuntimeArray 20
               23:      6(int) Constant 1
            24(O):             TypeStruct 6(int)
               25:      6(int) Constant 0
@@ -56,7 +57,7 @@ spv.tensorARM.descriptorHeap.comp
                5:             Label
               12:           9 Load 11(t)
               27:      6(int) TensorReadARM 12 17
-              28:     18(ptr) UntypedAccessChainKHR 22 19(resource_heap) 23
+              28:     18(ptr) UntypedAccessChainKHR 22(ssbo) 19(resource_heap) 23
               30:     29(ptr) BufferPointerEXT 28
               32:     31(ptr) AccessChain 30 25
                               Store 32 27


### PR DESCRIPTION
**Issue**: [glslang#4238](https://github.com/KhronosGroup/glslang/issues/4238)  
**Follow-up to**: https://github.com/Guang-035/glslang/commit/90a07568d79b17a968b9a9cd4bb48334df5fc1d2

**Description**

For `layout(descriptor_heap)` image arrays, for example:

```glsl
layout(descriptor_heap, r32f) writeonly uniform image2D Writes[];
layout(descriptor_heap, r32f) readonly uniform image2D Reads[];
```

- glslang creates wrapper struct types to carry the `NonReadable` / `NonWritable` member decorations. This change removes the incorrect `Block` decoration from those wrappers because they are not shader interface blocks.
- Remove Block decorations from descriptor heap layout and payload structs

**Note**: This currently requires a SPIRV-Tools validation update. I opened [SPIRV-Tools#6723](https://github.com/KhronosGroup/SPIRV-Tools/pull/6723) for that fix.
