### PR TITLE
Fix string escaping in preprocessed output

### DIFF
--- a/Test/baseResults/preprocessor.string_escaping.frag.out
+++ b/Test/baseResults/preprocessor.string_escaping.frag.out
@@ -1,0 +1,16 @@
+#version 450
+#extension GL_EXT_debug_printf : enable
+
+void main()
+{
+    debugPrintfEXT("double quote: \"");
+    debugPrintfEXT("backslash: \\");
+    debugPrintfEXT("bell: \a");
+    debugPrintfEXT("backspace: \b");
+    debugPrintfEXT("form feed: \f");
+    debugPrintfEXT("newline: \n");
+    debugPrintfEXT("carriage return: \r");
+    debugPrintfEXT("tab: \t");
+    debugPrintfEXT("vertical tab: \v");
+}
+

--- a/Test/preprocessor.string_escaping.frag
+++ b/Test/preprocessor.string_escaping.frag
@@ -1,0 +1,15 @@
+#version 450
+#extension GL_EXT_debug_printf : enable
+
+void main()
+{
+    debugPrintfEXT("double quote: \"");
+    debugPrintfEXT("backslash: \\");
+    debugPrintfEXT("bell: \a");
+    debugPrintfEXT("backspace: \b");
+    debugPrintfEXT("form feed: \f");
+    debugPrintfEXT("newline: \n");
+    debugPrintfEXT("carriage return: \r");
+    debugPrintfEXT("tab: \t");
+    debugPrintfEXT("vertical tab: \v");
+}

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1078,6 +1078,28 @@ private:
     int lastLine;
 };
 
+// Re-escape characters that would otherwise be emitted literally 
+// so the preprocessed output remains valid GLSL source.
+static void appendEscapedString(std::string& output, const char* string) {
+
+    for (const char* p = string; *p != '\0'; ++p) {
+        switch (*p) {
+        case '"': output += "\\\""; break;
+        case '\\': output += "\\\\"; break;
+        case '\a': output += "\\a"; break;
+        case '\b': output += "\\b"; break;
+        case '\f': output += "\\f"; break;
+        case '\n': output += "\\n"; break;
+        case '\r': output += "\\r"; break;
+        case '\t': output += "\\t"; break;
+        case '\v': output += "\\v"; break;
+        default:
+            output += *p;
+            break;
+        }
+    }
+}
+
 // DoPreprocessing is a valid ProcessingContext template argument,
 // which only performs the preprocessing step of compilation.
 // It places the result in the "string" argument to its constructor.
@@ -1203,11 +1225,13 @@ struct DoPreprocessing {
             if (token == PpAtomIdentifier)
                 lastTokenName = ppToken.name;
             lastToken = token;
-            if (token == PpAtomConstString)
+            if (token == PpAtomConstString) {
                 outputBuffer += "\"";
-            outputBuffer += ppToken.name;
-            if (token == PpAtomConstString)
+                appendEscapedString(outputBuffer, ppToken.name);
                 outputBuffer += "\"";
+            } else {
+                outputBuffer += ppToken.name;
+            } 
         } while (true);
         outputBuffer += '\n';
         *outputString = std::move(outputBuffer);

--- a/gtests/Pp.FromFile.cpp
+++ b/gtests/Pp.FromFile.cpp
@@ -75,6 +75,7 @@ INSTANTIATE_TEST_SUITE_P(
         "preprocessor.shift_out_of_range.vert",
         "preprocessor.elseseen.oob.vert",
         "preprocessor.macro.recursion.vert",
+        "preprocessor.string_escaping.frag",
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
Fixes #4375

When preprocessing GLSL source, escape sequences in string literals were decoded during tokenization and then emitted directly into the preprocessed output.

For example:
```glsl
debugPrintfEXT("newline: \n");
```
was emitted as:
```
debugPrintfEXT("newline: 
");
```
This produces invalid GLSL and can cause compilation errors when the preprocessed output is compiled again.

This change re-escapes characters when emitting `PpAtomConstString` tokens during preprocessing, preserving valid escape sequences in the preprocessed output.

The fix handles the standard escape sequences, including:
```
\"
\\
\a
\b
\f
\n
\r
\t
\v
```

I tested the standard escape sequences with `glslangValidator -E` and verified that the existing test suite passes