### PR TITLE
SPIR-V Builder: Do not emit invalid SPIR-V code if the instruction lenngth exceeds the allowed length, log an error and return empty SPIR-V if error count isn't zero.

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -213,6 +213,9 @@ public:
 
     void finishSpv(bool compileOnly);
     void dumpSpv(std::vector<unsigned int>& out);
+    // Number of fatal SPIR-V build errors (e.g. an instruction that exceeds the
+    // per-instruction word-count limit). Non-zero means 'out' must be discarded.
+    unsigned int getErrorCount() const { return builder.getErrorCount(); }
 
 protected:
     friend class DescHeapLayoutEmitter;
@@ -12781,6 +12784,14 @@ void GlslangToSpv(const TIntermediate& intermediate, std::vector<unsigned int>& 
     root->traverse(&it);
     it.finishSpv(options->compileOnly);
     it.dumpSpv(spirv);
+    if (it.getErrorCount() > 0) {
+        // At least one instruction exceeded the SPIR-V per-instruction
+        // word-count limit; the error has been recorded (and logged, if a
+        // logger was supplied). Do not hand back a corrupt/invalid module.
+        spirv.clear();
+        GetThreadPoolAllocator().pop();
+        return;
+    }
 
 #if ENABLE_OPT
     // If from HLSL, run spirv-opt to "legalize" the SPIR-V for Vulkan

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -213,6 +213,9 @@ public:
 
     void finishSpv(bool compileOnly);
     void dumpSpv(std::vector<unsigned int>& out);
+    // Number of fatal SPIR-V build errors (e.g. an instruction that exceeds the
+    // per-instruction word-count limit). Non-zero means 'out' must be discarded.
+    unsigned int getErrorCount() const { return builder.getErrorCount(); }
 
 protected:
     friend class DescHeapLayoutEmitter;
@@ -12878,6 +12881,14 @@ void GlslangToSpv(const TIntermediate& intermediate, std::vector<unsigned int>& 
     root->traverse(&it);
     it.finishSpv(options->compileOnly);
     it.dumpSpv(spirv);
+    if (it.getErrorCount() > 0) {
+        // At least one instruction exceeded the SPIR-V per-instruction
+        // word-count limit; the error has been recorded (and logged, if a
+        // logger was supplied). Do not hand back a corrupt/invalid module.
+        spirv.clear();
+        GetThreadPoolAllocator().pop();
+        return;
+    }
 
 #if ENABLE_OPT
     // If from HLSL, run spirv-opt to "legalize" the SPIR-V for Vulkan

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -48,12 +48,19 @@
 #include "SpvBuilder.h"
 #include "spvUtil.h"
 #include "hex_float.h"
+#include "doc.h"
+
+#include <string>
 
 #ifndef _WIN32
     #include <cstdio>
 #endif
 
 namespace spv {
+
+SpvErrorReporter::~SpvErrorReporter()
+{
+}
 
 Builder::Builder(unsigned int spvVersion, unsigned int magicNumber, SpvBuildLogger* buildLogger) :
     spvVersion(spvVersion),
@@ -67,9 +74,17 @@ Builder::Builder(unsigned int spvVersion, unsigned int magicNumber, SpvBuildLogg
     entryPointFunction(nullptr),
     generatingOpCodeForSpecConst(false),
     descHeapByteArrayType(NoResult),
-    logger(buildLogger)
+    logger(buildLogger),
+    errorCount(0)
 {
     clearAccessChain();
+}
+
+void Builder::error(const std::string& message)
+{
+    ++errorCount;
+    if (logger != nullptr)
+        logger->error(message);
 }
 
 Builder::~Builder()
@@ -4942,7 +4957,7 @@ Id Builder::accessChainGetInferredType()
     return type;
 }
 
-void Builder::dump(std::vector<unsigned int>& out) const
+void Builder::dump(std::vector<unsigned int>& out)
 {
     // Header, before first instructions:
     out.push_back(MagicNumber);
@@ -4955,20 +4970,20 @@ void Builder::dump(std::vector<unsigned int>& out) const
     for (auto it = capabilities.cbegin(); it != capabilities.cend(); ++it) {
         Instruction capInst(0, 0, Op::OpCapability);
         capInst.addImmediateOperand(*it);
-        capInst.dump(out);
+        capInst.dump(out, *this);
     }
 
     for (auto it = extensions.cbegin(); it != extensions.cend(); ++it) {
         Instruction extInst(0, 0, Op::OpExtension);
         extInst.addStringOperand(it->c_str());
-        extInst.dump(out);
+        extInst.dump(out, *this);
     }
 
     dumpInstructions(out, imports);
     Instruction memInst(0, 0, Op::OpMemoryModel);
     memInst.addImmediateOperand(addressModel);
     memInst.addImmediateOperand(memoryModel);
-    memInst.dump(out);
+    memInst.dump(out, *this);
 
     // Instructions saved up while building:
     dumpInstructions(out, entryPoints);
@@ -4980,7 +4995,7 @@ void Builder::dump(std::vector<unsigned int>& out) const
     for (int e = 0; e < (int)sourceExtensions.size(); ++e) {
         Instruction sourceExtInst(0, 0, Op::OpSourceExtension);
         sourceExtInst.addStringOperand(sourceExtensions[e]);
-        sourceExtInst.dump(out);
+        sourceExtInst.dump(out, *this);
     }
     dumpInstructions(out, names);
     dumpModuleProcesses(out);
@@ -4992,7 +5007,7 @@ void Builder::dump(std::vector<unsigned int>& out) const
     dumpInstructions(out, externals);
 
     // The functions
-    module.dump(out);
+    module.dump(out, *this);
 }
 
 //
@@ -5205,7 +5220,7 @@ void Builder::createConditionalBranch(Id condition, Block* thenBlock, Block* els
 // [OpSourceContinued]
 // ...
 void Builder::dumpSourceInstructions(const spv::Id fileId, const std::string& text,
-                                     std::vector<unsigned int>& out) const
+                                     std::vector<unsigned int>& out)
 {
     const int maxWordCount = 0xFFFF;
     const int opSourceWordCount = 4;
@@ -5229,24 +5244,24 @@ void Builder::dumpSourceInstructions(const spv::Id fileId, const std::string& te
                     if (nextByte == 0) {
                         // OpSource
                         sourceInst.addStringOperand(subString.c_str());
-                        sourceInst.dump(out);
+                        sourceInst.dump(out, *this);
                     } else {
                         // OpSourcContinued
                         Instruction sourceContinuedInst(Op::OpSourceContinued);
                         sourceContinuedInst.addStringOperand(subString.c_str());
-                        sourceContinuedInst.dump(out);
+                        sourceContinuedInst.dump(out, *this);
                     }
                     nextByte += nonNullBytesPerInstruction;
                 }
             } else
-                sourceInst.dump(out);
+                sourceInst.dump(out, *this);
         } else
-            sourceInst.dump(out);
+            sourceInst.dump(out, *this);
     }
 }
 
 // Dump an OpSource[Continued] sequence for the source and every include file
