### PR TITLE
Implement DebugEntryPoint instruction in NSDI 102

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -7599,6 +7599,11 @@ void TGlslangToSpvTraverser::makeFunctions(const glslang::TIntermSequence& glslF
                 builder.setupFunctionDebugInfo(shaderEntry, glslangIntermediate->getEntryPointMangledName().c_str(),
                                                std::vector<spv::Id>(), // main function has no param
                                                std::vector<char const*>());
+                if (options.emitNonSemanticShaderDebugInfo &&
+                    options.compilerSignature != nullptr && options.commandLineArguments != nullptr) {
+                    builder.makeDebugEntryPoint(shaderEntry, options.compilerSignature, options.commandLineArguments,
+                                                options.currentWorkingDirectory);
+                }
             }
             continue;
         }

--- a/SPIRV/GlslangToSpv.h
+++ b/SPIRV/GlslangToSpv.h
@@ -56,6 +56,10 @@ struct SpvOptions {
     bool emitNonSemanticShaderDebugSource{ false };
     bool compileOnly{false};
     bool optimizerAllowExpandedIDBound{false};
+    // Optional metadata overrides for NonSemantic.Shader.DebugInfo DebugEntryPoint.
+    const char* compilerSignature{nullptr};
+    const char* commandLineArguments{nullptr};
+    const char* currentWorkingDirectory{nullptr};
 };
 
 GLSLANG_EXPORT void GetSpirvVersion(std::string&);

--- a/SPIRV/NonSemanticShaderDebugInfo.h
+++ b/SPIRV/NonSemanticShaderDebugInfo.h
@@ -30,11 +30,11 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticShaderDebugInfoVersion = 101,
+    NonSemanticShaderDebugInfoVersion = 102,
     NonSemanticShaderDebugInfoVersion_BitWidthPadding = 0x7fffffff
 };
 enum {
-    NonSemanticShaderDebugInfoRevision = 6,
+    NonSemanticShaderDebugInfoRevision = 1,
     NonSemanticShaderDebugInfoRevision_BitWidthPadding = 0x7fffffff
 };
 

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -2904,6 +2904,35 @@ Id Builder::makeDebugFunction([[maybe_unused]] Function* function, Id nameId, Id
     return funcId;
 }
 
