### PR TITLE
fix oob deref on undeclared ray tracing location

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -4498,6 +4498,10 @@ bool TGlslangToSpvTraverser::visitAggregate(glslang::TVisit visit, glslang::TInt
                  const int set = glslangOp == glslang::EOpExecuteCallableKHR ? 1 : 0;
                  const int location = glslangOperands[arg]->getAsConstantUnion()->getConstArray()[0].getUConst();
                  auto itNode = locationToSymbol[set].find(location);
+                 if (itNode == locationToSymbol[set].end()) {
+                     logger->missingFunctionality("ray tracing location with no matching payload/callable data declaration");
+                     break;
+                 }
                  visitSymbol(itNode->second);
                  spv::Id symId = getSymbolId(itNode->second);
                  operands.push_back(symId);
@@ -4511,6 +4515,10 @@ bool TGlslangToSpvTraverser::visitAggregate(glslang::TVisit visit, glslang::TInt
                  const int location = glslangOperands[arg]->getAsConstantUnion()->getConstArray()[0].getUConst();
                  const int set = 2;
                  auto itNode = locationToSymbol[set].find(location);
+                 if (itNode == locationToSymbol[set].end()) {
+                     logger->missingFunctionality("ray tracing location with no matching hit object attribute declaration");
+                     break;
+                 }
                  visitSymbol(itNode->second);
                  spv::Id symId = getSymbolId(itNode->second);
                  operands.push_back(symId);

--- a/Test/baseResults/spv.RayGenShaderMotion_Errors.rgen.out
+++ b/Test/baseResults/spv.RayGenShaderMotion_Errors.rgen.out
@@ -1,0 +1,6 @@
+spv.RayGenShaderMotion_Errors.rgen
+ERROR: 0:12: 'no rayPayloadEXT/rayPayloadInEXT declared' : with layout(location = 1)
+ERROR: 1 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.RayGenShaderMotion_Errors.rgen
+++ b/Test/spv.RayGenShaderMotion_Errors.rgen
@@ -1,0 +1,13 @@
+#version 460
+#extension GL_EXT_ray_tracing : enable
+#extension GL_NV_ray_tracing_motion_blur : enable
+
+layout(binding = 0, set = 0) uniform accelerationStructureEXT accEXT;
+layout(location = 0) rayPayloadEXT vec4 payloadEXT;
+
+void main()
+{
+    // Payload location 1 is never declared. This must be diagnosed like traceRayEXT,
+    // not reach code generation where the payload location is looked up.
+    traceRayMotionNV(accEXT, 0u, 0u, 0u, 0u, 0u, vec3(0.5), 0.5f, vec3(1.0), 0.75f, 0.5, 1);
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3342,7 +3342,7 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
         checkConstantArgWithLocation(10, "payload number", nullptr, -1);
         break;
     case EOpTraceRayMotionNV:
-        checkConstantArgWithLocation(11, "payload number", nullptr, -1);
+        checkConstantArgWithLocation(11, "payload number", "no rayPayloadEXT/rayPayloadInEXT declared", 0);
         break;
     case EOpTraceKHR:
         checkConstantArgWithLocation(10, "payload number", "no rayPayloadEXT/rayPayloadInEXT declared", 0);

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -1166,6 +1166,7 @@ INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileVulkanToSpirv14TestNV,
     ::testing::ValuesIn(std::vector<std::string>({
     "spv.RayGenShaderMotion.rgen",
+    "spv.RayGenShaderMotion_Errors.rgen",
     "spv.IntersectShaderMotion.rint",
     "spv.AnyHitShaderMotion.rahit",
     "spv.ClosestHitShaderMotion.rchit",


### PR DESCRIPTION
ASan, an rgen calling traceRayMotionNV with a payload location that was never declared:

    SEGV on unknown address 0x000000000018
        #0 TGlslangToSpvTraverser::visitAggregate() GlslangToSpv.cpp:4572

The ray tracing lowering looks the payload/callable/attribute number up in locationToSymbol[set] and dereferences the iterator without checking that find() hit; every other find() in this file guards end() first. traceRayMotionNV also passed -1 to checkConstantArgWithLocation (no location check) while its traceRayEXT sibling passes 0, so an undeclared location slips through to code generation. Validate it like traceRayEXT, and guard both lookups against end() so the GL_EXT_spirv_intrinsics path, which skips the front-end check by design, cannot dereference a missing entry.