-void Builder::dumpSourceInstructions(std::vector<unsigned int>& out) const
+void Builder::dumpSourceInstructions(std::vector<unsigned int>& out)
 {
     if (emitNonSemanticShaderDebugInfo) return;
     dumpSourceInstructions(mainFileId, sourceText, out);
@@ -5254,20 +5269,59 @@ void Builder::dumpSourceInstructions(std::vector<unsigned int>& out) const
         dumpSourceInstructions(iItr->first, *iItr->second, out);
 }
 
-template <class Range> void Builder::dumpInstructions(std::vector<unsigned int>& out, const Range& instructions) const
+template <class Range> void Builder::dumpInstructions(std::vector<unsigned int>& out, const Range& instructions)
 {
     for (const auto& inst : instructions) {
-        inst->dump(out);
+        inst->dump(out, *this);
     }
 }
 
-void Builder::dumpModuleProcesses(std::vector<unsigned int>& out) const
+void Builder::dumpModuleProcesses(std::vector<unsigned int>& out)
 {
     for (int i = 0; i < (int)moduleProcesses.size(); ++i) {
         Instruction moduleProcessed(Op::OpModuleProcessed);
         moduleProcessed.addStringOperand(moduleProcesses[i]);
-        moduleProcessed.dump(out);
+        moduleProcessed.dump(out, *this);
     }
+}
+
+// SpvErrorReporter: a single SPIR-V instruction cannot be encoded because its
+// total word count exceeds the 16-bit WordCount header field (WordCountMax).
+// Build a clear, actionable message and record it via error(); the top level
+// rejects the module because the error count is now non-zero.
+void Builder::instructionWordCountOverflow(const Instruction& inst)
+{
+    const Op opCode = inst.getOpCode();
+    const size_t wordCount = inst.getWordCount();
+    const int numOperands = inst.getNumOperands();
+
+    std::string message = "SPIR-V: instruction ";
+    message += OpcodeString((int)opCode);
+    message += " would require ";
+    message += std::to_string(wordCount);
+    message += " words, exceeding the ";
+    message += std::to_string(WordCountMax);
+    message += "-word per-instruction limit";
+
+    switch (opCode) {
+    case Op::OpConstantComposite:
+    case Op::OpSpecConstantComposite:
+    case Op::OpConstantCompositeReplicateEXT:
+    case Op::OpSpecConstantCompositeReplicateEXT:
+        message += "; the constant aggregate has ";
+        message += std::to_string(numOperands);
+        message += " constituents (max ";
+        message += std::to_string(WordCountMax - 3);
+        message += "). Reduce the constant size or move it into a (uniform/storage) buffer.";
+        break;
+    default:
+        message += "; the instruction has ";
+        message += std::to_string(numOperands);
+        message += " operands. Reduce the size of the construct.";
+        break;
+    }
+
+    error(message);
 }
 
 bool Builder::DecorationInstructionLessThan::operator()(const std::unique_ptr<Instruction>& lhs,

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -48,12 +48,19 @@
 #include "SpvBuilder.h"
 #include "spvUtil.h"
 #include "hex_float.h"
+#include "doc.h"
+
+#include <string>
 
 #ifndef _WIN32
     #include <cstdio>
 #endif
 
 namespace spv {
+
+SpvErrorReporter::~SpvErrorReporter()
+{
+}
 
 Builder::Builder(unsigned int spvVersion, unsigned int magicNumber, SpvBuildLogger* buildLogger) :
     spvVersion(spvVersion),
@@ -67,9 +74,17 @@ Builder::Builder(unsigned int spvVersion, unsigned int magicNumber, SpvBuildLogg
     entryPointFunction(nullptr),
     generatingOpCodeForSpecConst(false),
     descHeapByteArrayType(NoResult),
-    logger(buildLogger)
+    logger(buildLogger),
+    errorCount(0)
 {
     clearAccessChain();
+}
+
+void Builder::error(const std::string& message)
+{
+    ++errorCount;
+    if (logger != nullptr)
+        logger->error(message);
 }
 
 Builder::~Builder()
@@ -4945,7 +4960,7 @@ Id Builder::accessChainGetInferredType()
     return type;
 }
 
-void Builder::dump(std::vector<unsigned int>& out) const
+void Builder::dump(std::vector<unsigned int>& out)
 {
     // Header, before first instructions:
     out.push_back(MagicNumber);
@@ -4958,20 +4973,20 @@ void Builder::dump(std::vector<unsigned int>& out) const
     for (auto it = capabilities.cbegin(); it != capabilities.cend(); ++it) {
         Instruction capInst(0, 0, Op::OpCapability);
         capInst.addImmediateOperand(*it);
-        capInst.dump(out);
+        capInst.dump(out, *this);
     }
 
     for (auto it = extensions.cbegin(); it != extensions.cend(); ++it) {
         Instruction extInst(0, 0, Op::OpExtension);
         extInst.addStringOperand(it->c_str());
-        extInst.dump(out);
+        extInst.dump(out, *this);
     }
 
     dumpInstructions(out, imports);
     Instruction memInst(0, 0, Op::OpMemoryModel);
     memInst.addImmediateOperand(addressModel);
     memInst.addImmediateOperand(memoryModel);
-    memInst.dump(out);
+    memInst.dump(out, *this);
 
     // Instructions saved up while building:
     dumpInstructions(out, entryPoints);
@@ -4983,7 +4998,7 @@ void Builder::dump(std::vector<unsigned int>& out) const
     for (int e = 0; e < (int)sourceExtensions.size(); ++e) {
         Instruction sourceExtInst(0, 0, Op::OpSourceExtension);
         sourceExtInst.addStringOperand(sourceExtensions[e]);
-        sourceExtInst.dump(out);
+        sourceExtInst.dump(out, *this);
     }
     dumpInstructions(out, names);
     dumpModuleProcesses(out);
@@ -4995,7 +5010,7 @@ void Builder::dump(std::vector<unsigned int>& out) const
     dumpInstructions(out, externals);
 
     // The functions
-    module.dump(out);
+    module.dump(out, *this);
 }
 
 //
@@ -5208,7 +5223,7 @@ void Builder::createConditionalBranch(Id condition, Block* thenBlock, Block* els
 // [OpSourceContinued]
 // ...
 void Builder::dumpSourceInstructions(const spv::Id fileId, const std::string& text,
-                                     std::vector<unsigned int>& out) const
+                                     std::vector<unsigned int>& out)
 {
     const int maxWordCount = 0xFFFF;
     const int opSourceWordCount = 4;
@@ -5232,24 +5247,24 @@ void Builder::dumpSourceInstructions(const spv::Id fileId, const std::string& te
                     if (nextByte == 0) {
                         // OpSource
                         sourceInst.addStringOperand(subString.c_str());
-                        sourceInst.dump(out);
+                        sourceInst.dump(out, *this);
                     } else {
                         // OpSourcContinued
                         Instruction sourceContinuedInst(Op::OpSourceContinued);
                         sourceContinuedInst.addStringOperand(subString.c_str());
-                        sourceContinuedInst.dump(out);
+                        sourceContinuedInst.dump(out, *this);
                     }
                     nextByte += nonNullBytesPerInstruction;
                 }
             } else
-                sourceInst.dump(out);
+                sourceInst.dump(out, *this);
         } else
-            sourceInst.dump(out);
+            sourceInst.dump(out, *this);
     }
 }
 
 // Dump an OpSource[Continued] sequence for the source and every include file