+Id Builder::makeDebugEntryPoint(Function* function, const char* compilerSignature, const char* commandLineArguments,
+                                const char* currentWorkingDirectory)
+{
+    assert(function != nullptr);
+    assert(compilerSignature != nullptr);
+    assert(commandLineArguments != nullptr);
+
+    const Id debugFunction = getDebugFunction(function->getId());
+    assert(debugFunction != NoResult);
+
+    if (currentWorkingDirectory != nullptr)
+        requireNonSemanticShaderDebugInfoVersion(NonSemanticShaderDebugInfoVersion);
+
+    const Id entryPointId = getUniqueId();
+    auto entryPoint = new Instruction(entryPointId, makeVoidType(), Op::OpExtInst);
+    entryPoint->reserveOperands(currentWorkingDirectory == nullptr ? 6 : 7);
+    entryPoint->addIdOperand(nonSemanticShaderDebugInfo);
+    entryPoint->addImmediateOperand(NonSemanticShaderDebugInfoDebugEntryPoint);
+    entryPoint->addIdOperand(debugFunction);
+    entryPoint->addIdOperand(makeDebugCompilationUnit());
+    entryPoint->addIdOperand(getStringId(compilerSignature));
+    entryPoint->addIdOperand(getStringId(commandLineArguments));
+    if (currentWorkingDirectory != nullptr)
+        entryPoint->addIdOperand(getStringId(currentWorkingDirectory));
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(entryPoint));
+    module.mapInstruction(entryPoint);
+    return entryPointId;
+}
+
 Id Builder::makeDebugLexicalBlock(uint32_t line, uint32_t column) {
     assert(!currentDebugScopeId.empty());
 

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -512,6 +512,8 @@ public:
     Id makeDebugValue(Id const debugLocalVariable, Id const value);
     Id makeDebugFunctionType(Id returnType, const std::vector<Id>& paramTypes);
     Id makeDebugFunction(Function* function, Id nameId, Id funcTypeId);
+    Id makeDebugEntryPoint(Function* function, const char* compilerSignature, const char* commandLineArguments,
+                           const char* currentWorkingDirectory = nullptr);
     Id makeDebugLexicalBlock(uint32_t line, uint32_t column);
     std::string unmangleFunctionName(std::string const& name) const;
 

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -56,6 +56,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -207,6 +208,7 @@ glslang::EShTargetLanguageVersion TargetVersion;     // not valid until TargetLa
 int GlslVersion = 0; // GLSL version specified on CLI, overrides #version in shader source
 
 std::vector<std::string> Processes;                     // what should be recorded by OpModuleProcessed, or equivalent
+std::string CommandLineArguments;                       // original arguments passed to the standalone compiler
 
 // Per descriptor-set binding base data
 typedef std::map<unsigned int, unsigned int> TPerSetBaseBinding;
@@ -564,6 +566,13 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
 
     ExecutableName = argv[0];
     workItems.reserve(argc);
+
+    CommandLineArguments.clear();
+    for (int arg = 1; arg < argc; ++arg) {
+        if (arg > 1)
+            CommandLineArguments += ' ';
+        CommandLineArguments += argv[arg];
+    }
 
     const auto bumpArg = [&]() {
         if (argc > 0) {
@@ -1608,6 +1617,12 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
                 spvOptions.disassemble = SpvToolsDisassembler;
                 spvOptions.validate = SpvToolsValidate;
                 spvOptions.compileOnly = compileOnly;
+                spvOptions.compilerSignature = "glslang";
+                spvOptions.commandLineArguments = CommandLineArguments.c_str();
+                std::error_code currentPathError;
+                const std::string currentWorkingDirectory = std::filesystem::current_path(currentPathError).string();
+                if (!currentPathError)
+                    spvOptions.currentWorkingDirectory = currentWorkingDirectory.c_str();
                 glslang::GlslangToSpv(*intermediate, spirv, &logger, &spvOptions);
 
                 // Dump the spv to a file or stdout, etc., but only if not doing

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -240,6 +240,10 @@ typedef struct glslang_spv_options_s {
     bool emit_nonsemantic_shader_debug_source;
     bool compile_only;
     bool optimize_allow_expanded_id_bound;
+    /* Optional metadata overrides for reproducing compilation */
+    const char* compiler_signature;
+    const char* command_line_arguments;
+    const char* current_working_directory;
 } glslang_spv_options_t;
 
 #ifdef __cplusplus

--- a/gtests/SpvDebugInfoTest.cpp
+++ b/gtests/SpvDebugInfoTest.cpp
@@ -164,10 +164,57 @@ bool containsDebugTypeBasic(const std::vector<uint32_t>& spirv, const char* expe
     return false;
 }
 
+bool containsDebugEntryPoint(const std::vector<uint32_t>& spirv, const char* expectedCompilerSignature,
+                             const char* expectedCommandLineArguments, const char* expectedCurrentWorkingDirectory)
+{
+    if (spirv.size() < 5 || spirv[0] != spv::MagicNumber)
+        return false;
+
+    const uint32_t idBound = spirv[3];
+    std::vector<std::string> strings(idBound);
+    uint32_t debugInfoImportId = 0;
+    uint32_t compilerSignatureId = 0;
+    uint32_t commandLineArgumentsId = 0;
+    uint32_t currentWorkingDirectoryId = 0;
+
+    for (size_t offset = 5; offset < spirv.size();) {
+        const uint32_t wordCount = spirv[offset] >> spv::WordCountShift;
+        const spv::Op opcode = static_cast<spv::Op>(spirv[offset] & spv::OpCodeMask);
+        if (wordCount == 0 || offset + wordCount > spirv.size())
+            return false;
+
+        if (opcode == spv::Op::OpExtInstImport && wordCount >= 3) {
+            if (decodeLiteralString(&spirv[offset + 2], wordCount - 2) ==
+                "NonSemantic.Shader.DebugInfo.102") {
+                debugInfoImportId = spirv[offset + 1];
+            }
+        } else if (opcode == spv::Op::OpString && wordCount >= 3) {
+            const uint32_t resultId = spirv[offset + 1];
+            if (resultId < idBound)
+                strings[resultId] = decodeLiteralString(&spirv[offset + 2], wordCount - 2);
+        } else if (opcode == spv::Op::OpExtInst && wordCount == 10 &&
+                   spirv[offset + 3] == debugInfoImportId &&
+                   spirv[offset + 4] == NonSemanticShaderDebugInfoDebugEntryPoint) {
+            compilerSignatureId = spirv[offset + 7];
+            commandLineArgumentsId = spirv[offset + 8];
+            currentWorkingDirectoryId = spirv[offset + 9];
+        }
+
+        offset += wordCount;
+    }
+
+    return debugInfoImportId != 0 && compilerSignatureId < idBound &&
+           strings[compilerSignatureId] == expectedCompilerSignature && commandLineArgumentsId < idBound &&
+           strings[commandLineArgumentsId] == expectedCommandLineArguments && currentWorkingDirectoryId < idBound &&
+           strings[currentWorkingDirectoryId] == expectedCurrentWorkingDirectory;
+}
+
 class SpvDebugInfoTest : public ::testing::Test {
 protected:
-    bool compileToSpirvWithDebugInfo(const std::string& source, std::vector<uint32_t>& spirv,
-                                     std::string& error)
+    bool compileToSpirvWithDebugInfo(const std::string& source, std::vector<uint32_t>& spirv, std::string& error,
+                                     const char* compilerSignature = nullptr,
+                                     const char* commandLineArguments = nullptr,
+                                     const char* currentWorkingDirectory = nullptr)
     {
         spirv.clear();
         error.clear();
@@ -196,6 +243,9 @@ protected:
         opts.generateDebugInfo = true;
         opts.emitNonSemanticShaderDebugInfo = true;
         opts.disableOptimizer = true;
+        opts.compilerSignature = compilerSignature;
+        opts.commandLineArguments = commandLineArguments;
+        opts.currentWorkingDirectory = currentWorkingDirectory;
 
         glslang::GlslangToSpv(*program.getIntermediate(EShLangCompute), spirv, &opts);
         return true;
@@ -215,6 +265,25 @@ protected:
         return out.str();
     }
 };
+
+TEST_F(SpvDebugInfoTest, DebugEntryPointUsesSuppliedCompilationMetadata)
+{
+    const std::string source = R"(
+#version 450 core
+layout(local_size_x = 1) in;
+void main() {}
+)";
+    constexpr char compilerSignature[] = "test compiler signature";
+    constexpr char commandLineArguments[] = "-V -gVS shader.comp";
+    constexpr char currentWorkingDirectory[] = "test/current/working/directory";
+    std::vector<uint32_t> spirv;
+    std::string error;
+    ASSERT_TRUE(compileToSpirvWithDebugInfo(source, spirv, error, compilerSignature, commandLineArguments,
+                                           currentWorkingDirectory))
+        << error;
+
+    EXPECT_TRUE(containsDebugEntryPoint(spirv, compilerSignature, commandLineArguments, currentWorkingDirectory));
+}
 
 // DebugTypeVectorIdEXT (opcode 109) must be emitted for OpTypeCooperativeVectorNV
 // when NonSemantic debug info is enabled.


### PR DESCRIPTION
Add support for emitting DebugEntryPoint instructions from NonSemantic.Shader.DebugInfo, allowing generated SPIR-V to record information needed to reproduce a compilation. This allows tooling to recover compilation environment of the SPIR-V and re-compile updated shader.

In glslang standalone, we produce "glslang" compiler signature and copy the exact compiler CLI arguments. For programmatic invocation, caller should provide these parameters.