### PR TITLE
Fix missing ArrayStride on OpAbortKHR message string

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -3423,6 +3423,9 @@ void TGlslangToSpvTraverser::createAbortEXT(const glslang::TIntermSequence &glsl
     // 2.4 Add decoration for this string.
     builder.addDecoration(msgArrType, spv::Decoration::UTFEncodedKHR);
     builder.addDecoration(msgLoadArrType, spv::Decoration::UTFEncodedKHR);
+    // The load-type array must carry an explicit ArrayStride, as required by
+    // the SPV_KHR_abort Message Type layout rules.
+    builder.addDecoration(msgLoadArrType, spv::Decoration::ArrayStride, 1);
     // 2.5 Collect data and type for construct an internal message structure member.
     structMemberType.push_back(msgArrType);
     structLoadMemberType.push_back(msgLoadArrType);


### PR DESCRIPTION
createAbortEXT() decorates the message struct's Offset members but
never gives the string array member an ArrayStride, so any shader
using abortEXT()/OpAbortKHR fails SPIR-V validation with:

    Array must be explicitly laid out with ArrayStride or
    ArrayStrideIdEXT decorations.

Per the SPV_KHR_abort registry spec's own example, ArrayStride goes
on the array type itself (OpDecorate, not OpMemberDecorate). Add it
to msgLoadArrType, matching that example exactly.