### PR TITLE
fix oob read folding component-wise intrinsics on matrices

### DIFF
--- a/Test/baseResults/hlsl.constantfold.matrix.frag.out
+++ b/Test/baseResults/hlsl.constantfold.matrix.frag.out
@@ -1,0 +1,290 @@
+hlsl.constantfold.matrix.frag
+Shader version: 500
+gl_FragCoord origin is upper left
+0:? Sequence
+0:5  Function Definition: @main( ( temp 4-component vector of float)
+0:5    Function Parameters: 
+0:?     Sequence
+0:6      Sequence
+0:6        move second child to first child ( temp 2X2 matrix of float)
+0:6          'mn' ( temp 2X2 matrix of float)
+0:6          Constant:
+0:6            1.000000
+0:6            2.000000
+0:6            2.000000
+0:6            1.000000
+0:7      Sequence
+0:7        move second child to first child ( temp 2X2 matrix of float)
+0:7          'mx' ( temp 2X2 matrix of float)
+0:7          Constant:
+0:7            4.000000
+0:7            3.000000
+0:7            3.000000
+0:7            4.000000
+0:8      Sequence
+0:8        move second child to first child ( temp 2X2 matrix of float)
+0:8          'cl' ( temp 2X2 matrix of float)
+0:8          Constant:
+0:8            1.000000
+0:8            5.000000
+0:8            8.000000
+0:8            1.000000
+0:9      Sequence
+0:9        move second child to first child ( temp 2X2 matrix of float)
+0:9          'lp' ( temp 2X2 matrix of float)
+0:9          Constant:
+0:9            1.000000
+0:9            2.000000
+0:9            3.000000
+0:9            4.000000
+0:10      Sequence
+0:10        move second child to first child ( temp 2X2 matrix of float)
+0:10          'st' ( temp 2X2 matrix of float)
+0:10          Constant:
+0:10            1.000000
+0:10            1.000000
+0:10            0.000000
+0:10            0.000000
+0:11      Sequence
+0:11        move second child to first child ( temp 2X2 matrix of float)
+0:11          'ss' ( temp 2X2 matrix of float)
+0:11          Constant:
+0:11            0.500000
+0:11            0.500000
+0:11            0.500000
+0:11            0.500000
+0:13      Branch: Return with expression
+0:13        Construct vec4 ( temp 4-component vector of float)
+0:13          add ( temp 2-component vector of float)
+0:13            add ( temp 2-component vector of float)
+0:13              add ( temp 2-component vector of float)
+0:13                direct index ( temp 2-component vector of float)
+0:13                  'mn' ( temp 2X2 matrix of float)
+0:13                  Constant:
+0:13                    0 (const int)
+0:13                direct index ( temp 2-component vector of float)
+0:13                  'mx' ( temp 2X2 matrix of float)
+0:13                  Constant:
+0:13                    0 (const int)
+0:13              direct index ( temp 2-component vector of float)
+0:13                'cl' ( temp 2X2 matrix of float)
+0:13                Constant:
+0:13                  0 (const int)
+0:13            direct index ( temp 2-component vector of float)
+0:13              'lp' ( temp 2X2 matrix of float)
+0:13              Constant:
+0:13                0 (const int)
+0:13          add ( temp 2-component vector of float)
+0:13            direct index ( temp 2-component vector of float)
+0:13              'st' ( temp 2X2 matrix of float)
+0:13              Constant:
+0:13                0 (const int)
+0:13            direct index ( temp 2-component vector of float)
+0:13              'ss' ( temp 2X2 matrix of float)
+0:13              Constant:
+0:13                0 (const int)
+0:5  Function Definition: main( ( temp void)
+0:5    Function Parameters: 
+0:?     Sequence
+0:5      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:5        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+0:? Sequence
+0:5  Function Definition: @main( ( temp 4-component vector of float)
+0:5    Function Parameters: 
+0:?     Sequence
+0:6      Sequence
+0:6        move second child to first child ( temp 2X2 matrix of float)
+0:6          'mn' ( temp 2X2 matrix of float)
+0:6          Constant:
+0:6            1.000000
+0:6            2.000000
+0:6            2.000000
+0:6            1.000000
+0:7      Sequence
+0:7        move second child to first child ( temp 2X2 matrix of float)
+0:7          'mx' ( temp 2X2 matrix of float)
+0:7          Constant:
+0:7            4.000000
+0:7            3.000000
+0:7            3.000000
+0:7            4.000000
+0:8      Sequence
+0:8        move second child to first child ( temp 2X2 matrix of float)
+0:8          'cl' ( temp 2X2 matrix of float)
+0:8          Constant:
+0:8            1.000000
+0:8            5.000000
+0:8            8.000000
+0:8            1.000000
+0:9      Sequence
+0:9        move second child to first child ( temp 2X2 matrix of float)
+0:9          'lp' ( temp 2X2 matrix of float)
+0:9          Constant:
+0:9            1.000000
+0:9            2.000000
+0:9            3.000000
+0:9            4.000000
+0:10      Sequence
+0:10        move second child to first child ( temp 2X2 matrix of float)
+0:10          'st' ( temp 2X2 matrix of float)
+0:10          Constant:
+0:10            1.000000
+0:10            1.000000
+0:10            0.000000
+0:10            0.000000
+0:11      Sequence
+0:11        move second child to first child ( temp 2X2 matrix of float)
+0:11          'ss' ( temp 2X2 matrix of float)
+0:11          Constant:
+0:11            0.500000
+0:11            0.500000
+0:11            0.500000
+0:11            0.500000
+0:13      Branch: Return with expression
+0:13        Construct vec4 ( temp 4-component vector of float)
+0:13          add ( temp 2-component vector of float)
+0:13            add ( temp 2-component vector of float)
+0:13              add ( temp 2-component vector of float)
+0:13                direct index ( temp 2-component vector of float)
+0:13                  'mn' ( temp 2X2 matrix of float)
+0:13                  Constant:
+0:13                    0 (const int)
+0:13                direct index ( temp 2-component vector of float)
+0:13                  'mx' ( temp 2X2 matrix of float)
+0:13                  Constant:
+0:13                    0 (const int)
+0:13              direct index ( temp 2-component vector of float)
+0:13                'cl' ( temp 2X2 matrix of float)
+0:13                Constant:
+0:13                  0 (const int)
+0:13            direct index ( temp 2-component vector of float)
+0:13              'lp' ( temp 2X2 matrix of float)
+0:13              Constant:
+0:13                0 (const int)
+0:13          add ( temp 2-component vector of float)
+0:13            direct index ( temp 2-component vector of float)
+0:13              'st' ( temp 2X2 matrix of float)
+0:13              Constant:
+0:13                0 (const int)
+0:13            direct index ( temp 2-component vector of float)
+0:13              'ss' ( temp 2X2 matrix of float)
+0:13              Constant:
+0:13                0 (const int)
+0:5  Function Definition: main( ( temp void)
+0:5    Function Parameters: 
+0:?     Sequence
+0:5      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:5        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+// Module Version 10000
+// Generated by (magic number): 8000b
+// Id's are bound by 72
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main" 70
+                              ExecutionMode 4 OriginUpperLeft
+                              Source HLSL 500
+                              Name 4  "main"
+                              Name 9  "@main("
+                              Name 14  "mn"
+                              Name 20  "mx"
+                              Name 26  "cl"
+                              Name 32  "lp"
+                              Name 34  "st"
+                              Name 39  "ss"
+                              Name 70  "@entryPointOutput"
+                              Decorate 70(@entryPointOutput) Location 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+               8:             TypeFunction 7(fvec4)
+              11:             TypeVector 6(float) 2
+              12:             TypeMatrix 11(fvec2) 2
+              13:             TypePointer Function 12
+              15:    6(float) Constant 1065353216
+              16:    6(float) Constant 1073741824
+              17:   11(fvec2) ConstantComposite 15 16
+              18:   11(fvec2) ConstantComposite 16 15
+              19:          12 ConstantComposite 17 18
+              21:    6(float) Constant 1082130432
+              22:    6(float) Constant 1077936128
+              23:   11(fvec2) ConstantComposite 21 22
+              24:   11(fvec2) ConstantComposite 22 21
+              25:          12 ConstantComposite 23 24
+              27:    6(float) Constant 1084227584
+              28:   11(fvec2) ConstantComposite 15 27
+              29:    6(float) Constant 1090519040
+              30:   11(fvec2) ConstantComposite 29 15
+              31:          12 ConstantComposite 28 30
+              33:          12 ConstantComposite 17 24
+              35:   11(fvec2) ConstantComposite 15 15
+              36:    6(float) Constant 0
+              37:   11(fvec2) ConstantComposite 36 36
+              38:          12 ConstantComposite 35 37
+              40:    6(float) Constant 1056964608
+              41:   11(fvec2) ConstantComposite 40 40
+              42:          12 ConstantComposite 41 41
+              43:             TypeInt 32 1
+              44:     43(int) Constant 0
+              45:             TypePointer Function 11(fvec2)
+              69:             TypePointer Output 7(fvec4)
+70(@entryPointOutput):     69(ptr) Variable Output
+         4(main):           2 Function None 3
+               5:             Label
+              71:    7(fvec4) FunctionCall 9(@main()
+                              Store 70(@entryPointOutput) 71
+                              Return
+                              FunctionEnd
+       9(@main():    7(fvec4) Function None 8
+              10:             Label
+          14(mn):     13(ptr) Variable Function
+          20(mx):     13(ptr) Variable Function
+          26(cl):     13(ptr) Variable Function
+          32(lp):     13(ptr) Variable Function
+          34(st):     13(ptr) Variable Function
+          39(ss):     13(ptr) Variable Function
+                              Store 14(mn) 19
+                              Store 20(mx) 25
+                              Store 26(cl) 31
+                              Store 32(lp) 33
+                              Store 34(st) 38
+                              Store 39(ss) 42
+              46:     45(ptr) AccessChain 14(mn) 44
+              47:   11(fvec2) Load 46
+              48:     45(ptr) AccessChain 20(mx) 44
+              49:   11(fvec2) Load 48
+              50:   11(fvec2) FAdd 47 49
+              51:     45(ptr) AccessChain 26(cl) 44
+              52:   11(fvec2) Load 51
+              53:   11(fvec2) FAdd 50 52
+              54:     45(ptr) AccessChain 32(lp) 44
+              55:   11(fvec2) Load 54
+              56:   11(fvec2) FAdd 53 55
+              57:     45(ptr) AccessChain 34(st) 44
+              58:   11(fvec2) Load 57
+              59:     45(ptr) AccessChain 39(ss) 44
+              60:   11(fvec2) Load 59
+              61:   11(fvec2) FAdd 58 60
+              62:    6(float) CompositeExtract 56 0
+              63:    6(float) CompositeExtract 56 1
+              64:    6(float) CompositeExtract 61 0
+              65:    6(float) CompositeExtract 61 1
+              66:    7(fvec4) CompositeConstruct 62 63 64 65
+                              ReturnValue 66
+                              FunctionEnd

--- a/Test/hlsl.constantfold.matrix.frag
+++ b/Test/hlsl.constantfold.matrix.frag
@@ -1,0 +1,14 @@
+// Constant folding of component-wise intrinsics whose operands are matrices.
+// getVectorSize() is 0 for a matrix, so these used to fold with a -1 smear
+// index (min/max/clamp/pow/lerp) or a zero-length result (step/smoothstep).
+float4 main() : SV_Target
+{
+    float2x2 mn = min(float2x2(1, 2, 3, 4), float2x2(4, 3, 2, 1));
+    float2x2 mx = max(float2x2(1, 2, 3, 4), float2x2(4, 3, 2, 1));
+    float2x2 cl = clamp(float2x2(0, 5, 10, -2), float2x2(1, 1, 1, 1), float2x2(8, 8, 8, 8));
+    float2x2 lp = lerp(float2x2(0, 0, 0, 0), float2x2(4, 4, 4, 4), float2x2(0.25, 0.5, 0.75, 1.0));
+    float2x2 st = step(float2x2(1, 2, 3, 4), float2x2(4, 3, 2, 1));
+    float2x2 ss = smoothstep(float2x2(0, 0, 0, 0), float2x2(2, 2, 2, 2), float2x2(1, 1, 1, 1));
+
+    return float4(mn[0] + mx[0] + cl[0] + lp[0], st[0] + ss[0]);
+}

--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -974,13 +974,13 @@ TIntermTyped* TIntermediate::fold(TIntermAggregate* aggrNode)
         break;
     case EOpStep:
         componentwise = true;
-        objectSize = std::max(children[0]->getAsTyped()->getType().getVectorSize(),
-                              children[1]->getAsTyped()->getType().getVectorSize());
+        objectSize = std::max(children[0]->getAsTyped()->getType().computeNumComponents(),
+                              children[1]->getAsTyped()->getType().computeNumComponents());
         break;
     case EOpSmoothStep:
         componentwise = true;
-        objectSize = std::max(children[0]->getAsTyped()->getType().getVectorSize(),
-                              children[2]->getAsTyped()->getType().getVectorSize());
+        objectSize = std::max(children[0]->getAsTyped()->getType().computeNumComponents(),
+                              children[2]->getAsTyped()->getType().computeNumComponents());
         break;
     case EOpMul:
         {
@@ -1001,13 +1001,13 @@ TIntermTyped* TIntermediate::fold(TIntermAggregate* aggrNode)
         for (int comp = 0; comp < objectSize; comp++) {
 
             // some arguments are scalars instead of matching vectors; simulate a smear
-            int arg0comp = std::min(comp, children[0]->getAsTyped()->getType().getVectorSize() - 1);
+            int arg0comp = std::min(comp, children[0]->getAsTyped()->getType().computeNumComponents() - 1);
             int arg1comp = 0;
             if (children.size() > 1)
-                arg1comp = std::min(comp, children[1]->getAsTyped()->getType().getVectorSize() - 1);
+                arg1comp = std::min(comp, children[1]->getAsTyped()->getType().computeNumComponents() - 1);
             int arg2comp = 0;
             if (children.size() > 2)
-                arg2comp = std::min(comp, children[2]->getAsTyped()->getType().getVectorSize() - 1);
+                arg2comp = std::min(comp, children[2]->getAsTyped()->getType().computeNumComponents() - 1);
 
             switch (aggrNode->getOp()) {
             case EOpAtan:

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -214,6 +214,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.comparison.vec.frag", "main"},
         {"hlsl.conditional.frag", "PixelShaderFunction"},
         {"hlsl.constantbuffer.frag", "main"},
+        {"hlsl.constantfold.matrix.frag", "main"},
         {"hlsl.constructArray.vert", "main"},
         {"hlsl.constructexpr.frag", "main"},
         {"hlsl.constructimat.frag", "main"},


### PR DESCRIPTION
1. component-wise intrinsic folding (min/max/clamp/pow/lerp) clamps the per-argument smear with getVectorSize(), which is 0 for a matrix, so a constant matrix operand indexes the TConstUnionArray at -1 (reads one TConstUnion before the pool buffer and folds those bytes into the emitted constant).
2. step/smoothstep size the whole result with getVectorSize() too, so a matrix gives a zero-length array carrying a 4-component type, and foldDereference/foldConstructor then dereference the null vector and crash.

Both now use computeNumComponents(), matching the other component-wise ops. HLSL declares these with the scalar/vector/matrix signature, so a short fragment reaches the path. Added Test/hlsl.constantfold.matrix.frag folding min/max/clamp/lerp/step/smoothstep on float2x2; it SEGVs on the current tree and folds correctly after the change.