### PR TITLE
Remove en dash which fails the build with cl.exe

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -6155,7 +6155,7 @@ spv::Id TGlslangToSpvTraverser::convertGlslangToSpvType(const glslang::TType& ty
     }
 
     if (type.isLongVector()) {
-        // SPIR-V LongVectorEXT not needed when component count is literal 2–4.
+        // SPIR-V LongVectorEXT not needed when component count is literal 2-4.
         const bool needLongVectorCap = type.hasSpecConstantVectorComponents() ||
             (type.getTypeParameters()->arraySizes->getDimSize(0) < 2 ||
              type.getTypeParameters()->arraySizes->getDimSize(0) > 4);


### PR DESCRIPTION
Depending on the system locale, this unnecessary use of an en dash causes the build to fail.