### PR TITLE
Add access to source entry point in C API.

### DIFF
--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -352,6 +352,10 @@ GLSLANG_EXPORT void glslang_shader_set_preamble(glslang_shader_t* shader, const 
     shader->shader->setPreamble(s);
 }
 
+GLSLANG_EXPORT void glslang_shader_set_source_entry_point(glslang_shader_t* shader, const char* s) {
+    shader->shader->setSourceEntryPoint(s);
+}
+
 GLSLANG_EXPORT void glslang_shader_set_entry_point(glslang_shader_t* shader, const char* s) {
     shader->shader->setEntryPoint(s);
 }

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -254,6 +254,9 @@ GLSLANG_EXPORT void glslang_finalize_process(void);
 GLSLANG_EXPORT glslang_shader_t* glslang_shader_create(const glslang_input_t* input);
 GLSLANG_EXPORT void glslang_shader_delete(glslang_shader_t* shader);
 GLSLANG_EXPORT void glslang_shader_set_preamble(glslang_shader_t* shader, const char* s);
+// Set a different entry point than main in GLSL that will be renamed to value set by glslang_shader_set_entry_point (SPIRV only).
+GLSLANG_EXPORT void glslang_shader_set_source_entry_point(glslang_shader_t* shader, const char* s);
+// Set a different entry point than main in output target (SPIRV only).
 GLSLANG_EXPORT void glslang_shader_set_entry_point(glslang_shader_t* shader, const char* s);
 GLSLANG_EXPORT void glslang_shader_set_invert_y(glslang_shader_t* shader, bool y);
 GLSLANG_EXPORT void glslang_shader_shift_binding(glslang_shader_t* shader, glslang_resource_type_t res, unsigned int base);


### PR DESCRIPTION
Hello, with the current C API, its not possible to use different entry point in GLSL via the C API, while it is possible with the C++ one for SPIRV generation. So this change simply expose the required function for that.