### PR TITLE
require constant scope and semantics operands in memorySemanticsCheck

### DIFF
--- a/Test/baseResults/spv.memoryScopeSemantics.nonConstArg.comp.out
+++ b/Test/baseResults/spv.memoryScopeSemantics.nonConstArg.comp.out
@@ -1,0 +1,12 @@
+spv.memoryScopeSemantics.nonConstArg.comp
+ERROR: 0:16: 'atomicAdd' : argument must be a compile-time constant 
+ERROR: 0:17: 'atomicLoad' : argument must be a compile-time constant 
+ERROR: 0:18: 'atomicStore' : argument must be a compile-time constant 
+ERROR: 0:20: 'atomicCompSwap' : argument must be a compile-time constant 
+ERROR: 0:21: 'imageAtomicAdd' : argument must be a compile-time constant 
+ERROR: 0:22: 'memoryBarrier' : argument must be a compile-time constant 
+ERROR: 0:23: 'controlBarrier' : argument must be a compile-time constant 
+ERROR: 7 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.memoryScopeSemantics.nonConstArg.comp
+++ b/Test/spv.memoryScopeSemantics.nonConstArg.comp
@@ -1,0 +1,24 @@
+#version 450
+#extension GL_KHR_memory_scope_semantics : require
+
+layout(local_size_x = 1) in;
+layout(binding = 0) buffer BufferU { coherent uint x; } bufferu;
+layout(binding = 1, r32ui) coherent uniform uimage2D imageu;
+
+void main()
+{
+    // The Scope, storage-class-semantics and semantics operands of these
+    // operations must be compile-time constants. Passing a non-constant used to
+    // crash the front end (null TIntermConstantUnion) or trip an id/immediate
+    // assert in SPIR-V generation for the Scope; each must now be diagnosed.
+    int dyn = int(gl_GlobalInvocationID.x);
+
+    uint origu = atomicAdd(bufferu.x, 1u, gl_ScopeDevice, gl_StorageSemanticsBuffer, dyn);
+    origu = atomicLoad(bufferu.x, gl_ScopeDevice, dyn, 0);
+    atomicStore(bufferu.x, 1u, dyn, gl_StorageSemanticsBuffer, gl_SemanticsRelease);
+    origu = atomicCompSwap(bufferu.x, 0u, 1u, gl_ScopeDevice, gl_StorageSemanticsBuffer,
+                           gl_SemanticsAcquireRelease, gl_StorageSemanticsBuffer, dyn);
+    imageAtomicAdd(imageu, ivec2(0, 0), 1u, gl_ScopeDevice, gl_StorageSemanticsImage, dyn);
+    memoryBarrier(gl_ScopeWorkgroup, gl_StorageSemanticsBuffer, dyn);
+    controlBarrier(dyn, gl_ScopeWorkgroup, gl_StorageSemanticsBuffer, gl_SemanticsAcquireRelease);
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -2890,6 +2890,63 @@ void TParseContext::memorySemanticsCheck(const TSourceLoc& loc, const TFunction&
     const TIntermTyped* arg0 = (*argp)[0]->getAsTyped();
     const bool isMS = arg0->getBasicType() == EbtSampler && arg0->getType().getSampler().isMultiSample();
 
+    // The Scope, storage-class-semantics and semantics operands must be
+    // compile-time constants. The extraction below reads them as constants, and
+    // SPIR-V generation folds the Scope to a literal, so a non-constant operand
+    // would otherwise deref a null TIntermConstantUnion here and trip an
+    // id/immediate assert in the back end. Locate the first constant operand and
+    // reject anything from there on that is not a compile-time constant.
+    int firstConstArg = -1;
+    switch (callNode.getOp()) {
+    case EOpAtomicAdd:
+    case EOpAtomicSubtract:
+    case EOpAtomicMin:
+    case EOpAtomicMax:
+    case EOpAtomicAnd:
+    case EOpAtomicOr:
+    case EOpAtomicXor:
+    case EOpAtomicExchange:
+    case EOpAtomicStore:
+        firstConstArg = 2;
+        break;
+    case EOpAtomicLoad:
+        firstConstArg = 1;
+        break;
+    case EOpAtomicCompSwap:
+        firstConstArg = 3;
+        break;
+    case EOpImageAtomicAdd:
+    case EOpImageAtomicMin:
+    case EOpImageAtomicMax:
+    case EOpImageAtomicAnd:
+    case EOpImageAtomicOr:
+    case EOpImageAtomicXor:
+    case EOpImageAtomicExchange:
+    case EOpImageAtomicStore:
+        firstConstArg = isMS ? 4 : 3;
+        break;
+    case EOpImageAtomicLoad:
+        firstConstArg = isMS ? 3 : 2;
+        break;
+    case EOpImageAtomicCompSwap:
+        firstConstArg = isMS ? 5 : 4;
+        break;
+    case EOpBarrier:
+    case EOpControlBarrierArriveEXT:
+    case EOpControlBarrierWaitEXT:
+    case EOpMemoryBarrier:
+        firstConstArg = 0;
+        break;
+    default:
+        break;
+    }
+    for (int i = firstConstArg; i >= 0 && i < (int)argp->size(); ++i) {
+        if ((*argp)[i]->getAsConstantUnion() == nullptr) {
+            error(loc, "argument must be a compile-time constant", fnCandidate.getName().c_str(), "");
+            return;
+        }
+    }
+
     // Grab the semantics and storage class semantics from the operands, based on opcode
     switch (callNode.getOp()) {
     case EOpAtomicAdd:

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -725,6 +725,7 @@ INSTANTIATE_TEST_SUITE_P(
         "spv.float64.frag",
         "spv.memoryScopeSemantics.comp",
         "spv.memoryScopeSemantics_Error.comp",
+        "spv.memoryScopeSemantics.nonConstArg.comp",
         "spv.splitBarrierMemoryScopeSemantics.comp",
         "spv.splitBarrierArriveMemoryScopeSemantics_Error1.comp",
         "spv.splitBarrierArriveMemoryScopeSemantics_Error2.comp",


### PR DESCRIPTION
UBSan, on a compute shader passing a non-constant to a `GL_KHR_memory_scope_semantics` atomic (`atomicAdd(x, 1, gl_ScopeDevice, gl_StorageSemanticsBuffer, dyn)`):

    ParseHelper.cpp:2923:55: runtime error: member call on null pointer of type 'glslang::TIntermConstantUnion'

`memorySemanticsCheck` reads the Scope, storage-class and semantics operands of these atomics/barriers as front-end constants (`(*argp)[i]->getAsConstantUnion()->getConstArray()[0]`), but nothing requires them to be. A non-constant storage/semantics operand makes `getAsConstantUnion()` return null and the `getConstArray()` call derefs it (a SEGV in a release build). A non-constant Scope is not read here but reaches SPIR-V generation, where `createAtomicOperation` folds it via `getConstantScalar` and hits the `getImmediateOperand` assert (debug) or emits a bogus literal Scope from an id (release).

Compute, per opcode, the index of the first operand that must be constant and reject anything from there to the end that is not, reusing the existing "argument must be a compile-time constant" diagnostic. That covers Scope, storage and semantics for every op the function handles. Test exercises atomicAdd/Load/Store/CompSwap, imageAtomicAdd, memoryBarrier and controlBarrier.