### PR TITLE
fix oob operand read on short coopMatPerElementNV arg list

### DIFF
--- a/Test/baseResults/spv.coopmat2_perelement_error.comp.out
+++ b/Test/baseResults/spv.coopmat2_perelement_error.comp.out
@@ -1,0 +1,9 @@
+spv.coopmat2_perelement_error.comp
+ERROR: 0:18: 'coopMatPerElementNV' : expected a result matrix, an input matrix, and a per-element function 
+ERROR: 0:19: 'coopMatPerElementNV' : expected a result matrix, an input matrix, and a per-element function 
+ERROR: 0:20: 'coopMatPerElementNV' : expected a result matrix, an input matrix, and a per-element function 
+ERROR: 0:21: 'coopMatPerElementNV' : expected a result matrix, an input matrix, and a per-element function 
+ERROR: 4 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.coopmat2_perelement_error.comp
+++ b/Test/spv.coopmat2_perelement_error.comp
@@ -1,0 +1,22 @@
+#version 450 core
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_cooperative_matrix : enable
+#extension GL_EXT_shader_explicit_arithmetic_types : enable
+#extension GL_NV_cooperative_matrix2 : enable
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+float16_t relu(const in uint32_t row, const in uint32_t col, const in float16_t x) { return max(x, float16_t(0)); }
+
+void main()
+{
+    coopmat<float16_t, gl_ScopeWorkgroup, 64, 32, gl_MatrixUseAccumulator> Acc;
+
+    // coopMatPerElementNV is declared with an empty prototype, so overload
+    // resolution accepts these malformed calls; each is missing at least one of
+    // the required (result matrix, input matrix, per-element function) arguments.
+    coopMatPerElementNV();
+    coopMatPerElementNV(relu);
+    coopMatPerElementNV(Acc);
+    coopMatPerElementNV(Acc, Acc);
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1663,6 +1663,20 @@ TIntermTyped* TParseContext::handleFunctionCall(const TSourceLoc& loc, TFunction
 
 void TParseContext::handleCoopMat2FunctionCall(const TSourceLoc& loc, const TFunction* fnCandidate, TIntermTyped* result, TIntermNode* arguments)
 {
+    // coopMatPerElementNV/EXT are declared with an empty prototype, so overload
+    // resolution accepts any argument list. Fewer than the required (result matrix,
+    // input matrix, per-element function) arguments is not passed as an aggregate,
+    // skips the validation below, and reaches SPIR-V generation, which dereferences
+    // operands[0] as the result matrix.
+    if (fnCandidate->getBuiltInOp() == EOpCooperativeMatrixPerElementOpNV) {
+        const TIntermAggregate* aggregate = arguments ? arguments->getAsAggregate() : nullptr;
+        if (aggregate == nullptr || aggregate->getSequence().size() < 3) {
+            error(loc, "expected a result matrix, an input matrix, and a per-element function",
+                  fnCandidate->getName().c_str(), "");
+            return;
+        }
+    }
+
     if (arguments && arguments->getAsAggregate()) {
         auto &sequence = arguments->getAsAggregate()->getSequence();
 

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -1026,6 +1026,7 @@ INSTANTIATE_TEST_SUITE_P(
         "spv.coopmatmaint1_error.comp",
         "spv.coopmat2_constructor.comp",
         "spv.coopmat2_error.comp",
+        "spv.coopmat2_perelement_error.comp",
         "spv.coopmat2_tensor.comp",
         "spv.coopmat2_decode_vector.comp",
         "spv.coopmat2_decode_vector_b.comp",


### PR DESCRIPTION
ASan, `coopMatPerElementNV()` and `coopMatPerElementNV(relu)`:

    SEGV in spv::Builder::getContainedTypeId (SpvBuilder.cpp:1782)
      from TGlslangToSpvTraverser::visitAggregate (GlslangToSpv.cpp:4943), reading operands[0]

`coopMatPerElementNV`/`EXT` are declared with an empty prototype (`void coopMatPerElementNV();`), so overload resolution accepts any argument list. A call missing one of the required (result matrix, input matrix, per-element function) operands is not passed as an aggregate, so the whole validation body in `handleCoopMat2FunctionCall` (guarded by `arguments->getAsAggregate()`) is skipped and the malformed `EOpCooperativeMatrixPerElementOpNV` reaches codegen, where `operands[0]` is read as the result matrix: with no arguments the operand vector is empty, with one it holds the function id whose type lookup dereferences a null instruction.

Reject a per-element call that is not an aggregate of at least three arguments in the front end. Both builtins map to `EOpCooperativeMatrixPerElementOpNV`, so one check covers them, and only these two use the empty prototype. Added `Test/spv.coopmat2_perelement_error.comp`.