-void Builder::dumpSourceInstructions(std::vector<unsigned int>& out) const
+void Builder::dumpSourceInstructions(std::vector<unsigned int>& out)
 {
     if (emitNonSemanticShaderDebugInfo) return;
     dumpSourceInstructions(mainFileId, sourceText, out);
@@ -5257,20 +5272,59 @@ void Builder::dumpSourceInstructions(std::vector<unsigned int>& out) const
         dumpSourceInstructions(iItr->first, *iItr->second, out);
 }
 
-template <class Range> void Builder::dumpInstructions(std::vector<unsigned int>& out, const Range& instructions) const
+template <class Range> void Builder::dumpInstructions(std::vector<unsigned int>& out, const Range& instructions)
 {
     for (const auto& inst : instructions) {
-        inst->dump(out);
+        inst->dump(out, *this);
     }
 }
 
-void Builder::dumpModuleProcesses(std::vector<unsigned int>& out) const
+void Builder::dumpModuleProcesses(std::vector<unsigned int>& out)
 {
     for (int i = 0; i < (int)moduleProcesses.size(); ++i) {
         Instruction moduleProcessed(Op::OpModuleProcessed);
         moduleProcessed.addStringOperand(moduleProcesses[i]);
-        moduleProcessed.dump(out);
+        moduleProcessed.dump(out, *this);
     }
+}
+
+// SpvErrorReporter: a single SPIR-V instruction cannot be encoded because its
+// total word count exceeds the 16-bit WordCount header field (WordCountMax).
+// Build a clear, actionable message and record it via error(); the top level
+// rejects the module because the error count is now non-zero.
+void Builder::instructionWordCountOverflow(const Instruction& inst)
+{
+    const Op opCode = inst.getOpCode();
+    const size_t wordCount = inst.getWordCount();
+    const int numOperands = inst.getNumOperands();
+
+    std::string message = "SPIR-V: instruction ";
+    message += OpcodeString((int)opCode);
+    message += " would require ";
+    message += std::to_string(wordCount);
+    message += " words, exceeding the ";
+    message += std::to_string(WordCountMax);
+    message += "-word per-instruction limit";
+
+    switch (opCode) {
+    case Op::OpConstantComposite:
+    case Op::OpSpecConstantComposite:
+    case Op::OpConstantCompositeReplicateEXT:
+    case Op::OpSpecConstantCompositeReplicateEXT:
+        message += "; the constant aggregate has ";
+        message += std::to_string(numOperands);
+        message += " constituents (max ";
+        message += std::to_string(WordCountMax - 3);
+        message += "). Reduce the constant size or move it into a (uniform/storage) buffer.";
+        break;
+    default:
+        message += "; the instruction has ";
+        message += std::to_string(numOperands);
+        message += " operands. Reduce the size of the construct.";
+        break;
+    }
+
+    error(message);
 }
 
 bool Builder::DecorationInstructionLessThan::operator()(const std::unique_ptr<Instruction>& lhs,

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -90,7 +90,7 @@ struct StructMemberDebugInfo {
     spv::Id debugTypeOverride {0};
 };
 
-class Builder {
+class Builder : public SpvErrorReporter {
     class CompositeConstantKey {
     public:
         enum Kind {
@@ -318,6 +318,19 @@ class Builder {
 public:
     Builder(unsigned int spvVersion, unsigned int userNumber, SpvBuildLogger* logger);
     virtual ~Builder();
+
+    // Record a fatal build error. Always increments the error count (so it is
+    // observable even when no logger is attached) and, when a logger exists,
+    // forwards the human-readable message to it.
+    void error(const std::string& message);
+    // Number of fatal errors recorded so far. The top level checks this after
+    // serialization to decide whether the produced module must be discarded.
+    unsigned int getErrorCount() const { return errorCount; }
+
+    // SpvErrorReporter: called from serialization when an instruction is too
+    // long to encode. Builds the meaningful diagnostic and records it via
+    // error().
+    void instructionWordCountOverflow(const Instruction& inst) override;
 
     static const int maxMatrixSize = 4;
 
@@ -1240,7 +1253,11 @@ public:
     // move OpSampledImage instructions to be next to their users.
     void postProcessSamplers();
 
-    void dump(std::vector<unsigned int>&) const;
+    // Serialize the whole module into 'out'. If any instruction was too long
+    // to encode within the SPIR-V 16-bit per-instruction word-count limit, the
+    // error is recorded (see getErrorCount()); the caller must then discard
+    // 'out', as it does not contain a valid module.
+    void dump(std::vector<unsigned int>&);
 
     // Add a branch to the target block.
     // If set implicit, the branch instruction shouldn't have debug source location.
@@ -1274,10 +1291,13 @@ protected:
     void simplifyAccessChainSwizzle();
     void createAndSetNoPredecessorBlock(const char*);
     void createSelectionMerge(Block* mergeBlock, SelectionControlMask control);
-    void dumpSourceInstructions(std::vector<unsigned int>&) const;
-    void dumpSourceInstructions(const spv::Id fileId, const std::string& text, std::vector<unsigned int>&) const;
-    template <class Range> void dumpInstructions(std::vector<unsigned int>& out, const Range& instructions) const;
-    void dumpModuleProcesses(std::vector<unsigned int>&) const;
+    // The dump* helpers below are non-const because serialization can record
+    // an error (via the SpvErrorReporter that the Builder implements) when an
+    // instruction exceeds the SPIR-V per-instruction word-count limit.
+    void dumpSourceInstructions(std::vector<unsigned int>&);
+    void dumpSourceInstructions(const spv::Id fileId, const std::string& text, std::vector<unsigned int>&);
+    template <class Range> void dumpInstructions(std::vector<unsigned int>& out, const Range& instructions);
+    void dumpModuleProcesses(std::vector<unsigned int>&);
     spv::MemoryAccessMask sanitizeMemoryAccessForStorageClass(spv::MemoryAccessMask memoryAccess, StorageClass sc)
         const;
     struct DecorationInstructionLessThan {
@@ -1464,6 +1484,10 @@ protected:
 
     // The stream for outputting warnings and errors.
     SpvBuildLogger* logger;
+
+    // Count of fatal errors recorded via error(). Maintained independently of
+    // 'logger' so the build outcome is observable even without a message sink.
+    unsigned int errorCount;
 };  // end Builder class
 
 } // end spv namespace

--- a/SPIRV/spvIR.h
+++ b/SPIRV/spvIR.h
@@ -63,11 +63,32 @@ namespace spv {
 class Block;
 class Function;
 class Module;
+class Instruction;
 
 const Id NoResult = 0;
 const Id NoType = 0;
 
 const Decoration NoPrecision = Decoration::Max;
+
+// A SPIR-V instruction stores its total word count (including the opcode
+// header word) in the high 16 bits of its first word. That field cannot hold
+// a value larger than this, so no single instruction may be longer than this
+// many words. This is a hard physical-encoding limit from the SPIR-V spec's
+// "Physical Layout"; it is not a target/driver option and cannot be raised.
+const unsigned int WordCountMax = 0xFFFFu;
+
+//
+// Receives fatal errors discovered while serializing SPIR-V.
+//
+class SpvErrorReporter {
+public:
+    virtual ~SpvErrorReporter();
+
+    // Report that 'inst' cannot be encoded because its total word count would
+    // overflow the 16-bit per-instruction WordCount field (WordCountMax).
+    // Implementations must count the error and produce a meaningful message.
+    virtual void instructionWordCountOverflow(const Instruction& inst) = 0;
+};
 
 #ifdef __GNUC__
 #   define POTENTIALLY_UNUSED __attribute__((unused))
@@ -237,19 +258,41 @@ public:
         return operands[op];
     }
 
-    // Write out the binary form.
-    void dump(std::vector<unsigned int>& out) const
+    // Total number of words this instruction occupies when serialized,
+    // including the leading opcode/word-count header word. Computed as a
+    // wide (non-truncating) type so callers can detect an over-limit
+    // instruction before it is packed into the 16-bit WordCount field.
+    size_t getWordCount() const
     {
-        // Compute the wordCount
-        unsigned int wordCount = 1;
+        size_t wordCount = 1;
         if (typeId)
             ++wordCount;
         if (resultId)
             ++wordCount;
-        wordCount += (unsigned int)operands.size();
+        wordCount += operands.size();
+        return wordCount;
+    }
+
+    // Write out the binary form.
+    // If this instruction is too long to encode (its word count would overflow
+    // the 16-bit WordCount header field), nothing is written to 'out'; instead
+    // the problem is reported to 'errorReporter' (which counts it) so the build can
+    // be rejected at the top level. This never writes a silently truncated (and
+    // therefore corrupt) instruction header.
+    void dump(std::vector<unsigned int>& out, SpvErrorReporter& errorReporter) const
+    {
+        const size_t wordCount = getWordCount();
+
+        // The WordCount header field is only 16 bits wide. A larger value
+        // would be truncated by the shift below, desynchronizing any parser
+        // that reads the resulting stream. Report it rather than corrupt.
+        if (wordCount > WordCountMax) {
+            errorReporter.instructionWordCountOverflow(*this);
+            return;
+        }
 
         // Write out the beginning of the instruction
-        out.push_back(((wordCount) << WordCountShift) | (unsigned)opCode);
+        out.push_back(((unsigned int)wordCount << WordCountShift) | (unsigned)opCode);
         if (typeId)
             out.push_back(typeId);
         if (resultId)
@@ -393,13 +436,13 @@ public:
         }
     }
 
-    void dump(std::vector<unsigned int>& out) const
+    void dump(std::vector<unsigned int>& out, SpvErrorReporter& errorReporter) const
     {
-        instructions[0]->dump(out);
+        instructions[0]->dump(out, errorReporter);
         for (int i = 0; i < (int)localVariables.size(); ++i)
-            localVariables[i]->dump(out);
+            localVariables[i]->dump(out, errorReporter);
         for (int i = 1; i < (int)instructions.size(); ++i)
-            instructions[i]->dump(out);
+            instructions[i]->dump(out, errorReporter);
     }
 
 protected:
@@ -516,24 +559,26 @@ public:
             Decoration::RelaxedPrecision : NoPrecision;
     }
 
-    void dump(std::vector<unsigned int>& out) const
+    void dump(std::vector<unsigned int>& out, SpvErrorReporter& errorReporter) const
     {
         // OpLine
         if (lineInstruction != nullptr) {
-            lineInstruction->dump(out);
+            lineInstruction->dump(out, errorReporter);
         }
 
         // OpFunction
-        functionInstruction.dump(out);
+        functionInstruction.dump(out, errorReporter);
 
         // OpFunctionParameter
         for (int p = 0; p < (int)parameterInstructions.size(); ++p)
-            parameterInstructions[p]->dump(out);
+            parameterInstructions[p]->dump(out, errorReporter);
 
         // Blocks
-        inReadableOrder(blocks[0], [&out](const Block* b, ReachReason, Block*) { b->dump(out); });
+        inReadableOrder(blocks[0], [&out, &errorReporter](const Block* b, ReachReason, Block*) {
+            b->dump(out, errorReporter);
+        });
         Instruction end(0, 0, Op::OpFunctionEnd);
-        end.dump(out);
+        end.dump(out, errorReporter);
     }
 
     LinkageType getLinkType() const { return linkType; }
@@ -590,10 +635,10 @@ public:
         return (StorageClass)idToInstruction[typeId]->getImmediateOperand(0);
     }
 
-    void dump(std::vector<unsigned int>& out) const
+    void dump(std::vector<unsigned int>& out, SpvErrorReporter& errorReporter) const
     {
         for (int f = 0; f < (int)functions.size(); ++f)
-            functions[f]->dump(out);
+            functions[f]->dump(out, errorReporter);
     }
 
 protected:


### PR DESCRIPTION
- every SPIR-V instruction has a length field that is limited to 16 bit, allowing a maximum of 65535 words
- however, several instruction are created from GLSL entities that have looser restrictions
- a "typical case" when this might happen is a constant array that is too long
- detect this case and send error messages to a logger if the user has set one and stop, do not depend on optional validation pass