### PR TITLE
Guard std::filesystem so InfoSink.h builds without <filesystem>

### DIFF
--- a/glslang/Include/InfoSink.h
+++ b/glslang/Include/InfoSink.h
@@ -36,7 +36,9 @@
 #define _INFOSINK_INCLUDED_
 
 #include "../Include/Common.h"
+#if __has_include(<filesystem>)
 #include <filesystem>
+#endif
 #include <cmath>
 
 namespace glslang {
@@ -105,11 +107,19 @@ public:
         }
 
         if(loc.getFilename() == nullptr && shaderFileName != nullptr && absolute) {
+        #if defined(__cpp_lib_filesystem)
             append(std::filesystem::absolute(shaderFileName).string());
+        #else
+            append(shaderFileName);
+        #endif
         } else {
             std::string location = loc.getStringNameOrNum(false);
             if (absolute) {
+        #if defined(__cpp_lib_filesystem)
                 append(std::filesystem::absolute(location).string());
+        #else
+                append(location);
+        #endif
             } else {
                 append(location);
             }


### PR DESCRIPTION
`InfoSink.h` includes `<filesystem>` and calls `std::filesystem::absolute()` in `TInfoSinkBase::location()`. This does not compile if the standard library was built without a working `<filesystem>`. One example is LLVM libc++ built with `LIBCXX_ENABLE_FILESYSTEM=OFF`, which happens on wasm32-wasi and some embedded targets where the C library has no `statvfs`. A lot of files include `InfoSink.h`, so the whole build fails, not just the diagnostics.

I wrapped the include in `#if __has_include(<filesystem>)` and wrapped the two `absolute()` calls in `#if defined(__cpp_lib_filesystem)` to check whether `<filesystem>` is usable. When it is not usable, the code appends the plain path instead of the absolute one. On platforms that have `<filesystem>`, nothing changes.