### PR TITLE
iomapper: fix out-of-bounds indexing in TDefaultIoResolverBase::addStage

### DIFF
--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -85,9 +85,9 @@ public:
     int resolveInOutComponent(EShLanguage /*stage*/, TVarEntryInfo& ent) override;
     int resolveInOutIndex(EShLanguage /*stage*/, TVarEntryInfo& ent) override;
     void addStage(EShLanguage stage, TIntermediate& stageIntermediate) override {
-        if (stage < EShLangCount) {
-            stageMask[stage] = true;
-            stageIntermediates[stage] = &stageIntermediate;
+        if ((unsigned)stage < EShLangCount) {
+            stageMask[(unsigned)stage] = true;
+            stageIntermediates[(unsigned)stage] = &stageIntermediate;
         }
     }
     uint32_t computeTypeLocationSize(const TType& type, EShLanguage stage);


### PR DESCRIPTION
EShLanguage is a signed enum, so the existing `stage < EShLangCount` guard admits negative values. Those values then wrap when used as array indices into stageMask[] and stageIntermediates[], reading and writing outside the arrays.

Cast to unsigned in the guard and at both index sites so a negative enum value is rejected up-front and the indices are provably in range.

Resolves a static analysis warning.