### PR TITLE
iomapper: guard uniformVarMap before dereferencing it in uniform validation

### DIFF
--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -647,7 +647,7 @@ struct TSymbolValidater
         } else if (base->getQualifier().isUniformOrBuffer() && !base->getQualifier().isPushConstant()) {
             // validate uniform type;
             for (int i = 0; i < EShLangCount; i++) {
-                if (i != currentStage && outVarMaps[i] != nullptr) {
+                if (i != currentStage && uniformVarMap[i] != nullptr) {
                     auto ent2 = uniformVarMap[i]->find(name);
                     if (ent2 != uniformVarMap[i]->end()) {
                         ent2->second.symbol->getType().appendMangledName(mangleName2);


### PR DESCRIPTION
In `TSymbolValidater`'s uniform-type validation loop, the null guard tests `outVarMaps[i]` but the body dereferences `uniformVarMap[i]` (`uniformVarMap[i]->find(name)` and `->end()`). The two arrays are usually allocated or left null together, which masks the problem, but the guard is checking the wrong array: if a stage has `outVarMaps[i]` non-null while `uniformVarMap[i]` is null the loop dereferences a null pointer, and in the reverse case cross-stage uniform validation is silently skipped.

Check `uniformVarMap[i]` instead, matching how the in/out branches above guard `inVarMaps`/`outVarMaps` against the array they actually use.

Fixes #4313.