### PR TITLE
Increase input_attachment_index limit

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -966,8 +966,8 @@ public:
                  unsigned int layoutXfbOffset            : 13;
     static const unsigned int layoutXfbOffsetEnd     = 0x1FFF;
 
-                 unsigned int layoutAttachment           :  8;  // for input_attachment_index
-    static const unsigned int layoutAttachmentEnd      = 0XFF;
+                 unsigned int layoutAttachment;                 // for input_attachment_index
+    static const unsigned int layoutAttachmentEnd = INT_MAX;
 
                  unsigned int layoutSpecConstantId;
     static const unsigned int layoutSpecConstantIdEnd = UINT_MAX;


### PR DESCRIPTION
The new limit is INT_MAX, as opposed to UINT_MAX, because INT_MAX is large enough and there are other places in the code where the value of the limit is cast to int.

The need to increase this comes from an upcoming Vulkan extension that will allow the indices to be much larger in practice, and I'm creating GLSL tests in CTS. I would very much like not to have to write SPIR-V assembly for this.