### PR TITLE
Don't crash on empty struct initializers

### DIFF
--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -1312,6 +1312,7 @@ TIntermTyped* TIntermediate::foldDereference(TIntermTyped* node, int index, cons
             start += (*node->getType().getStruct())[i].type->computeNumComponents();
     }
 
+    size = std::min(size, node->getAsConstantUnion()->getConstArray().size());
     result = addConstantUnion(TConstUnionArray(node->getAsConstantUnion()->getConstArray(), start, size), node->getType(), loc);
 
     if (result == nullptr)


### PR DESCRIPTION
Empty struct initializers aren't allowed in GLSL, however when cascading errors mode is enabled, the compiler would segfault in constant folding when accessing an improperly initialized struct. This change adds a bounds check to prevent the segfault.

Fixes #4017 