### PR TITLE
Reject descriptor_heap combined image samplers

### DIFF
--- a/Test/baseResults/spv.descriptorHeap.CombinedSampler.error.frag.out
+++ b/Test/baseResults/spv.descriptorHeap.CombinedSampler.error.frag.out
@@ -1,0 +1,6 @@
+spv.descriptorHeap.CombinedSampler.error.frag
+ERROR: 0:4: 'u_image' : layout(descriptor_heap) cannot be used with combined image samplers. 
+ERROR: 1 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.descriptorHeap.CombinedSampler.error.frag
+++ b/Test/spv.descriptorHeap.CombinedSampler.error.frag
@@ -1,0 +1,14 @@
+#version 450
+#extension GL_EXT_descriptor_heap : require
+
+layout(descriptor_heap) uniform sampler2D u_image[];
+
+layout(location = 0) flat in vec2 vtx_out_texCoord;
+layout(location = 0) out vec4 o_result;
+
+void main()
+{
+    vec2 texCoord = vtx_out_texCoord;
+    vec4 result = texture(u_image[0], texCoord);
+    o_result = result;
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -10640,6 +10640,11 @@ bool TParseContext::untypedHeapCheck(TSymbol* symbol, const TType& type, const T
                     "declared with a run-time sized array type.", name, "");
                 return false;
             }
+            if (type.getBasicType() == EbtSampler && type.getSampler().isCombined()) {
+                error(loc, "layout(descriptor_heap) cannot be used with combined image samplers.",
+                      name, "");
+                return false;
+            }
             if (!type.containsHeapArray() && !isHeapStruct) {
                 error(loc, "layout(descriptor_heap) decorated variable could only be declared as an array.",
                       name, "");

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -898,6 +898,7 @@ INSTANTIATE_TEST_SUITE_P(
         "spv.descriptorHeap.Buffer.comp",
         "spv.descriptorHeap.BufferStruct.comp",
         "spv.descriptorHeap.BufferQualifiers.frag",
+        "spv.descriptorHeap.CombinedSampler.error.frag",
         "spv.descriptorHeap.ImageQualifiers.frag",
         "spv.descriptorHeap.Stride.comp",
         "spv.descriptorHeap.DebugPrintf.comp",


### PR DESCRIPTION
**Motivation:**
Issue #4236 reports that `layout(descriptor_heap) uniform sampler2D u_image[];` is currently accepted by glslang even though combined image samplers cannot be represented with untyped pointers. This lets glslang generate invalid SPIR-V that is only rejected later by `spirv-val`.

**Solution:**
Reject combined image samplers during descriptor heap semantic checking. When `layout(descriptor_heap)` is applied to a combined sampler type such as `sampler2D`, glslang now emits a front-end error telling users to use separate texture and sampler types instead. A focused negative test is added to cover this case.


