### PR TITLE
validate saturatedConvertEXT argument count

### DIFF
--- a/Test/baseResults/spv.floate4m3.saturatedConvert.error.comp.out
+++ b/Test/baseResults/spv.floate4m3.saturatedConvert.error.comp.out
@@ -1,0 +1,8 @@
+spv.floate4m3.saturatedConvert.error.comp
+ERROR: 0:16: '' : requires exactly two parameters 
+ERROR: 0:17: '' : requires exactly two parameters 
+ERROR: 0:18: '' : requires exactly two parameters 
+ERROR: 3 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.floate4m3.saturatedConvert.error.comp
+++ b/Test/spv.floate4m3.saturatedConvert.error.comp
@@ -1,0 +1,19 @@
+#version 450 core
+
+#extension GL_EXT_float_e4m3 : require
+#extension GL_EXT_shader_explicit_arithmetic_types : enable
+
+layout(local_size_x = 1) in;
+
+void main()
+{
+    floate4m3_t a;
+    float b;
+
+    // saturatedConvertEXT is declared with an empty prototype, so overload
+    // resolution accepts any argument list. Anything other than exactly two
+    // arguments must be rejected before the front end indexes the operands.
+    saturatedConvertEXT(a);
+    saturatedConvertEXT(a, b, b);
+    saturatedConvertEXT();
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1648,7 +1648,13 @@ TIntermTyped* TParseContext::handleFunctionCall(const TSourceLoc& loc, TFunction
 
             if (fnCandidate->getBuiltInOp() == EOpConstructSaturated) {
                 // result type is taken from the first parameter
-                result->setType(result->getAsAggregate()->getSequence()[0]->getAsTyped()->getType());
+                TIntermAggregate* aggregate = result->getAsAggregate();
+                if (aggregate != nullptr && aggregate->getSequence().size() == 2)
+                    result->setType(aggregate->getSequence()[0]->getAsTyped()->getType());
+                else if (aggregate == nullptr)
+                    // a call with the wrong argument count folds away from an aggregate and
+                    // never reaches builtInOpCheck; reject it here before SPIR-V generation
+                    error(loc, "requires exactly two parameters", "", "");
             }
         }
     }
@@ -4020,10 +4026,12 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
 
     case EOpConstructSaturated:
     {
-        auto &sequence = callNode.getAsAggregate()->getSequence();
-        if (sequence.size() != 2) {
+        const TIntermAggregate* aggregate = callNode.getAsAggregate();
+        if (aggregate == nullptr || aggregate->getSequence().size() != 2) {
             error(loc, "requires exactly two parameters", "", "");
+            break;
         }
+        auto &sequence = aggregate->getSequence();
         auto &op0Type = sequence[0]->getAsTyped()->getType();
         auto &op1Type = sequence[1]->getAsTyped()->getType();
         if (op0Type.getBasicType() != EbtFloatE5M2 && op0Type.getBasicType() != EbtFloatE4M3) {

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -1035,6 +1035,7 @@ INSTANTIATE_TEST_SUITE_P(
         "spv.floate4m3.comp",
         "spv.floate4m3.const.comp",
         "spv.floate4m3_error.comp",
+        "spv.floate4m3.saturatedConvert.error.comp",
         "spv.floate5m2.comp",
         "spv.floate5m2.const.comp",
         "spv.floate5m2_error.comp",


### PR DESCRIPTION
ASAN, `saturatedConvertEXT(x)` with one argument:

    ERROR: AddressSanitizer: SEGV on unknown address
    #0 glslang::TParseContext::builtInOpCheck(...) ParseHelper.cpp:4099

`saturatedConvertEXT` (GL_EXT_float_e4m3 / GL_EXT_float_e5m2) has an empty prototype, so overload resolution accepts any argument list. The `EOpConstructSaturated` case reads `sequence[0]`/`sequence[1]` after only warning on `size() != 2` without returning, so a one-argument call reads one element past a size-1 aggregate and dereferences a garbage `TIntermNode*`. A zero-argument call folds to a constant that is not an operator, so it skips `builtInOpCheck` and reaches `result->getAsAggregate()->getSequence()[0]` in `handleFunctionCall` on an absent aggregate, then asserts in `createSpvConstantFromConstUnionArray` during SPIR-V generation.

Validate the count in both spots before indexing: `builtInOpCheck` null-checks the aggregate and requires two operands, and `handleFunctionCall` only takes the result type from operand 0 when two operands are present, erroring otherwise so no SPIR-V is generated. Added Test/spv.floate4m3.saturatedConvert.error.comp.
