### PR TITLE
fix oob read on empty array initializer in convertInitializerList

### DIFF
--- a/Test/baseResults/glsl.nullInitializer.error.vert.out
+++ b/Test/baseResults/glsl.nullInitializer.error.vert.out
@@ -1,0 +1,27 @@
+glsl.nullInitializer.error.vert
+ERROR: 0:11: 'initializer list' : array initializer must be non-empty 
+ERROR: 1 compilation errors.  No code generated.
+
+
+Shader version: 460
+Requested GL_EXT_null_initializer
+ERROR: node is still EOpNull!
+0:9  Function Definition: main( ( global void)
+0:9    Function Parameters: 
+0:?   Linker Objects
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+
+Linked vertex stage:
+
+
+Shader version: 460
+Requested GL_EXT_null_initializer
+ERROR: node is still EOpNull!
+0:9  Function Definition: main( ( global void)
+0:9    Function Parameters: 
+0:?   Linker Objects
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+

--- a/Test/glsl.nullInitializer.error.vert
+++ b/Test/glsl.nullInitializer.error.vert
@@ -1,0 +1,12 @@
+#version 460
+#extension GL_EXT_null_initializer : enable
+
+// An empty initializer list ({}) is only valid as a whole null initializer.
+// When one appears nested as an array element initializer there are no elements
+// to size the array or derive its element type from, so it must be rejected
+// rather than reading past the empty initializer sequence.
+
+void main()
+{
+    int a[1][3] = { {} };    // ERROR, empty initializer list for an array element
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -9907,6 +9907,13 @@ TIntermTyped* TParseContext::convertInitializerList(const TSourceLoc& loc, const
         arrayType.shallowCopy(type);                     // sharing struct stuff is fine
         arrayType.copyArraySizes(*type.getArraySizes());  // but get a fresh copy of the array information, to edit below
 
+        // a nested empty initializer list ({}) has no elements to size the array or
+        // derive its element type from, so reject it before the getSequence()[0] read below
+        if (initList->getSequence().empty()) {
+            error(loc, "array initializer must be non-empty", "initializer list", "");
+            return nullptr;
+        }
+
         // edit array sizes to fill in unsized dimensions
         arrayType.changeOuterArraySize((int)initList->getSequence().size());
         TIntermTyped* firstInit = initList->getSequence()[0]->getAsTyped();

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -313,6 +313,7 @@ INSTANTIATE_TEST_SUITE_P(
         "coord_conventions.frag",
         "gl_FragCoord.frag",
         "glsl.interpOp.error.frag",
+        "glsl.nullInitializer.error.vert",
         "location_aliasing.tesc",
         "location_aliasing1.frag",
         "GL_EXT_draw_instanced.vert",


### PR DESCRIPTION
ASan, on a shader with a nested empty initializer list:

    SEGV on unknown address 0x000000000000
    ParseHelper.cpp:9987 in glslang::TParseContext::convertInitializerList

The array branch reads getSequence()[0] to derive inner array dimensions but never checks the initializer list is non-empty. A nested {} (an empty EOpNull aggregate, legal under GL_EXT_null_initializer) that lands on an array element type reaches it with a zero-length sequence, so the index runs past the end. The struct/matrix/vector branches already validate the count first, and the HLSL convertInitializerList guards the same read with size() > 0. Reject the empty list with an error to match.

Repro: `int a[1][3] = { {} };` with GL_EXT_null_initializer. Test added under gtests AST (glsl.nullInitializer.error.vert).