### PR TITLE
fix out-of-bounds read on long vector index in checkIndex

### DIFF
--- a/Test/baseResults/spv.longVectorBadParams.index.comp.out
+++ b/Test/baseResults/spv.longVectorBadParams.index.comp.out
@@ -1,0 +1,9 @@
+spv.longVectorBadParams.index.comp
+ERROR: 0:15: '[' :  vector index out of range '8'
+ERROR: 0:16: '[' :  vector index out of range '500'
+ERROR: 0:17: '[' :  vector index out of range '500'
+ERROR: 0:18: '[' :  index out of range '-1'
+ERROR: 4 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.longVectorBadParams.index.comp
+++ b/Test/spv.longVectorBadParams.index.comp
@@ -1,0 +1,19 @@
+#version 450 core
+#extension GL_EXT_long_vector : enable
+
+layout(local_size_x = 1) in;
+
+layout(set = 0, binding = 0) buffer Buf {
+    float o[4];
+} buf;
+
+void main()
+{
+    const vector<float, 8> c = vector<float, 8>(1.5);
+    vector<float, 8> v = vector<float, 8>(2.5);
+
+    buf.o[0] = c[8];
+    buf.o[1] = c[500];
+    buf.o[2] = v[500];
+    buf.o[3] = v[-1];
+}

--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -313,6 +313,11 @@ void TParseContextBase::checkIndex(const TSourceLoc& loc, const TType& type, int
             error(loc, "", "[", "cooperative vector index out of range '%d'", index);
             index = type.computeNumComponents() - 1;
         }
+    } else if (type.isLongVector()) {
+        if (!type.hasSpecConstantVectorComponents() && index >= type.computeNumComponents()) {
+            error(loc, "", "[", "vector index out of range '%d'", index);
+            index = type.computeNumComponents() - 1;
+        }
     }
 }
 

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -773,6 +773,7 @@ INSTANTIATE_TEST_SUITE_P(
         "spv.longVectorBadParams.decls.comp",
         "spv.longVectorBadParams.constructors.comp",
         "spv.longVectorBadParams.constructors.as.type.comp",
+        "spv.longVectorBadParams.index.comp",
         "spv.longVectorBuiltins.comp",
         "spv.longVectorBuiltinsfp16.comp",
         "spv.longVectorBuiltinsfp64.comp",


### PR DESCRIPTION
ASan, compute shader subscripting a `const vector<float, 8>` with 500:

    ConstantUnion.h:893: heap-buffer-overflow READ of size 12
      #1 glslang::TConstUnionArray::TConstUnionArray(TConstUnionArray const&, int, int)
      #2 glslang::TIntermediate::foldDereference(...) Constant.cpp:1315
      #3 glslang::TParseContext::handleBracketDereference(...) ParseHelper.cpp:601

checkIndex clamps arrays, vectors, matrices and cooperative vectors, but a
GL_EXT_long_vector keeps its component count in typeParameters->arraySizes, so
isVector() is false and nothing bounds the subscript before foldDereference
slices the constant array at size * index. Small overruns are quieter than the
trace suggests: `c[8]` on an 8-component vector reports no error and folds
whatever follows the pool allocation into an emitted OpConstant.

The new branch skips the clamp when the component count is a specialization
constant, the way the array branch already skips specialization-sized arrays.
