### PR TITLE
preprocessor: guard against column underflow in DoPreprocessing

### DIFF
--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1178,7 +1178,8 @@ struct DoPreprocessing {
                 // Don't emit whitespace onto empty lines.
                 // Copy any whitespace characters at the start of a line
                 // from the input to the output.
-                outputBuffer += std::string(ppToken.loc.column - 1, ' ');
+                if (ppToken.loc.column > 0)
+                    outputBuffer += std::string(ppToken.loc.column - 1, ' ');
             }
 
             // Output a space in between tokens, but not at the start of a line,


### PR DESCRIPTION
## Summary

Fixes a `std::terminate()` crash (via uncaught `std::length_error`) in `DoPreprocessing::operator()` at `ShaderLang.cpp:1181`.

## Root Cause

When outputting a preprocessed shader, the code copies leading whitespace to align tokens:

```cpp
if (isNewLine) {
    outputBuffer += std::string(ppToken.loc.column - 1, ' ');
}
```

If `ppToken.loc.column == 0` — which can happen after a backslash-newline continuation at end-of-input — the expression `0 - 1` on the signed `int column` produces `-1`, which converts to `SIZE_MAX` when passed to `std::string(size_t, char)`. This throws `std::length_error`, and since the exception is uncaught, `std::terminate()` → `abort()`.

## Reproducer

36-byte pure ASCII input (no binary bytes required):

```
GL_EXT_shader_image_load_formatted\

```

Crash path:
```
TShader::preprocess(GetDefaultResources(), 450, ENoProfile, false, false, EShMsgDefault, &out, includer)
  → DoPreprocessing::operator()
    → std::string(ppToken.loc.column - 1, ' ')   // column==0 → SIZE_MAX
      → std::__throw_length_error
        → std::terminate()
          → abort()
```

Found by libFuzzer (`fuzz_glslang_direct`) calling `TShader::preprocess()` directly with `EShMsgDefault`.

## Fix

Add a `column > 0` guard before the subtraction:

```cpp
if (isNewLine) {
    if (ppToken.loc.column > 0)
        outputBuffer += std::string(ppToken.loc.column - 1, ' ');
}
```

Note: callers that pass `EShMsgOnlyPreprocessor` (e.g. shaderc) do not hit this code path and are not affected. The fix ensures correctness for all callers.
