### PR TITLE
fix oob idInstruction/idDescriptor access on out-of-bound <id>

### DIFF
--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -199,6 +199,9 @@ void SpirvStream::processInstructions()
             resultId = stream[word++];
             --numOperands;
 
+            if (resultId >= bound)
+                Kill(out, "Bad <id>");
+
             // save instruction for future reference
             idInstruction[resultId] = instructionStart;
         }
@@ -418,6 +421,8 @@ void SpirvStream::disassembleInstruction(Id resultId, Id /*typeId*/, Op opCode, 
                 idDescriptor[resultId] = "ptr";
                 break;
             case Op::OpTypeVector:
+                if (stream[word] >= bound)
+                    Kill(out, "Bad <id>");
                 if (idDescriptor[stream[word]].size() > 0) {
                     if (idDescriptor[stream[word]].substr(0,2) == "bf") {
                         idDescriptor[resultId].append(idDescriptor[stream[word]].begin(), idDescriptor[stream[word]].begin() + 2);


### PR DESCRIPTION
ASan, `spv::Disassemble()` on a caller-supplied 7-word module whose header id bound (word 3) is 1, carrying an `OpTypeVoid` with result `<id>` 4096:

    ==37347==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000018a30
    WRITE of size 4 at 0x602000018a30 thread T0
        #0 spv::SpirvStream::processInstructions() disassemble.cpp:203
        #1 spv::Disassemble(std::ostream&, std::vector<unsigned int> const&) disassemble.cpp:906

    0x602000018a30 is located 16380 bytes after 4-byte region [0x602000014a30,0x602000014a34)
    allocated by thread T0 here:
        #8 spv::SpirvStream::validate() disassemble.cpp:156

`idInstruction` and `idDescriptor` are sized from that bound, and `formatId`/`outputId` already `Kill` on `id >= bound`, but the result `<id>` indexes `idInstruction` two lines before `outputResultId` gets to check it, so the store lands wherever the module asks. `OpTypeVector` has the same gap: it reads `idDescriptor` at the component-type `<id>` to build the descriptor string before the operand loop runs that id through `outputId`, which ASan reports as an out-of-bounds read on the descriptor vector. Both ids are checked against the bound where they are read now.

Build with `-DBUILD_WERROR=ON` and `ctest` are clean; valid modules disassemble unchanged.
