### PR TITLE
fix oob read on short arg list to struct buffer methods

### DIFF
--- a/Test/baseResults/hlsl.structbuffer.store.args.error.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.store.args.error.frag.out
@@ -1,0 +1,64 @@
+hlsl.structbuffer.store.args.error.frag
+ERROR: 0:6: '' : too few arguments to buffer method 
+ERROR: 1 compilation errors.  No code generated.
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:5  Function Definition: @main( ( temp 4-component vector of float)
+0:5    Function Parameters: 
+0:?     Sequence
+0:6      ERROR: Bad aggregation op
+ ( temp void)
+0:6        'buf' (layout( row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:6        Constant:
+0:6          0 (const int)
+0:7      Branch: Return with expression
+0:7        Constant:
+0:7          0.000000
+0:7          0.000000
+0:7          0.000000
+0:7          0.000000
+0:5  Function Definition: main( ( temp void)
+0:5    Function Parameters: 
+0:?     Sequence
+0:5      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:5        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     'buf' (layout( row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:5  Function Definition: @main( ( temp 4-component vector of float)
+0:5    Function Parameters: 
+0:?     Sequence
+0:6      ERROR: Bad aggregation op
+ ( temp void)
+0:6        'buf' (layout( row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:6        Constant:
+0:6          0 (const int)
+0:7      Branch: Return with expression
+0:7        Constant:
+0:7          0.000000
+0:7          0.000000
+0:7          0.000000
+0:7          0.000000
+0:5  Function Definition: main( ( temp void)
+0:5    Function Parameters: 
+0:?     Sequence
+0:5      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:5        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     'buf' (layout( row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+SPIR-V is not generated for failed compile or link

--- a/Test/hlsl.structbuffer.store.args.error.frag
+++ b/Test/hlsl.structbuffer.store.args.error.frag
@@ -1,0 +1,8 @@
+
+RWByteAddressBuffer buf;
+
+float4 main() : SV_Target0
+{
+    buf.Store(0);
+    return 0;
+}

--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -3534,6 +3534,45 @@ void HlslParseContext::decomposeStructBufferMethods(const TSourceLoc& loc, TInte
     if (argArray == nullptr)
         return;  // It might not be a struct buffer method.
 
+    // These builtins resolve by name against a zero-parameter prototype, so normal
+    // overload resolution never checks the argument count. Validate it here before
+    // indexing the argument sequence, otherwise a call with too few arguments reads
+    // past the end of the aggregate (or dereferences a null aggregate for a bare
+    // buffer object with no arguments).
+    const int argCount = argAggregate ? (int)argAggregate->getSequence().size() : 1;
+    int minArgCount = 1; // the buffer object at index 0
+    switch (op) {
+    case EOpMethodLoad:
+    case EOpMethodLoad2:
+    case EOpMethodLoad3:
+    case EOpMethodLoad4:
+    case EOpMethodGetDimensions:
+    case EOpMethodAppend:
+    case EOpInterlockedAdd:
+    case EOpInterlockedAnd:
+    case EOpInterlockedExchange:
+    case EOpInterlockedMax:
+    case EOpInterlockedMin:
+    case EOpInterlockedOr:
+    case EOpInterlockedXor:
+    case EOpInterlockedCompareExchange:
+    case EOpInterlockedCompareStore:
+        minArgCount = 2;
+        break;
+    case EOpMethodStore:
+    case EOpMethodStore2:
+    case EOpMethodStore3:
+    case EOpMethodStore4:
+        minArgCount = 3;
+        break;
+    default:
+        break;
+    }
+    if (argCount < minArgCount) {
+        error(loc, "too few arguments to buffer method", "", "");
+        return;
+    }
+
     switch (op) {
     case EOpMethodLoad:
         {

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -429,6 +429,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.structbuffer.coherent.frag", "main"},
         {"hlsl.structbuffer.floatidx.comp", "main"},
         {"hlsl.structbuffer.incdec.frag", "main"},
+        {"hlsl.structbuffer.store.args.error.frag", "main"},
         {"hlsl.structbuffer.fn.frag", "main"},
         {"hlsl.structbuffer.fn2.comp", "main"},
         {"hlsl.structbuffer.rw.frag", "main"},


### PR DESCRIPTION
UBSan/ASan on `buf.Store(0)` (missing value argument) in a fragment shader:

    hlslParseHelper.cpp:3652:70: runtime error: member call on misaligned address 0xfefefefefefefefe for type 'TIntermNode'
    AddressSanitizer: SEGV ... READ, decomposeStructBufferMethods -> handleFunctionCall

Struct/byte-address buffer methods (Load/Store/GetDimensions/Interlocked*/Append) resolve by name against a zero-parameter builtin prototype in `handleFunctionCall`, so overload resolution never checks the caller's argument count. `decomposeStructBufferMethods` then indexes the argument aggregate directly (`getSequence()[1]`, `getSequence()[2]`), so a call with too few arguments reads one past the end of the sequence and uses it as a node pointer; a bare `buf.GetDimensions()` with no arguments leaves the aggregate null and dereferences it.

Validate the count against the minimum each method actually reads before indexing, and error out otherwise.
