### PR TITLE
preprocessor: guard elseSeen/ifdepth against negative elsetracker

### DIFF
--- a/Test/baseResults/preprocessor.elseseen.oob.vert.err
+++ b/Test/baseResults/preprocessor.elseseen.oob.vert.err
@@ -1,0 +1,15 @@
+ERROR: 0:18: 'preprocessor evaluation' : bad expression 
+ERROR: 0:18: '#if' : unexpected tokens following directive 
+ERROR: 0:31: '#endif' : mismatched statements 
+ERROR: 0:32: '#endif' : mismatched statements 
+ERROR: 0:33: '#endif' : mismatched statements 
+ERROR: 0:34: '#endif' : mismatched statements 
+ERROR: 0:35: '#endif' : mismatched statements 
+ERROR: 0:36: '#endif' : mismatched statements 
+ERROR: 0:37: '#endif' : mismatched statements 
+ERROR: 0:38: '#endif' : mismatched statements 
+ERROR: 0:39: '#endif' : mismatched statements 
+ERROR: 0:40: '#endif' : mismatched statements 
+ERROR: 12 compilation errors.  No code generated.
+
+

--- a/Test/preprocessor.elseseen.oob.vert
+++ b/Test/preprocessor.elseseen.oob.vert
@@ -1,0 +1,42 @@
+// Test: guard against elseSeen[elsetracker] OOB write when elsetracker < 0.
+//
+// A malformed #if expression causes eval() to return err=true; CPPif increments
+// ifdepth/elsetracker but skips the branch scan.  The subsequent nested
+// #if 0 / #endif block enters CPPelse with depth > 0, driving ifdepth negative
+// via the unguarded --ifdepth at Pp.cpp:328.  Once ifdepth < 0 the
+// readCPPline guard (if (ifdepth == 0)) is permanently bypassed, and every
+// further #endif decrements elsetracker without bound.
+//
+// Without the fix, elseSeen[elsetracker] writes 0x00 backward through TPpContext
+// into lastLineTokenLocs, crashing in scanToken (PpContext.h:384).
+// With the fix, both write sites check elsetracker >= 0, and the unguarded
+// --ifdepth is protected by if (ifdepth > 0).
+
+#version 450
+
+// Step 1: bad expression desynchronises ifdepth and elsetracker.
+#if %%%
+#endif
+
+// Step 2: nested block enters CPPelse depth>0 path, ifdepth goes negative.
+#if 0
+  #if 1
+    #if 1
+    #endif
+  #endif
+#endif
+
+// Step 3: excess #endifs hit readCPPline with ifdepth < 0; without the
+// elsetracker >= 0 guard they would write OOB into the struct.
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+
+void main() {}

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -316,7 +316,8 @@ int TPpContext::CPPelse(int matchelse, TPpToken* ppToken)
             }
         } else if (nextAtom == PpAtomEndif) {
             token = extraTokenCheck(nextAtom, ppToken, scanToken(ppToken));
-            elseSeen[elsetracker] = false;
+            if (elsetracker >= 0)
+                elseSeen[elsetracker] = false;
             --elsetracker;
             if (depth == 0) {
                 // found the #endif we are looking for
@@ -325,7 +326,8 @@ int TPpContext::CPPelse(int matchelse, TPpToken* ppToken)
                 break;
             }
             --depth;
-            --ifdepth;
+            if (ifdepth > 0)
+                --ifdepth;
         } else if (matchelse && depth == 0) {
             if (nextAtom == PpAtomElse) {
                 elseSeen[elsetracker] = true;
@@ -1008,7 +1010,8 @@ int TPpContext::readCPPline(TPpToken* ppToken)
             if (ifdepth == 0)
                 parseContext.ppError(ppToken->loc, "mismatched statements", "#endif", "");
             else {
-                elseSeen[elsetracker] = false;
+                if (elsetracker >= 0)
+                    elseSeen[elsetracker] = false;
                 --elsetracker;
                 --ifdepth;
             }

--- a/gtests/Pp.FromFile.cpp
+++ b/gtests/Pp.FromFile.cpp
@@ -72,6 +72,7 @@ INSTANTIATE_TEST_SUITE_P(
         "preprocess.inactive_stringify.vert",
         "preprocessor.paste_stringify.vert",
         "preprocessor.stringify_invalid.vert",
+        "preprocessor.elseseen.oob.vert",
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
A malformed #if expression (e.g. '#if %%%') causes eval() to return err=true. CPPif increments ifdepth and elsetracker but does not invoke CPPelse, leaving the preprocessor tracking a phantom conditional block. Subsequent excess #endif directives are consumed inside CPPelse: the depth > 0 path at Pp.cpp:328 runs --ifdepth without any guard, driving ifdepth negative. Once ifdepth < 0 the 'if (ifdepth == 0)' guard in readCPPline is permanently bypassed (only catches exactly zero). Every further #endif then executes elseSeen[elsetracker] = false with elsetracker running arbitrarily negative, writing zero-bytes backward through TPpContext into the lastLineTokenLocs vector control block, corrupting its internal pointers and causing a deterministic SEGV.

Fix with three one-line guards:
- Pp.cpp:319 (CPPelse): check elsetracker >= 0 before writing elseSeen
- Pp.cpp:328 (CPPelse depth>0 path): check ifdepth > 0 before decrement
- Pp.cpp:1011 (readCPPline): check elsetracker >= 0 before writing elseSeen

Add test preprocessor.elseseen.oob.vert that reproduces the crash path: a bad #if desynchronises the counters, excess #endifs then drive elsetracker to -10. With the fix all excess #endifs produce 'mismatched statements' errors cleanly; without it the process crashes.